### PR TITLE
Fix model defaults to avoid OpenAPI serialization errors

### DIFF
--- a/src/lib/Pydantic2FastAPI_test.py
+++ b/src/lib/Pydantic2FastAPI_test.py
@@ -627,6 +627,21 @@ class TestFastAPIIntegration:
         assert data["has_registry"] is True
 
 
+class TestModelFieldSanitization:
+    """Ensure generated models have serializable defaults."""
+
+    def test_domain_models_use_serializable_defaults(self):
+        """TeamModel fields should avoid ModelFieldAccessor defaults."""
+        from logic.BLL_Auth import TeamModel
+        from logic.AbstractLogicManager import ModelFieldAccessor
+
+        for field in TeamModel.model_fields.values():
+            assert not isinstance(field.default, ModelFieldAccessor)
+
+        assert TeamModel.model_fields["id"].is_required()
+        assert TeamModel.model_fields["description"].default is None
+
+
 class TestCompleteWorkflow:
     """Test complete workflow with real operations."""
 


### PR DESCRIPTION
## Summary
- sanitize generated Pydantic models so inherited fields no longer keep ModelFieldAccessor defaults that break OpenAPI serialization
- add a regression test that ensures TeamModel fields expose serializable defaults

## Testing
- python -m pytest src/lib/Pydantic2FastAPI_test.py -k serializable -v

------
https://chatgpt.com/codex/tasks/task_e_68e7c972235c832e99398259fa737ca0