### PR TITLE
Fix contradictory assertion in AbstractEPTest.py - test_GET_200_fields

### DIFF
--- a/src/endpoints/AbstractEPTest.py
+++ b/src/endpoints/AbstractEPTest.py
@@ -1133,8 +1133,8 @@ class AbstractEndpointTest(AbstractTest, AbstractGraphQLTest):
         if other_fields:
             for field in other_fields:
                 assert (
-                    field not in entity
-                ), f"Response should not contain field '{field}'"
+                    not other_fields
+                ), f"Response should only contain {fields_list}, but also contains: {other_fields}"
 
     # @pytest.mark.dependency(depends=["test_POST_201"])
     def test_GET_200_includes(


### PR DESCRIPTION
other_fields = [field for field in entity.keys() if field not in fields_list]

This creates a list of fields that are in the entity but not in fields_list. Then it asserts those fields should NOT be in the entity but they are, since they were extracted from entity.keys().