### PR TITLE
Test get 200 includes

### DIFF
--- a/.obsidian/core-plugins.json
+++ b/.obsidian/core-plugins.json
@@ -27,5 +27,7 @@
   "file-recovery": true,
   "publish": false,
   "sync": true,
-  "webviewer": false
+  "webviewer": false,
+  "footnotes": false,
+  "bases": true
 }


### PR DESCRIPTION
Normalize include/fields query parameters before passing them to manager methods.

Add _normalize_query_list helper that accepts None, a string (comma-separated) or a list/tuple and returns a deduped, stripped list[str] or None.
Use the helper in generated GET, LIST and SEARCH handlers 
