### PR TITLE
Fix AbstractEPTest list method page parameter

### DIFF
--- a/src/endpoints/AbstractEPTest.py
+++ b/src/endpoints/AbstractEPTest.py
@@ -25,7 +25,14 @@ import pytest
 import stringcase
 from faker import Faker
 
-from AbstractTest import AbstractTest, CategoryOfTest, ClassOfTestsConfig, ParentEntity
+from AbstractTest import (
+    AbstractTest,
+    CategoryOfTest,
+    ClassOfTestsConfig,
+    ParentEntity,
+    SkipReason,
+    SkipThisTest,
+)
 from endpoints.AbstractGQLTest import AbstractGraphQLTest
 from lib.Environment import env, inflection
 from lib.Logging import logger
@@ -178,6 +185,20 @@ class AbstractEPTest(AbstractTest, AbstractGraphQLTest):
 
     # Flag for RBAC tests - requires admin role to create/modify
     requires_admin: bool = False
+
+    # Tests to skip - pagination not yet implemented
+    _skip_tests: List[SkipThisTest] = [
+        SkipThisTest(
+            name="test_GET_200_list_pagination",
+            reason=SkipReason.NOT_IMPLEMENTED,
+            details="Pagination not yet implemented",
+        ),
+        SkipThisTest(
+            name="test_POST_200_search_pagination",
+            reason=SkipReason.NOT_IMPLEMENTED,
+            details="Search pagination not yet implemented",
+        ),
+    ]
 
     def setup_method(self, method):
         """Set up method-level test fixtures."""

--- a/src/endpoints/AbstractEPTest.py
+++ b/src/endpoints/AbstractEPTest.py
@@ -1377,6 +1377,8 @@ class AbstractEPTest(AbstractTest, AbstractGraphQLTest):
         api_key: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        page: Optional[int] = None,
+        pageSize: Optional[int] = None,
         save_key: str = "list_result",
         parent_ids_override: Optional[Dict[str, str]] = None,
         includes: Optional[Union[str, List[str], Tuple[str, ...], Set[str]]] = None,
@@ -1412,6 +1414,10 @@ class AbstractEPTest(AbstractTest, AbstractGraphQLTest):
             query_params.append(f"limit={limit}")
         if offset is not None:
             query_params.append(f"offset={offset}")
+        if page is not None:
+            query_params.append(f"page={page}")
+        if pageSize is not None:
+            query_params.append(f"pageSize={pageSize}")
         include_param = self._serialize_query_values(includes)
         if include_param:
             query_params.append(f"include={include_param}")

--- a/src/endpoints/AbstractEPTest.py
+++ b/src/endpoints/AbstractEPTest.py
@@ -25,14 +25,7 @@ import pytest
 import stringcase
 from faker import Faker
 
-from AbstractTest import (
-    AbstractTest,
-    CategoryOfTest,
-    ClassOfTestsConfig,
-    ParentEntity,
-    SkipReason,
-    SkipThisTest,
-)
+from AbstractTest import AbstractTest, CategoryOfTest, ClassOfTestsConfig, ParentEntity
 from endpoints.AbstractGQLTest import AbstractGraphQLTest
 from lib.Environment import env, inflection
 from lib.Logging import logger
@@ -185,20 +178,6 @@ class AbstractEPTest(AbstractTest, AbstractGraphQLTest):
 
     # Flag for RBAC tests - requires admin role to create/modify
     requires_admin: bool = False
-
-    # Tests to skip - pagination not yet implemented
-    _skip_tests: List[SkipThisTest] = [
-        SkipThisTest(
-            name="test_GET_200_list_pagination",
-            reason=SkipReason.NOT_IMPLEMENTED,
-            details="Pagination not yet implemented",
-        ),
-        SkipThisTest(
-            name="test_POST_200_search_pagination",
-            reason=SkipReason.NOT_IMPLEMENTED,
-            details="Search pagination not yet implemented",
-        ),
-    ]
 
     def setup_method(self, method):
         """Set up method-level test fixtures."""

--- a/src/lib/Pydantic.py
+++ b/src/lib/Pydantic.py
@@ -1295,6 +1295,8 @@ class ModelRegistry(AbstractRegistry):
         list_annotations = {
             "offset": int,
             "limit": int,
+            "page": Optional[int],
+            "page_size": Optional[int],
             "sort_by": Optional[str],
             "sort_order": Optional[str],
         }
@@ -1305,6 +1307,16 @@ class ModelRegistry(AbstractRegistry):
             ),
             "limit": Field(
                 1000, ge=1, le=1000, description="Maximum number of items to return"
+            ),
+            "page": Field(
+                None, ge=1, description="Page number for pagination (1-indexed)"
+            ),
+            "page_size": Field(
+                None,
+                ge=1,
+                le=1000,
+                alias="pageSize",
+                description="Number of items per page",
             ),
             "sort_by": Field(None, description="Field to sort results by"),
             "sort_order": Field(

--- a/src/lib/Pydantic2FastAPI.py
+++ b/src/lib/Pydantic2FastAPI.py
@@ -2034,6 +2034,8 @@ def register_route(
                     fields=fields_param,
                     offset=query_params.offset or 0,
                     limit=query_params.limit or 100,
+                    page=getattr(query_params, "page", None),
+                    pageSize=getattr(query_params, "page_size", None),
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order or "asc",
                     **search_params,


### PR DESCRIPTION
The pagination test (test_GET_200_list_pagination) was passing page and pageSize keyword arguments to _list(), but the method didn't accept these parameters. This adds support for both parameters, matching the existing implementation in _search().