### PR TITLE
Fix missing parameters in SQLAlchemy documentation

### DIFF
--- a/src/database/DB.Management.md
+++ b/src/database/DB.Management.md
@@ -69,7 +69,7 @@ Consolidated database connectivity and engine setup with multi-database support.
 
 **Features:**
 - Dynamic database configuration from environment variables
-- Connection pooling (20 pool size, 10 max overflow for PostgreSQL)
+- Connection pooling (20 pool size, 30 max overflow for PostgreSQL)
 - Automatic SQLite database file creation
 - Database-specific declarative base management
 - Thread-safe session management with automatic cleanup

--- a/src/database/DB.Patterns.md
+++ b/src/database/DB.Patterns.md
@@ -32,7 +32,7 @@ class UserModel(ApplicationModel, DatabaseMixin):
     # Table configuration
     table_comment: ClassVar[str] = "User accounts"
 
-    # The .DB property automatically creates SQLAlchemy model with:
+    # The .DB() classmethod automatically creates SQLAlchemy model with:
     # - UUID primary key (String type for SQLite compatibility)
     # - created_at, created_by_user_id timestamps
     # - All Pydantic fields converted to SQLAlchemy columns
@@ -167,7 +167,7 @@ class UserModel:
     email: Optional[str] = Field(description="User's email address")
 
     # Inherits Create, Update, Search from parent or defines them
-    # DatabaseMixin automatically generates SQLAlchemy model via .DB property
+    # DatabaseMixin automatically generates SQLAlchemy model via .DB() classmethod
 ```
 
 **Database Benefits:**
@@ -486,7 +486,13 @@ class DatabaseMixin:
                 return declarative_base._pydantic_models[registry_key]
 
         # Generate the SQLAlchemy model and cache it
-        sqlalchemy_model = create_sqlalchemy_model(cls, model_registry, base_model=declarative_base)
+        sqlalchemy_model = create_sqlalchemy_model(
+            cls,
+            model_registry,
+            tablename=None,        # Optional: override auto-generated table name
+            table_comment=None,    # Optional: custom table comment
+            base_model=declarative_base
+        )
         declarative_base._pydantic_models[registry_key] = sqlalchemy_model
 
         return sqlalchemy_model

--- a/src/database/DB.Permissions.md
+++ b/src/database/DB.Permissions.md
@@ -88,8 +88,14 @@ Central permission validation function:
 
 ```python
 def check_permission(
-    user_id, record_cls, record_id, db, declarative_base,
-    required_level=None, minimum_role=None, db_manager=None
+    user_id,           # User requesting access
+    record_cls,        # Model class to check
+    record_id,         # Record ID to check
+    db,                # Database session
+    declarative_base,  # Required: SQLAlchemy declarative base (e.g., db_manager.Base)
+    required_level=None,
+    minimum_role=None,
+    db_manager=None
 ):
     """
     Comprehensive permission check with:

--- a/src/database/DB.SeededUsers.md
+++ b/src/database/DB.SeededUsers.md
@@ -91,8 +91,8 @@ def is_root_id(user_id: str) -> bool:
     return user_id == env("ROOT_ID")
 
 def is_any_internal_id(user_id: str) -> bool:
-    """Check if user_id matches SYSTEM_ID"""
-    return user_id == env("SYSTEM_ID")
+    """Check if user_id matches any system ID (ROOT_ID, SYSTEM_ID, or TEMPLATE_ID)"""
+    return user_id in (ROOT_ID, SYSTEM_ID, TEMPLATE_ID)
 
 def is_template_id(user_id: str) -> bool:
     """Check if user_id matches TEMPLATE_ID"""

--- a/src/database/DB.Seeding.md
+++ b/src/database/DB.Seeding.md
@@ -423,9 +423,9 @@ logging.getLogger("database.StaticSeeder").setLevel(logging.DEBUG)
 **Symptom**: Expected extensions not found in seed data
 **Solution**: Check extension module naming and ensure they inherit from `AbstractStaticExtension`
 
-#### 5. DB Property Access Errors
-**Symptom**: TypeError about calling DB property without base parameter
-**Solution**: Ensure all `.DB` calls include the declarative base: `model.DB(db_manager.Base)`
+#### 5. DB() Classmethod Access Errors
+**Symptom**: TypeError about calling DB() classmethod without base parameter
+**Solution**: Ensure all `.DB()` calls include the declarative base: `model.DB(db_manager.Base)`
 
 ### Diagnostic Commands
 ```python

--- a/src/extensions/EXT.Patterns.md
+++ b/src/extensions/EXT.Patterns.md
@@ -1148,7 +1148,7 @@ from logic.AbstractLogicManager import AbstractBLLManager, ApplicationModel, Dat
 class MyEntityModel(ApplicationModel, DatabaseMixin):
     name: str = Field(..., description="Entity name")
     table_comment: str = "My extension entities"
-    # The .DB property with SQLAlchemy model is automatically created
+    # The .DB() classmethod with SQLAlchemy model is automatically created
 
 class MyEntityManager(AbstractBLLManager):
     Model = MyEntityModel
@@ -1207,7 +1207,7 @@ class MyDatabaseModel(ApplicationModel, DatabaseMixin):
     custom_field: str = Field(..., description="Custom field")
     table_comment: str = "Extension database table"
     
-    # The DatabaseMixin automatically creates a .DB property with the SQLAlchemy model
+    # The DatabaseMixin automatically creates a .DB() classmethod with the SQLAlchemy model
 ```
 
 ## Creating an Extension


### PR DESCRIPTION
- Update create_sqlalchemy_model() signature in DB.Patterns.md to show tablename and table_comment optional parameters
- Fix is_any_internal_id() in DB.SeededUsers.md to correctly document that it checks all three system IDs (ROOT_ID, SYSTEM_ID, TEMPLATE_ID)
- Correct PostgreSQL max_overflow from 10 to 30 in DB.Management.md
- Add parameter comments to check_permission() signature in DB.Permissions.md clarifying declarative_base is required
- Change ".DB property" to ".DB() classmethod" terminology across DB.Patterns.md, DB.Seeding.md, and EXT.Patterns.md for accuracy