### PR TITLE
Fix documentation signature mismatch in admin team IDs

### DIFF
--- a/src/Framework.md
+++ b/src/Framework.md
@@ -78,7 +78,7 @@ Extensions and services use consistent configuration:
 ## Database Layer
 
 ### Management
-- **DatabaseManager**: Thread-safe connection pooling with multi-database support (PostgreSQL, SQLite, MariaDB, MSSQL, Vector)
+- **DatabaseManager**: Thread-safe connection pooling with multi-database support (PostgreSQL, SQLite, MySQL, MariaDB, MSSQL)
 - **Declarative Base Isolation**: Each DatabaseManager instance maintains separate declarative base
 - **Migration System**: Alembic-based with core and extension-specific migrations, automatic dependency resolution
 

--- a/src/database/DB.Permissions.md
+++ b/src/database/DB.Permissions.md
@@ -89,12 +89,12 @@ Central permission validation function:
 ```python
 def check_permission(
     user_id,           # User requesting access
-    record_cls,        # Model class to check
+    record_cls,        # Model class to check (Pydantic model with .DB() method, OR SQLAlchemy model)
     record_id,         # Record ID to check
     db,                # Database session
-    declarative_base,  # Required: SQLAlchemy declarative base (e.g., db_manager.Base)
-    required_level=None,
-    minimum_role=None,
+    declarative_base,  # Required for Pydantic models; optional if passing SQLAlchemy model directly
+    required_level=None,  # Specific PermissionType required (takes precedence over minimum_role)
+    minimum_role=None,    # Minimum role: 'user' -> VIEW, 'admin' -> EDIT, 'superadmin' -> SHARE
     db_manager=None
 ):
     """
@@ -104,6 +104,10 @@ def check_permission(
     - Permission table lookups
     - Role hierarchy validation
     - Database manager integration
+
+    Note: record_cls can be either:
+    - A Pydantic model class with DatabaseMixin (has .DB() method) - requires declarative_base
+    - A SQLAlchemy model class (has __tablename__) - declarative_base can be None
     """
     
     # ROOT_ID has universal access
@@ -160,7 +164,11 @@ Advanced recursive CTE implementation with depth limiting and optimization:
 
 ```python
 def _get_admin_accessible_team_ids_cte(
-    user_id: str, db: Session, max_depth: int = 5
+    user_id: str,
+    db: Session,
+    declarative_base,           # Required: SQLAlchemy declarative base (e.g., db_manager.Base)
+    max_depth: int = 5,
+    unique_suffix: str = "",    # Optional: Suffix for CTE naming to avoid conflicts in complex queries
 ) -> CTE:
     """
     Generate optimized recursive CTE with:

--- a/src/database/DB.Seeding.md
+++ b/src/database/DB.Seeding.md
@@ -236,24 +236,26 @@ def seed_data(cls) -> List[Dict[str, Any]]:
 ## Seeding Workflow
 
 ### 1. Initialization
+The main seeding entry point is `ModelRegistry._seed()`, which coordinates the seeding process. There is no standalone `seed()` function in `StaticSeeder.py` - all seeding orchestration happens through the ModelRegistry:
+
 ```python
-def seed(db_manager: DatabaseManager, extensions_list: str = "", model_registry=None):
-    """Main seeding entry point."""
+# In ModelRegistry class
+def _seed(self):
+    """Main seeding entry point in ModelRegistry."""
     logger.debug("Starting database seeding process...")
-    
-    # Load and initialize extensions before seeding
-    _load_extensions(extensions_list)
-    
+
     # Get database session
-    session = db_manager.get_session()
-    
-    # Get models that need seeding from ModelRegistry
-    models_to_seed = get_all_models(db_manager, extensions_list, model_registry)
-    
-    # Seed each model in dependency order
+    session = self.db_manager.get_session()
+
+    # Get models that need seeding, sorted by dependencies
+    models_to_seed = self._get_models_in_dependency_order()
+
+    # Seed each model in dependency order using StaticSeeder helper
     for model in models_to_seed:
-        seed_model(model, session, db_manager, model_registry)
+        seed_model(model, session, self.db_manager, self)
 ```
+
+The `seed_model()` helper function from `StaticSeeder.py` handles individual model seeding:
 
 ### 2. Model Seeding Process
 ```python

--- a/src/database/DB.Test.md
+++ b/src/database/DB.Test.md
@@ -233,8 +233,10 @@ self.verify_permission_checks(entity_id, allowed_users, denied_users)
 ## Test Configuration
 
 ### Test Dependencies
-Tests are marked with pytest dependencies to ensure proper execution order:
+Tests can be marked with pytest dependencies to ensure proper execution order. Note that test dependencies are currently disabled in the codebase to allow for parallel test execution:
 ```python
+# Test dependencies are optional and currently disabled
+# To enable sequential ordering, uncomment the dependency decorator:
 # @pytest.mark.dependency(depends=["test_CRUD_create"])
 def test_CRUD_get(self, admin_a, team_a, return_type):
 ```

--- a/src/database/StaticPermissions.py
+++ b/src/database/StaticPermissions.py
@@ -284,7 +284,9 @@ def find_create_permission_reference_chain(cls, db, visited=None):
         )
 
 
-def check_permission_table_access(user_id, cls, db, operation=None, **kwargs):
+def check_permission_table_access(
+    user_id, cls, db, declarative_base=None, operation=None, **kwargs
+):
     """
     Special permission check for the Permission table.
     Users need SHARE permission or admin access to the resource they're trying to manage permissions for.
@@ -293,6 +295,7 @@ def check_permission_table_access(user_id, cls, db, operation=None, **kwargs):
         user_id: The ID of the user to check
         cls: The model class being checked (should be Permission)
         db: Database session
+        declarative_base: SQLAlchemy declarative base for model resolution
         operation: The operation being performed (create, update, delete)
         **kwargs: Permission properties, including resource_type and resource_id
 
@@ -318,11 +321,13 @@ def check_permission_table_access(user_id, cls, db, operation=None, **kwargs):
         return (True, None)  # SYSTEM_ID can also manage all permissions
 
     # Check if the user can manage permissions for this resource
-    return can_manage_permissions(user_id, resource_type, resource_id, db, operation)
+    return can_manage_permissions(
+        user_id, resource_type, resource_id, db, declarative_base, operation
+    )
 
 
 def check_access_to_all_referenced_entities(
-    user_id, cls, db, minimum_role=None, **kwargs
+    user_id, cls, db, declarative_base=None, minimum_role=None, **kwargs
 ):
     """
     Check if the user has access to all referenced entities specified by foreign keys.
@@ -332,6 +337,7 @@ def check_access_to_all_referenced_entities(
         user_id: The ID of the user to check
         cls: The model class
         db: Database session
+        declarative_base: SQLAlchemy declarative base for model resolution
         minimum_role: Minimum role name required
         **kwargs: Foreign key values to check
 
@@ -342,7 +348,7 @@ def check_access_to_all_referenced_entities(
     # Special handling for Permission table
     if cls.__name__ == "Permission":  # Use name check
         can_access, error_msg = check_permission_table_access(
-            user_id, cls, db, **kwargs
+            user_id, cls, db, declarative_base=declarative_base, **kwargs
         )
         if not can_access:
             return (
@@ -392,7 +398,12 @@ def check_access_to_all_referenced_entities(
         # Check if user has access to this record using the optimized check
         # Defaulting to VIEW access unless minimum_role is specified
         access_result, error_msg = check_permission(
-            user_id, ref_model, ref_id, db, minimum_role
+            user_id,
+            ref_model,
+            ref_id,
+            db,
+            declarative_base,
+            minimum_role=minimum_role,
         )
 
         if access_result == PermissionResult.NOT_FOUND:
@@ -405,7 +416,7 @@ def check_access_to_all_referenced_entities(
 
 
 def can_manage_permissions(
-    user_id, resource_type, resource_id, db, operation_type=None
+    user_id, resource_type, resource_id, db, declarative_base=None, operation_type=None
 ):
     """
     Check if a user can manage permissions for a resource.
@@ -416,6 +427,7 @@ def can_manage_permissions(
         resource_type: The table name (string) of the resource type to check
         resource_id: The ID of the resource to check
         db: Database session
+        declarative_base: SQLAlchemy declarative base for model resolution
         operation_type: Type of operation (create, edit, delete)
 
     Returns:
@@ -511,7 +523,12 @@ def can_manage_permissions(
 
     # Check for explicit SHARE permission using check_permission
     result, _ = check_permission(
-        user_id, model_class, resource_id, db, PermissionType.SHARE
+        user_id,
+        model_class,
+        resource_id,
+        db,
+        declarative_base,
+        required_level=PermissionType.SHARE,
     )
     if result == PermissionResult.GRANTED:
         return (True, None)
@@ -519,17 +536,20 @@ def can_manage_permissions(
     # Check if the user has EDIT permission to the resource
     if user_can_edit(user_id, model_class, resource_id, db):
         # For deletion, check if they have DELETE permission as well
-        if (
-            operation_type == "delete"
-            and not check_permission(
-                user_id, model_class, resource_id, db, PermissionType.DELETE
-            )[0]
-            == PermissionResult.GRANTED
-        ):
-            return (
-                False,
-                f"User {user_id} does not have DELETE permission for {resource_type} {resource_id}",
+        if operation_type == "delete":
+            delete_result, _ = check_permission(
+                user_id,
+                model_class,
+                resource_id,
+                db,
+                declarative_base,
+                required_level=PermissionType.DELETE,
             )
+            if delete_result != PermissionResult.GRANTED:
+                return (
+                    False,
+                    f"User {user_id} does not have DELETE permission for {resource_type} {resource_id}",
+                )
         return (True, None)
 
     return (
@@ -722,7 +742,23 @@ def check_permission(
                 required_level = PermissionType.VIEW
 
         # Get the SQLAlchemy model for the record class
-        record_db_cls = record_cls.DB(declarative_base)
+        # Handle both Pydantic models (with .DB() method) and SQLAlchemy models (with __tablename__)
+        if hasattr(record_cls, "__tablename__"):
+            # Already a SQLAlchemy model - use directly
+            record_db_cls = record_cls
+        elif hasattr(record_cls, "DB") and callable(getattr(record_cls, "DB", None)):
+            # Pydantic model - call .DB() to get SQLAlchemy model
+            if declarative_base is None:
+                return (
+                    PermissionResult.ERROR,
+                    f"declarative_base is required when passing Pydantic model {record_cls.__name__}",
+                )
+            record_db_cls = record_cls.DB(declarative_base)
+        else:
+            return (
+                PermissionResult.ERROR,
+                f"Invalid record class: {record_cls} - must be a Pydantic model with .DB() method or SQLAlchemy model",
+            )
 
         # Check if the record exists at all
         record_exists = db.query(exists().where(record_db_cls.id == record_id)).scalar()

--- a/src/database/StaticPermissions_test.py
+++ b/src/database/StaticPermissions_test.py
@@ -382,15 +382,17 @@ class TestPermissionChecks:
         resource_id = test_records["resource_id"]
         regular_user_id = test_records["regular_user_id"]
 
-        # Setup mock DB to return None (resource not found)
+        # Setup mock DB to return False for exists check and None for the record query
+        mock_db.query.return_value.scalar.return_value = False
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
         # Test using the actual check_permission function with mocked database
+        # ResourceForTest is a valid SQLAlchemy model (has __tablename__), so it should work
         result, _ = check_permission(
             regular_user_id, ResourceForTest, resource_id, mock_db, Base
         )
-        # Since ResourceForTest doesn't have a DB attribute, it returns ERROR instead of NOT_FOUND
-        assert result == PermissionResult.ERROR
+        # With the exists check returning False, we expect NOT_FOUND
+        assert result == PermissionResult.NOT_FOUND
 
 
 # Test permission references


### PR DESCRIPTION
Documentation fixes:
- Update _get_admin_accessible_team_ids_cte signature to include declarative_base and unique_suffix parameters
- Correct DB.Seeding.md to reflect that ModelRegistry._seed() is the entry point, not a standalone seed() function
- Remove non-existent "Vector" database type from Framework.md
- Clarify that test dependency decorators are optional and currently disabled in DB.Test.md
- Clarify check_permission parameter documentation to explain record_cls accepts both Pydantic and SQLAlchemy models

Implementation fixes in StaticPermissions.py:
- Add declarative_base parameter to check_access_to_all_referenced_entities, can_manage_permissions, and check_permission_table_access
- Fix incorrect check_permission calls that were passing minimum_role/PermissionType as declarative_base
- Update check_permission to handle both Pydantic models (with .DB() method) and SQLAlchemy models (with __tablename__)