### PR TITLE
Add negative-path security tests across auth, framework, and extension surfaces

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -31,3 +31,4 @@ markers =
     stripe: Stripe payment provider tests
     timeout: Test timeout configuration
     dependency: Test dependencies (pytest-dependency)
+    security: Explicit-deny / negative-path security tests (cross-tenant, mass-assignment, JWT tampering, lockout, etc.)

--- a/src/database/StaticPermissions_test.py
+++ b/src/database/StaticPermissions_test.py
@@ -1647,3 +1647,76 @@ def test_invited_user_sees_child_and_parent_team(model_registry, use_invitee):
 
     assert "Invitation Child" in team_names
     assert "Invitation Parent" in team_names
+
+
+# ----------------------------------------------------------------------
+# Security: explicit-deny / negative-path permission tests.
+#
+# These assert that the static-permission layer rejects spoofed identities
+# and treats null ownership as denied for non-root users.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestPermissionSpoofingDenied:
+    """A user_id passed to check_permission is trusted by the caller; these
+    tests assert the permission layer itself does not amplify privileges
+    beyond the user's actual standing in the DB."""
+
+    def test_permission_filter_with_unknown_user_returns_no_rows(
+        self, mock_db, test_records
+    ):
+        """A user_id that is not any of root/system/template and has no
+        team/permission rows must produce an exclusionary filter."""
+        from database.StaticPermissions import generate_permission_filter
+
+        ResourceForTest = test_records["ResourceForTest"]
+        unknown_user = create_uuid()
+        # No mock setup for permissions/teams — the user has nothing.
+
+        try:
+            filter_expr = generate_permission_filter(
+                unknown_user, ResourceForTest, mock_db, Base
+            )
+        except Exception:
+            # If the function raises for a missing user, that's also "deny".
+            return
+
+        # The filter must not be `True` (i.e. allow all). Either it is
+        # `False`, an empty disjunction, or a non-trivial expression.
+        assert filter_expr is not True, (
+            "generate_permission_filter returned `True` for an unknown user "
+            "(which would expose every row). Permission layer must default "
+            "to deny."
+        )
+
+    def test_check_permission_denies_when_record_has_null_team_for_non_root(
+        self, mock_db, test_records
+    ):
+        """A non-root user must NOT be granted access to a resource whose
+        `user_id` and `team_id` are both NULL (no clear ownership)."""
+        from database.StaticPermissions import PermissionResult
+
+        ResourceForTest = test_records["ResourceForTest"]
+        resource_id = test_records["resource_id"]
+        regular_user_id = test_records["regular_user_id"]
+
+        # Mock a record with null ownership.
+        mock_record = MagicMock()
+        mock_record.user_id = None
+        mock_record.team_id = None
+        mock_record.created_by_user_id = None
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            mock_record
+        )
+
+        result, _ = check_permission(
+            regular_user_id, ResourceForTest, resource_id, mock_db, Base
+        )
+        # The acceptable outcomes for a fully-anonymous record are DENIED,
+        # NOT_FOUND, or ERROR. GRANTED would be a privilege-escalation gap.
+        assert result != PermissionResult.GRANTED, (
+            "check_permission returned GRANTED for a record with NULL "
+            "user_id and NULL team_id to a non-root user. Permission layer "
+            "must default to deny."
+        )

--- a/src/endpoints/AbstractEPTest.py
+++ b/src/endpoints/AbstractEPTest.py
@@ -2611,6 +2611,371 @@ class AbstractEPTest(AbstractTest, AbstractGraphQLTest):
             response.status_code == 403
         ), "Creation with insufficient permissions should return 403"
 
+    # ------------------------------------------------------------------
+    # Security: explicit-deny / negative-path framework invariants.
+    # These run against every concrete AbstractEPTest subclass and prove
+    # the auto-generated endpoints enforce deny-by-default regardless of
+    # what an extension author writes in their BLL/EXT/PRV.
+    # ------------------------------------------------------------------
+
+    # Field names that must never appear in a Response body. If they do,
+    # an extension author has accidentally exposed a secret column via
+    # the auto-generated Network model.
+    SECRET_RESPONSE_FIELDS = (
+        "password_hash",
+        "password",
+        "secret",
+        "api_key_hash",
+        "recovery_answer_hash",
+        "answer_hash",
+        "jwt_secret",
+        "client_secret",
+    )
+
+    @staticmethod
+    def _walk_for_secret_fields(payload: Any, banned: Tuple[str, ...]) -> List[str]:
+        """Walk a JSON-decoded response and collect any banned key names found."""
+        found: List[str] = []
+        stack: List[Any] = [payload]
+        while stack:
+            current = stack.pop()
+            if isinstance(current, dict):
+                for k, v in current.items():
+                    if k in banned:
+                        found.append(k)
+                    stack.append(v)
+            elif isinstance(current, list):
+                stack.extend(current)
+        return found
+
+    @pytest.mark.security
+    def test_GET_404_other_team(
+        self, server: Any, admin_a: Any, admin_b: Any, team_a: Any, team_b: Any
+    ):
+        """Cross-tenant GET denial: admin_b cannot read admin_a's team_a entity."""
+        if not self.team_scoped:
+            pytest.skip("Entity not team-scoped")
+
+        entity = self._create(
+            server, admin_a.jwt, admin_a.id, team_a.id, key="cross_tenant_get"
+        )
+
+        response = server.get(
+            self.get_detail_endpoint(entity["id"], {}),
+            headers=self._get_appropriate_headers(admin_b.jwt),
+        )
+
+        assert response.status_code in (
+            403,
+            404,
+        ), f"Expected 403/404 for cross-tenant GET, got {response.status_code}"
+
+    @pytest.mark.security
+    def test_GET_200_list_excludes_other_team(
+        self, server: Any, admin_a: Any, admin_b: Any, team_a: Any, team_b: Any
+    ):
+        """Cross-tenant LIST denial: admin_b's list never includes admin_a's row."""
+        if not self.team_scoped:
+            pytest.skip("Entity not team-scoped")
+
+        entity = self._create(
+            server, admin_a.jwt, admin_a.id, team_a.id, key="cross_tenant_list"
+        )
+
+        response = server.get(
+            self.get_list_endpoint({}),
+            headers=self._get_appropriate_headers(admin_b.jwt),
+        )
+
+        # Some endpoints return 403 for cross-tenant list; that's acceptable.
+        if response.status_code in (401, 403, 404):
+            return
+
+        assert response.status_code == 200, (
+            f"Cross-tenant list should return 200 (filtered) or 403/404; "
+            f"got {response.status_code}"
+        )
+
+        # Substring check on the raw body catches the id wherever it is nested.
+        assert (
+            entity["id"] not in response.text
+        ), f"Cross-tenant list leaked entity id {entity['id']} from team_a to admin_b"
+
+    @pytest.mark.security
+    def test_PUT_404_other_team(
+        self, server: Any, admin_a: Any, admin_b: Any, team_a: Any, team_b: Any
+    ):
+        """Cross-tenant PUT denial: admin_b cannot update admin_a's entity."""
+        if not self.team_scoped:
+            pytest.skip("Entity not team-scoped")
+
+        entity = self._create(
+            server, admin_a.jwt, admin_a.id, team_a.id, key="cross_tenant_put"
+        )
+
+        update_data: Dict[str, Any] = {}
+        if self.string_field_to_update:
+            update_data[self.string_field_to_update] = (
+                f"Hijacked by B {self.faker.word()}"
+            )
+
+        response = server.put(
+            self.get_update_endpoint(entity["id"], {}),
+            json={self.entity_name: update_data},
+            headers=self._get_appropriate_headers(admin_b.jwt),
+        )
+
+        assert response.status_code in (
+            403,
+            404,
+        ), f"Expected 403/404 for cross-tenant PUT, got {response.status_code}"
+
+    @pytest.mark.security
+    def test_DELETE_404_other_team(
+        self, server: Any, admin_a: Any, admin_b: Any, team_a: Any, team_b: Any
+    ):
+        """Cross-tenant DELETE denial: admin_b cannot delete admin_a's entity."""
+        if not self.team_scoped:
+            pytest.skip("Entity not team-scoped")
+
+        entity = self._create(
+            server, admin_a.jwt, admin_a.id, team_a.id, key="cross_tenant_delete"
+        )
+
+        response = server.delete(
+            self.get_delete_endpoint(entity["id"], {}),
+            headers=self._get_appropriate_headers(admin_b.jwt),
+        )
+
+        assert response.status_code in (
+            403,
+            404,
+        ), f"Expected 403/404 for cross-tenant DELETE, got {response.status_code}"
+
+    @pytest.mark.security
+    def test_POST_ignores_audit_fields_in_body(
+        self, server: Any, admin_a: Any, team_a: Any
+    ):
+        """Mass-assignment denial: client-supplied audit fields are stripped/ignored."""
+        if self.system_entity:
+            pytest.skip(
+                "System entities are created via API key; audit-field test n/a"
+            )
+
+        attacker_uuid = str(uuid.uuid4())
+        attacker_iso = "1999-01-01T00:00:00+00:00"
+
+        base_payload = self.create_payload(
+            name=f"Audit-field test {self.faker.word()}", team_id=team_a.id
+        )
+        # Inject every audit-field a sloppy extension dev might allow.
+        base_payload["created_by_user_id"] = attacker_uuid
+        base_payload["updated_by_user_id"] = attacker_uuid
+        base_payload["created_at"] = attacker_iso
+        base_payload["updated_at"] = attacker_iso
+        base_payload["id"] = attacker_uuid
+
+        path_parent_ids: Dict[str, str] = {}
+        if self.parent_entities:
+            for parent in self.parent_entities:
+                if parent.path_level in [1, 2] or (
+                    hasattr(parent, "is_path") and parent.is_path
+                ):
+                    path_parent_ids[f"{parent.name}_id"] = team_a.id
+
+        response = server.post(
+            self.get_create_endpoint(path_parent_ids),
+            json={self.entity_name: base_payload},
+            headers=self._get_appropriate_headers(admin_a.jwt),
+        )
+
+        # Acceptable: 201 (silently stripped) or 422 (rejected).
+        # Forbidden: 201 with persisted attacker values.
+        assert response.status_code in (201, 422), (
+            f"Audit-field POST should be stripped (201) or rejected (422); "
+            f"got {response.status_code}: {response.text[:300]}"
+        )
+        if response.status_code != 201:
+            return
+
+        body = response.json()
+        # Drill into the response to find the entity.
+        candidate = body.get(self.entity_name) if isinstance(body, dict) else None
+        if candidate is None and isinstance(body, dict):
+            candidate = body
+        if not isinstance(candidate, dict):
+            return
+
+        if "id" in candidate:
+            assert candidate["id"] != attacker_uuid, (
+                "Mass-assignment: server accepted client-supplied id "
+                "(audit-field invariant violated)"
+            )
+        if "created_by_user_id" in candidate:
+            assert candidate["created_by_user_id"] != attacker_uuid, (
+                "Mass-assignment: server accepted client-supplied "
+                "created_by_user_id (audit-field invariant violated)"
+            )
+        if "created_at" in candidate:
+            assert (
+                candidate["created_at"] != attacker_iso
+            ), "Mass-assignment: server accepted client-supplied created_at"
+
+    @pytest.mark.security
+    def test_PUT_ignores_audit_fields_in_body(
+        self, server: Any, admin_a: Any, team_a: Any
+    ):
+        """Mass-assignment denial on PUT: audit fields in body are stripped/ignored."""
+        if self.system_entity:
+            pytest.skip(
+                "System entities are mutated via API key; audit-field test n/a"
+            )
+
+        entity = self._create(
+            server, admin_a.jwt, admin_a.id, team_a.id, key="audit_put_test"
+        )
+
+        attacker_uuid = str(uuid.uuid4())
+        attacker_iso = "1999-01-01T00:00:00+00:00"
+        update_data: Dict[str, Any] = {
+            "created_by_user_id": attacker_uuid,
+            "updated_by_user_id": attacker_uuid,
+            "created_at": attacker_iso,
+            "updated_at": attacker_iso,
+            "id": attacker_uuid,
+        }
+        if self.string_field_to_update:
+            update_data[self.string_field_to_update] = f"Audit PUT {self.faker.word()}"
+
+        response = server.put(
+            self.get_update_endpoint(entity["id"], {}),
+            json={self.entity_name: update_data},
+            headers=self._get_appropriate_headers(admin_a.jwt),
+        )
+
+        assert response.status_code in (200, 422), (
+            f"Audit-field PUT should be stripped (200) or rejected (422); "
+            f"got {response.status_code}: {response.text[:300]}"
+        )
+        if response.status_code != 200:
+            return
+
+        body = response.json()
+        candidate = body.get(self.entity_name) if isinstance(body, dict) else None
+        if candidate is None and isinstance(body, dict):
+            candidate = body
+        if not isinstance(candidate, dict):
+            return
+
+        if "id" in candidate:
+            assert (
+                candidate["id"] == entity["id"]
+            ), "Mass-assignment: server overwrote id from PUT body"
+        if "created_by_user_id" in candidate and "created_by_user_id" in entity:
+            assert (
+                candidate["created_by_user_id"] == entity["created_by_user_id"]
+            ), "Mass-assignment: server accepted PUT-body created_by_user_id"
+
+    @pytest.mark.security
+    def test_GET_response_omits_secret_fields(
+        self, server: Any, admin_a: Any, team_a: Any
+    ):
+        """Secret-column denial: response body contains no known-sensitive field name."""
+        entity = self._create(
+            server, admin_a.jwt, admin_a.id, team_a.id, key="secret_field_test"
+        )
+
+        path_parent_ids: Dict[str, str] = {}
+        if self.parent_entities:
+            for parent in self.parent_entities:
+                if parent.foreign_key in entity:
+                    parent_id = entity[parent.foreign_key]
+                    if parent.path_level in [1, 2] or (
+                        hasattr(parent, "is_path") and parent.is_path
+                    ):
+                        path_parent_ids[f"{parent.name}_id"] = parent_id
+
+        response = server.get(
+            self.get_detail_endpoint(entity["id"], path_parent_ids),
+            headers=self._get_appropriate_headers(admin_a.jwt),
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200 reading own entity; got {response.status_code}"
+        )
+
+        leaked = self._walk_for_secret_fields(
+            response.json(), self.SECRET_RESPONSE_FIELDS
+        )
+        assert not leaked, (
+            f"Response leaked secret field(s) {leaked} for {self.entity_name}; "
+            f"the auto-generated Network model must strip these columns."
+        )
+
+    @pytest.mark.security
+    def test_GET_pagination_cap_enforced(
+        self, server: Any, admin_a: Any, team_a: Any
+    ):
+        """DoS denial: list endpoint clamps oversized limit to the framework cap."""
+        # Create one row so the list response is well-formed.
+        self._create(server, admin_a.jwt, admin_a.id, team_a.id, key="pagination_cap")
+
+        response = server.get(
+            f"{self.get_list_endpoint({})}?limit=100000",
+            headers=self._get_appropriate_headers(admin_a.jwt),
+        )
+        # Either silently clamped (200) or rejected (422). Never 500.
+        assert response.status_code in (200, 422), (
+            f"Oversized limit should clamp (200) or 422; got {response.status_code}"
+        )
+        if response.status_code != 200:
+            return
+        body = response.json()
+        # If the body is the list-form {plural: [...]}, count it; else pass.
+        if isinstance(body, dict):
+            for v in body.values():
+                if isinstance(v, list):
+                    assert len(v) <= 1000, (
+                        f"Pagination cap not enforced: returned {len(v)} rows "
+                        "but framework cap is 1000 (AbstractLogicManager.py:1053)"
+                    )
+                    break
+
+    @pytest.mark.security
+    def test_GET_search_rejects_unknown_field(
+        self, server: Any, admin_a: Any, team_a: Any
+    ):
+        """Filter-whitelist denial: search on a non-whitelisted column → 422.
+
+        Many extension authors will not narrow `searchable_fields`. The framework
+        must reject filters on internal columns (`password_hash`, `jwt_secret`) so a
+        sloppy author cannot accidentally expose a probing oracle.
+        """
+        if not self.supports_search:
+            pytest.skip("Entity does not support search")
+
+        # Use a column name that no legitimate model exposes.
+        forbidden_field = "password_hash"
+        response = server.get(
+            f"{self.get_list_endpoint({})}?{forbidden_field}=anything",
+            headers=self._get_appropriate_headers(admin_a.jwt),
+        )
+
+        assert response.status_code in (200, 422), (
+            f"Unknown search field {forbidden_field} should be rejected (422) or "
+            f"silently ignored (200); got {response.status_code}"
+        )
+        if response.status_code == 200:
+            # Silently ignored is acceptable; assert the secret name didn't leak
+            # back as a key in the response.
+            leaked = self._walk_for_secret_fields(
+                response.json(), (forbidden_field,)
+            )
+            assert not leaked, (
+                f"Search accepted unknown field {forbidden_field} and surfaced it "
+                "in the response; whitelist enforcement is missing."
+            )
+
     def test_POST_404_nonexistent_parent(self, server: Any, admin_a: Any, team_a: Any):
         """Test creating a resource with a nonexistent parent."""
         if not self.parent_entities or not any(

--- a/src/endpoints/EP_Auth_test.py
+++ b/src/endpoints/EP_Auth_test.py
@@ -1245,6 +1245,333 @@ class TestUserAndSessionEndpoints(AbstractEPTest):
         # Assert response status is 401 Unauthorized
         self._assert_response_status(response, 401, "GET (empty JWT)", "/v1/user")
 
+    # ------------------------------------------------------------------
+    # Security: explicit-deny / negative-path auth tests.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _forged_jwt(payload: Dict[str, Any], *, alg: str, key: str) -> str:
+        """Encode a JWT with arbitrary alg/key — used to forge tampered tokens."""
+        import jwt as pyjwt
+
+        return pyjwt.encode(payload, key, algorithm=alg)
+
+    @staticmethod
+    def _alg_none_jwt(payload: Dict[str, Any]) -> str:
+        """Construct a JWT with `alg: none` and no signature."""
+        import base64
+        import json as _json
+
+        def _b64(data: bytes) -> str:
+            return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+        header = _b64(_json.dumps({"alg": "none", "typ": "JWT"}).encode())
+        body = _b64(_json.dumps(payload).encode())
+        return f"{header}.{body}."
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_GET_401_jwt_alg_none(self, server: Any, admin_a: Any) -> None:
+        """JWT with `alg:none` (no signature) must be rejected."""
+        forged = self._alg_none_jwt(
+            {"sub": admin_a.id, "email": admin_a.email, "exp": 9999999999}
+        )
+        response = server.get(
+            "/v1", headers={"Authorization": f"Bearer {forged}"}
+        )
+        assert (
+            response.status_code == 401
+        ), f"alg:none JWT must be rejected; got {response.status_code}"
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_GET_401_jwt_wrong_secret(self, server: Any, admin_a: Any) -> None:
+        """JWT signed with attacker-chosen secret must be rejected."""
+        forged = self._forged_jwt(
+            {"sub": admin_a.id, "email": admin_a.email, "exp": 9999999999},
+            alg="HS256",
+            key="attacker-controlled-secret",
+        )
+        response = server.get(
+            "/v1", headers={"Authorization": f"Bearer {forged}"}
+        )
+        assert (
+            response.status_code == 401
+        ), f"JWT signed with wrong secret must be rejected; got {response.status_code}"
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_GET_401_jwt_expired(self, server: Any, admin_a: Any) -> None:
+        """JWT with `exp` in the past must be rejected (5min leeway accounted for)."""
+        forged = self._forged_jwt(
+            {
+                "sub": admin_a.id,
+                "email": admin_a.email,
+                "exp": 1000,
+                "iat": 500,
+            },
+            alg="HS256",
+            key=env("JWT_SECRET"),
+        )
+        response = server.get(
+            "/v1", headers={"Authorization": f"Bearer {forged}"}
+        )
+        assert (
+            response.status_code == 401
+        ), f"Expired JWT must be rejected; got {response.status_code}"
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_GET_401_jwt_modified_sub_claim(
+        self, server: Any, admin_a: Any
+    ) -> None:
+        """JWT whose body is rewritten without re-signing must be rejected."""
+        import base64
+        import json as _json
+
+        parts = admin_a.jwt.split(".")
+        assert len(parts) == 3, "JWT must have header.body.signature"
+
+        # Pad to make base64 decoding tolerant of stripped padding.
+        pad = lambda s: s + "=" * (-len(s) % 4)
+        body = _json.loads(base64.urlsafe_b64decode(pad(parts[1])))
+        body["sub"] = str(uuid.uuid4())  # impersonate a different user
+        new_body = (
+            base64.urlsafe_b64encode(_json.dumps(body).encode())
+            .rstrip(b"=")
+            .decode()
+        )
+        tampered = f"{parts[0]}.{new_body}.{parts[2]}"
+
+        response = server.get(
+            "/v1", headers={"Authorization": f"Bearer {tampered}"}
+        )
+        assert (
+            response.status_code == 401
+        ), f"Tampered JWT body must invalidate signature; got {response.status_code}"
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_GET_401_revoked_session_still_rejects_jwt(
+        self, server: Any, db: Any
+    ) -> None:
+        """JWT issued for a revoked session must not authenticate.
+
+        EXPECTED FAIL today — JWT generation in BLL_Auth.py:688-700 does not
+        embed `jti=session_key`, so revoking the session does not invalidate
+        the bearer token. Surfaces gap.
+        """
+        from conftest import create_user
+
+        test_user = create_user(
+            server=server,
+            email=f"revoke_test_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpassword",
+            first_name="RevokeTest",
+            last_name="User",
+        )
+        # Pull the user's session and revoke it directly.
+        sessions = server.get(
+            "/v1/session",
+            headers=self._get_appropriate_headers(test_user.jwt),
+        ).json().get("sessions", [])
+        if not sessions:
+            pytest.skip("No session created for test_user")
+
+        session_id = sessions[0]["id"]
+        revoke = server.delete(
+            f"/v1/session/{session_id}",
+            headers=self._get_appropriate_headers(test_user.jwt),
+        )
+        assert revoke.status_code == 204, "Could not revoke session"
+
+        # The JWT issued before revocation must now be rejected.
+        response = server.get(
+            "/v1", headers=self._get_appropriate_headers(test_user.jwt)
+        )
+        assert response.status_code == 401, (
+            "JWT belonging to a revoked session must be rejected — currently "
+            "passes because JWT lacks jti binding to session_key."
+        )
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_POST_429_after_many_failed_logins(
+        self, server: Any, db: Any
+    ) -> None:
+        """Repeated wrong-password attempts must trigger account lockout (429)."""
+        from conftest import create_user
+
+        test_user = create_user(
+            server=server,
+            email=f"lockout_test_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpassword",
+            first_name="LockoutTest",
+            last_name="User",
+        )
+
+        wrong_payload = {"email": test_user.email, "password": "definitely-wrong"}
+        # Try up to 10 attempts; the framework caps at 5 failures / 1h.
+        last_status = None
+        saw_lockout = False
+        for _ in range(10):
+            r = server.post("/v1/user/authorize", json=wrong_payload)
+            last_status = r.status_code
+            if r.status_code == 429:
+                saw_lockout = True
+                break
+            assert r.status_code == 401, (
+                f"Wrong password should be 401 until lockout; got {r.status_code}"
+            )
+
+        assert saw_lockout, (
+            f"Account must lock after repeated failures (BLL_Auth.py:1058-1079); "
+            f"last status was {last_status} after 10 attempts."
+        )
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_POST_no_username_enumeration_in_error(
+        self, server: Any, db: Any
+    ) -> None:
+        """Login error message must NOT distinguish 'no such user' from 'wrong password'."""
+        from conftest import create_user
+
+        test_user = create_user(
+            server=server,
+            email=f"enum_test_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpassword",
+            first_name="EnumTest",
+            last_name="User",
+        )
+        wrong_pw = server.post(
+            "/v1/user/authorize",
+            json={"email": test_user.email, "password": "wrong"},
+        )
+        no_user = server.post(
+            "/v1/user/authorize",
+            json={
+                "email": f"nobody_{uuid.uuid4().hex[:8]}@example.com",
+                "password": "wrong",
+            },
+        )
+        assert (
+            wrong_pw.status_code == no_user.status_code == 401
+        ), "Both should be 401"
+        assert (
+            wrong_pw.json().get("detail") == no_user.json().get("detail")
+        ), (
+            "Error detail must be identical for nonexistent user vs wrong password "
+            "(prevents username enumeration)."
+        )
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_PATCH_password_requires_current_password(
+        self, server: Any, db: Any
+    ) -> None:
+        """PATCH /v1/user without `current_password` must reject."""
+        from conftest import create_user
+
+        test_user = create_user(
+            server=server,
+            email=f"pw_curr_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpassword",
+            first_name="PwCurr",
+            last_name="User",
+        )
+        # Missing current_password entirely.
+        r1 = server.patch(
+            "/v1/user",
+            json={"new_password": "Strong-Password-1!"},
+            headers=self._get_appropriate_headers(test_user.jwt),
+        )
+        assert r1.status_code in (
+            400,
+            401,
+            403,
+            422,
+        ), f"PATCH without current_password should reject; got {r1.status_code}"
+
+        # Wrong current_password.
+        r2 = server.patch(
+            "/v1/user",
+            json={
+                "current_password": "incorrect",
+                "new_password": "Strong-Password-1!",
+            },
+            headers=self._get_appropriate_headers(test_user.jwt),
+        )
+        assert r2.status_code in (
+            401,
+            403,
+        ), f"Wrong current_password should reject 401/403; got {r2.status_code}"
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_PATCH_password_rejects_weak(self, server: Any, db: Any) -> None:
+        """Weak password must be rejected by policy.
+
+        EXPECTED FAIL today — no password strength enforcement
+        (BLL_Auth.py search shows none). Surfaces gap.
+        """
+        from conftest import create_user
+
+        test_user = create_user(
+            server=server,
+            email=f"pw_weak_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpassword",
+            first_name="PwWeak",
+            last_name="User",
+        )
+        r = server.patch(
+            "/v1/user",
+            json={"current_password": "testpassword", "new_password": "a"},
+            headers=self._get_appropriate_headers(test_user.jwt),
+        )
+        assert (
+            r.status_code == 422
+        ), f"Single-char password must fail policy (422); got {r.status_code}"
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_DELETE_session_403_cross_user(
+        self, server: Any, db: Any
+    ) -> None:
+        """A user must not be able to delete another user's session."""
+        from conftest import create_user
+
+        user_x = create_user(
+            server=server,
+            email=f"sess_x_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpassword",
+            first_name="SessX",
+            last_name="User",
+        )
+        user_y = create_user(
+            server=server,
+            email=f"sess_y_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpassword",
+            first_name="SessY",
+            last_name="User",
+        )
+        x_sessions = server.get(
+            "/v1/session",
+            headers=self._get_appropriate_headers(user_x.jwt),
+        ).json().get("sessions", [])
+        if not x_sessions:
+            pytest.skip("user_x has no session to target")
+        target = x_sessions[0]["id"]
+
+        response = server.delete(
+            f"/v1/session/{target}",
+            headers=self._get_appropriate_headers(user_y.jwt),
+        )
+        assert response.status_code in (
+            403,
+            404,
+        ), f"user_y must not delete user_x's session; got {response.status_code}"
+
     def test_DELETE_204(self, server: Any, db: Any):
         """Test deleting a user with an isolated test user (does not use shared fixtures)."""
 
@@ -3285,3 +3612,115 @@ class TestInvitationEndpoints(AbstractEPTest):
                 invalid_data,
                 parent_ids_override,
             )
+
+    # ------------------------------------------------------------------
+    # Security: invitation explicit-deny / negative-path tests.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_PATCH_invitation_rejected_after_already_accepted(
+        self, server: Any, admin_a: Any, team_a: Any
+    ) -> None:
+        """An invitation code accepted once must not work again."""
+        from conftest import create_user
+
+        invitation = self._create_team_invitation_auto_code(server, admin_a, team_a)
+        endpoint = f"/v1/invitation/{invitation['id']}"
+        payload = {"invitation": {"invitation_code": invitation["code"]}}
+
+        first_user = create_user(server)
+        if first_user is None:
+            pytest.skip("Failed to create first user")
+        r1 = server.patch(
+            endpoint,
+            json=payload,
+            headers=self._get_appropriate_headers(first_user.jwt),
+        )
+        assert r1.status_code == 200, f"First accept must succeed; got {r1.status_code}"
+
+        # Second user tries the same code.
+        second_user = create_user(server)
+        if second_user is None:
+            pytest.skip("Failed to create second user")
+        r2 = server.patch(
+            endpoint,
+            json=payload,
+            headers=self._get_appropriate_headers(second_user.jwt),
+        )
+        assert r2.status_code in (
+            400,
+            403,
+            404,
+            409,
+            410,
+            422,
+        ), (
+            f"Re-using a single-use invitation code must reject; got {r2.status_code}. "
+            "If max_uses>1 this is expected; tighten the test once the framework "
+            "exposes single-use semantics."
+        )
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_PATCH_invitation_rejected_with_invalid_code(
+        self, server: Any, admin_a: Any, team_a: Any
+    ) -> None:
+        """A made-up invitation code must not authorize team membership."""
+        from conftest import create_user
+
+        invitation = self._create_team_invitation_auto_code(server, admin_a, team_a)
+        endpoint = f"/v1/invitation/{invitation['id']}"
+        payload = {"invitation": {"invitation_code": "AAAAAAAA"}}
+
+        new_user = create_user(server)
+        if new_user is None:
+            pytest.skip("Failed to create user")
+        response = server.patch(
+            endpoint,
+            json=payload,
+            headers=self._get_appropriate_headers(new_user.jwt),
+        )
+        assert response.status_code in (
+            400,
+            403,
+            404,
+            422,
+        ), (
+            f"Made-up invitation code must be rejected; got {response.status_code}"
+        )
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_PATCH_invitation_rejected_for_higher_role_than_inviter(
+        self, server: Any, admin_a: Any, team_a: Any
+    ) -> None:
+        """Invitation cannot grant a role above the inviter's authority.
+
+        EXPECTED FAIL today — no explicit role-hierarchy validation visible in
+        BLL_Auth.py invitation creation. Surfaces a privilege-escalation gap.
+        """
+        # admin_a is a team admin. Try to create an invitation that grants the
+        # platform-level ROOT_ID role (which admin_a does not hold).
+        root_role_id = env("ROOT_ID")
+        payload = {
+            "invitation": {
+                "code": uuid.uuid4().hex[:8].upper(),
+                "role_id": root_role_id,
+                "max_uses": 1,
+            }
+        }
+        endpoint = f"/v1/team/{team_a.id}/invitation"
+        response = server.post(
+            endpoint,
+            json=payload,
+            headers=self._get_appropriate_headers(admin_a.jwt),
+        )
+        assert response.status_code in (
+            400,
+            403,
+            422,
+        ), (
+            f"Inviting to a role above the inviter's role must be rejected; "
+            f"got {response.status_code}: {response.text[:200]}"
+        )

--- a/src/extensions/AbstractExtensionProvider_test.py
+++ b/src/extensions/AbstractExtensionProvider_test.py
@@ -1370,3 +1370,60 @@ class TestExtensionRegistryMethods:
         assert len(names) == 2
         assert "test_extension" in names
         assert "test_system_component" in names
+
+
+# ----------------------------------------------------------------------
+# Security: extension-load explicit-deny tests.
+#
+# A sloppy or malicious operator who sets APP_EXTENSIONS to a path or
+# a name that resolves outside extensions/ must NOT be able to import
+# arbitrary modules. These tests assert the loader rejects such inputs
+# rather than silently following them.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestExtensionLoadDeniesPathTraversal:
+    """The extension loader must reject names that resolve outside extensions/."""
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "../../../etc/passwd",
+            "..\\..\\windows\\system32",
+            "/absolute/path/extension",
+            "extension; rm -rf /",
+            "extension\x00null_byte",
+            "extension/../../../etc",
+        ],
+    )
+    def test_register_extension_rejects_unsafe_name(self, bad_name):
+        """Names containing path-traversal markers must raise, not import."""
+        registry = ExtensionRegistry("")
+
+        class BadExtension(AbstractStaticExtension):
+            name = bad_name
+            description = "should never load"
+
+        with pytest.raises(Exception):
+            registry.register_extension(BadExtension)
+
+
+@pytest.mark.security
+class TestExtensionRegistryDeniesOverride:
+    """Registering two extensions with the same name must not silently win."""
+
+    def test_duplicate_extension_name_rejected(self):
+        registry = ExtensionRegistry("")
+
+        class Ext1(AbstractStaticExtension):
+            name = "duplicate_name_test"
+            description = "first"
+
+        class Ext2(AbstractStaticExtension):
+            name = "duplicate_name_test"
+            description = "second"
+
+        registry.register_extension(Ext1)
+        with pytest.raises(Exception):
+            registry.register_extension(Ext2)

--- a/src/extensions/auth_mfa/BLL_Auth_MFA_test.py
+++ b/src/extensions/auth_mfa/BLL_Auth_MFA_test.py
@@ -304,3 +304,113 @@ class TestMultifactorRecoveryCodeManager(AbstractBLLTest, ExtensionServerMixin):
 
         assert len(recovery_codes) == 2
         assert all(not rc.is_used for rc in recovery_codes)
+
+    # ------------------------------------------------------------------
+    # Security: explicit-deny / negative-path MFA tests.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.security
+    @pytest.mark.mfa
+    def test_recovery_code_one_time_use(self, admin_a, model_registry):
+        """A recovery code accepted once must be rejected on replay."""
+        mfa_manager = MultifactorMethodManager(
+            requester_id=admin_a.id, model_registry=model_registry
+        )
+        mfa_method = mfa_manager.create(
+            user_id=admin_a.id,
+            method_type=MultifactorMethodType.TOTP,
+        )
+        rec_manager = MultifactorRecoveryCodeManager(
+            requester_id=admin_a.id, model_registry=model_registry
+        )
+        codes = rec_manager.generate_recovery_codes(mfa_method.id, count=2)
+        # `generate_recovery_codes` returns the cleartext codes once.
+        first_code = codes[0] if isinstance(codes, list) else None
+        if first_code is None:
+            pytest.skip("Recovery-code generator did not return cleartext codes")
+
+        # First use must succeed.
+        assert rec_manager.verify_recovery_code(mfa_method.id, first_code) is True
+
+        # Replay must fail.
+        replay = rec_manager.verify_recovery_code(mfa_method.id, first_code)
+        assert replay is False, (
+            "Recovery code accepted on replay; one-time-use flag is not "
+            "enforced by MultifactorRecoveryCodeManager.verify_recovery_code."
+        )
+
+    @pytest.mark.security
+    @pytest.mark.mfa
+    def test_recovery_code_high_entropy(self, admin_a, model_registry):
+        """Recovery codes must be high-entropy and unique across a sample."""
+        mfa_manager = MultifactorMethodManager(
+            requester_id=admin_a.id, model_registry=model_registry
+        )
+        mfa_method = mfa_manager.create(
+            user_id=admin_a.id,
+            method_type=MultifactorMethodType.TOTP,
+        )
+        rec_manager = MultifactorRecoveryCodeManager(
+            requester_id=admin_a.id, model_registry=model_registry
+        )
+        seen = set()
+        for _ in range(20):
+            batch = rec_manager.generate_recovery_codes(mfa_method.id, count=5)
+            if not isinstance(batch, list):
+                pytest.skip("Recovery-code generator did not return cleartext codes")
+            for code in batch:
+                assert code not in seen, "Duplicate recovery code in 100-sample batch"
+                assert len(code) >= 10, f"Recovery code too short: {len(code)}"
+                seen.add(code)
+
+    @pytest.mark.security
+    @pytest.mark.mfa
+    def test_totp_replay_rejected(self, admin_a, model_registry):
+        """A valid TOTP code must NOT verify a second time within the same window.
+
+        EXPECTED FAIL today — pyotp.TOTP.verify() does not track used codes,
+        and BLL_Auth_MFA.py:328 has no per-(method, code) replay table.
+        """
+        import pyotp
+
+        mfa_manager = MultifactorMethodManager(
+            requester_id=admin_a.id, model_registry=model_registry
+        )
+        mfa_method = mfa_manager.create(
+            user_id=admin_a.id,
+            method_type=MultifactorMethodType.TOTP,
+        )
+        secret = mfa_method.totp_secret
+        code = pyotp.TOTP(secret).now()
+
+        first = mfa_manager.verify_totp_code(secret, code)
+        replay = mfa_manager.verify_totp_code(secret, code)
+        assert first is True, "First TOTP verification must succeed"
+        assert replay is False, (
+            "TOTP code accepted on replay within the same window. "
+            "BLL_Auth_MFA.py needs a per-(method, time-step) used-codes table."
+        )
+
+    @pytest.mark.security
+    @pytest.mark.mfa
+    def test_totp_rejects_far_future_code(self, admin_a, model_registry):
+        """A TOTP code from far outside the valid window must be rejected."""
+        import pyotp
+        import time
+
+        mfa_manager = MultifactorMethodManager(
+            requester_id=admin_a.id, model_registry=model_registry
+        )
+        mfa_method = mfa_manager.create(
+            user_id=admin_a.id,
+            method_type=MultifactorMethodType.TOTP,
+        )
+        secret = mfa_method.totp_secret
+
+        # Generate a code 5 minutes in the future.
+        future_code = pyotp.TOTP(secret).at(int(time.time()) + 300)
+        accepted = mfa_manager.verify_totp_code(secret, future_code)
+        assert accepted is False, (
+            "TOTP code from 5 minutes in the future was accepted; "
+            "valid_window=1 (30s drift) should reject it."
+        )

--- a/src/extensions/email/PRV_SendGrid_EMail_test.py
+++ b/src/extensions/email/PRV_SendGrid_EMail_test.py
@@ -349,3 +349,61 @@ class TestSendgridProvider(AbstractPRVTest):
         assert getattr(SendGrid_ContactModel, "_is_extension_model", False)
         assert getattr(SendGrid_TemplateModel, "_is_extension_model", False)
         assert getattr(SendGrid_CampaignModel, "_is_extension_model", False)
+
+    # ------------------------------------------------------------------
+    # Security: explicit-deny tests for email header injection.
+    # A sloppy caller passes user-controlled input as `subject` or
+    # `recipient`; the framework must reject CRLF sequences before
+    # they can graft additional headers (Bcc:, Reply-To:, ...).
+    # EXPECTED FAIL today — no validation visible in send_email.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_send_email_rejects_crlf_in_subject(self, provider_instance):
+        """A subject containing CRLF must NOT reach the SendGrid client."""
+        from extensions.email.PRV_SendGrid_EMail import SendgridProvider
+
+        crlf_subject = "Hello\r\nBcc: attacker@evil.example.com"
+        result = await SendgridProvider.send_email(
+            provider_instance,
+            recipient="user@example.com",
+            subject=crlf_subject,
+            body="<p>safe</p>",
+        )
+        # The framework must either raise or return an error string. It
+        # MUST NOT silently call out with the malicious subject.
+        assert isinstance(result, str)
+        assert (
+            "error" in result.lower()
+            or "invalid" in result.lower()
+            or "crlf" in result.lower()
+            or "header" in result.lower()
+        ), (
+            f"send_email accepted CRLF in subject (returned {result!r}); "
+            "SendgridProvider must reject newlines in subject/recipient."
+        )
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_send_email_rejects_crlf_in_recipient(self, provider_instance):
+        """A recipient containing CRLF must be rejected."""
+        from extensions.email.PRV_SendGrid_EMail import SendgridProvider
+
+        crlf_recipient = "victim@example.com\r\nBcc: attacker@evil.example.com"
+        result = await SendgridProvider.send_email(
+            provider_instance,
+            recipient=crlf_recipient,
+            subject="hi",
+            body="<p>safe</p>",
+        )
+        assert isinstance(result, str)
+        assert (
+            "error" in result.lower()
+            or "invalid" in result.lower()
+            or "crlf" in result.lower()
+            or "address" in result.lower()
+        ), (
+            f"send_email accepted CRLF in recipient (returned {result!r}); "
+            "SendgridProvider must reject newlines in recipient."
+        )

--- a/src/extensions/payment/PRV_Stripe_Payment_test.py
+++ b/src/extensions/payment/PRV_Stripe_Payment_test.py
@@ -342,3 +342,56 @@ class TestStripeProvider:
             assert default_currency == env("STRIPE_CURRENCY")
         else:
             assert default_currency == "USD"  # Default fallback
+
+    # ------------------------------------------------------------------
+    # Security: webhook explicit-deny tests.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_process_webhook_rejects_tampered_body(self, provider_instance):
+        """A body altered after signing must be rejected."""
+        original = b'{"id": "evt_1", "type": "payment_intent.succeeded"}'
+        tampered = b'{"id": "evt_1", "type": "payment_intent.refunded"}'
+        # We don't have a valid signature for either, so use a syntactically
+        # plausible-but-wrong sig to confirm the verify path engages.
+        bogus_sig = "t=1700000000,v1=" + ("00" * 32)
+        try:
+            result = await PaymentExtensionStripeProvider.process_webhook(
+                provider_instance, tampered, bogus_sig
+            )
+            assert isinstance(result, dict)
+            assert (
+                "error" in result or not result.get("success", True)
+            ), "Tampered body must surface as error"
+        except Exception as e:
+            err = str(e).lower()
+            assert any(
+                t in err for t in ("signature", "webhook", "invalid", "verify")
+            ), f"Tampered body raised unexpected error: {e}"
+
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_process_webhook_rejects_old_timestamp(self, provider_instance):
+        """A signature whose `t=` is far in the past must be rejected (replay).
+
+        EXPECTED FAIL today if the provider doesn't enforce a max
+        timestamp tolerance.
+        """
+        body = b'{"id": "evt_old", "type": "payment_intent.succeeded"}'
+        old_ts = "1000000000"  # 2001 — definitely older than any tolerance
+        old_sig = f"t={old_ts},v1=" + ("00" * 32)
+        try:
+            result = await PaymentExtensionStripeProvider.process_webhook(
+                provider_instance, body, old_sig
+            )
+            assert isinstance(result, dict)
+            assert (
+                "error" in result or not result.get("success", True)
+            ), "Old-timestamp webhook must be rejected"
+        except Exception as e:
+            err = str(e).lower()
+            assert any(
+                t in err
+                for t in ("timestamp", "tolerance", "stale", "signature")
+            ), f"Old timestamp raised unexpected error: {e}"

--- a/src/lib/Environment_test.py
+++ b/src/lib/Environment_test.py
@@ -300,5 +300,58 @@ class TestEnvironmentIntegration(TestMixin):
             self.assertEqual(test_settings.APP_NAME, "Server")  # Default value
 
 
+# ----------------------------------------------------------------------
+# Security: explicit-deny / negative-path tests for production defaults.
+# These assert that obviously-insecure defaults are not silently
+# accepted when the runtime is `ENVIRONMENT=production`.
+# Most are EXPECTED FAIL today — surfacing the gap is the point.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestProductionDefaultsAreFailClosed(TestMixin):
+    """A production deployment must refuse insecure defaults at start-up."""
+
+    def test_root_api_key_default_rejected_in_production(
+        self, clean_environment, monkeypatch
+    ):
+        """ROOT_API_KEY="n0ne" in production must fail validation.
+
+        EXPECTED FAIL today — Environment.py:40 default is the literal
+        string "n0ne" and there is no production-mode guard.
+        """
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("ROOT_API_KEY", "n0ne")
+        with pytest.raises(Exception):
+            AppSettings.model_validate(os.environ)
+
+    def test_jwt_secret_required_in_production(
+        self, clean_environment, monkeypatch
+    ):
+        """JWT_SECRET unset/empty in production must fail validation.
+
+        EXPECTED FAIL today — JWT_SECRET has no production-mode guard.
+        """
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("JWT_SECRET", "")
+        with pytest.raises(Exception):
+            AppSettings.model_validate(os.environ)
+
+    def test_allowed_domains_wildcard_rejected_in_production(
+        self, clean_environment, monkeypatch
+    ):
+        """ALLOWED_DOMAINS="*" combined with credentials must fail in production.
+
+        EXPECTED FAIL today — Environment.py:42 default is "*" and there is
+        no production-mode guard. With CORS allow_credentials=True (app.py:456)
+        the browser CORS spec rejects `*` anyway, but the framework should
+        explicitly fail-closed instead of relying on browser behaviour.
+        """
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("ALLOWED_DOMAINS", "*")
+        with pytest.raises(Exception):
+            AppSettings.model_validate(os.environ)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/src/lib/Logging_test.py
+++ b/src/lib/Logging_test.py
@@ -1,0 +1,100 @@
+"""Security tests for the logging subsystem.
+
+These tests assert that the framework's logger redacts known-sensitive
+keyword arguments and structured-log fields. A sloppy extension author who
+calls ``logger.info("user logged in", password=password)`` should not leak
+the password to stdout — the framework must scrub it.
+
+Most of these tests are EXPECTED FAIL today: ``src/lib/Logging.py`` does
+not install any redaction filter (see file contents — only a single
+``logger.add(sys.stdout, level=log_level, filter=format_with_timezone)``).
+Surfacing these failures is the audit's intent.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+from loguru import logger as loguru_logger
+
+from lib.Logging import logger
+
+
+SENSITIVE_KEYS = (
+    "password",
+    "current_password",
+    "new_password",
+    "token",
+    "jwt",
+    "api_key",
+    "secret",
+    "client_secret",
+    "refresh_token",
+    "authorization",
+)
+
+
+@pytest.fixture
+def captured_log_output():
+    """Attach a temporary loguru sink to capture log records, then detach.
+
+    Yields the StringIO buffer; tests read ``buffer.getvalue()``.
+    """
+    buffer = io.StringIO()
+    sink_id = loguru_logger.add(buffer, level="DEBUG", format="{message} | {extra}")
+    try:
+        yield buffer
+    finally:
+        loguru_logger.remove(sink_id)
+
+
+@pytest.mark.security
+@pytest.mark.parametrize("key", SENSITIVE_KEYS)
+def test_log_redacts_sensitive_kwarg(captured_log_output, key):
+    """``logger.info(..., <sensitive>=<value>)`` must NOT contain the value.
+
+    EXPECTED FAIL today — no redaction filter is installed in lib/Logging.py.
+    Surfaces the gap.
+    """
+    canary = "CANARY-VALUE-THAT-MUST-NEVER-APPEAR-IN-LOGS"
+    # Bind the sensitive kwarg via loguru's structured-extra mechanism.
+    logger.bind(**{key: canary}).info(f"event with sensitive {key}")
+
+    output = captured_log_output.getvalue()
+    assert canary not in output, (
+        f"Logger leaked sensitive value bound to '{key}': "
+        f"value {canary!r} appeared in log output. "
+        "lib/Logging.py needs a redaction filter for sensitive kwargs."
+    )
+
+
+@pytest.mark.security
+def test_log_redacts_authorization_header_in_request_dump(captured_log_output):
+    """A request object's Authorization header must not appear in logs."""
+    bearer = "Bearer secret-token-CANARY-12345"
+    logger.bind(headers={"Authorization": bearer}).info("incoming request")
+
+    output = captured_log_output.getvalue()
+    assert "secret-token-CANARY-12345" not in output, (
+        "Authorization-header value leaked into logs. "
+        "lib/Logging.py needs a request-header sanitizer."
+    )
+
+
+@pytest.mark.security
+def test_log_redacts_password_in_message_string(captured_log_output):
+    """A password embedded in the log message body must be scrubbed.
+
+    Catches the case where a developer interpolates a password directly
+    into the log string instead of passing it as a kwarg.
+    """
+    canary = "literal-password-CANARY-67890"
+    logger.info(f"login attempt with password={canary}")
+
+    output = captured_log_output.getvalue()
+    assert canary not in output, (
+        "Logger emitted a literal password embedded in message text. "
+        "lib/Logging.py needs a regex-based scrubber for inline secrets."
+    )

--- a/src/lib/Pydantic2FastAPI_test.py
+++ b/src/lib/Pydantic2FastAPI_test.py
@@ -1279,3 +1279,121 @@ def test_encode_query_values_trims_and_deduplicates():
         == "team.members"
     )
     assert AbstractEPTest._serialize_query_values(None) is None
+
+
+# ----------------------------------------------------------------------
+# Security: framework-invariant tests for the auto-generated REST surface.
+#
+# The "sloppy extension developer" axis. A vanilla BLL manager with no
+# special config must produce endpoints that are deny-by-default, with
+# no audit-field writability and no secret-column response leakage.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.security
+class TestAutoGenerationInvariants:
+    """Invariants the framework must enforce regardless of extension code."""
+
+    # The model_registry session-scoped fixture from src/conftest.py provides
+    # the live registry already populated by all loaded extensions.
+
+    AUDIT_FIELDS_BANNED_ON_INPUT = (
+        "id",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "created_by_user_id",
+        "updated_by_user_id",
+        "deleted_by_user_id",
+    )
+
+    SECRET_FIELDS_BANNED_ON_OUTPUT = (
+        "password_hash",
+        "secret",
+        "api_key_hash",
+        "recovery_answer_hash",
+        "answer_hash",
+        "jwt_secret",
+        "client_secret",
+    )
+
+    def test_create_schemas_strip_audit_fields(self, model_registry):
+        """A `Create` Network model must not expose audit fields as writable.
+
+        EXPECTED FAIL on any model whose `.Create` schema includes audit
+        fields — that is the gap surfaced by this test.
+        """
+        violations: List[str] = []
+        for model_name, registered in model_registry.models.items():
+            create_cls = getattr(registered, "Create", None)
+            if create_cls is None or not hasattr(create_cls, "model_fields"):
+                continue
+            for banned in self.AUDIT_FIELDS_BANNED_ON_INPUT:
+                if banned in create_cls.model_fields:
+                    violations.append(f"{model_name}.Create exposes '{banned}'")
+
+        assert not violations, (
+            "Auto-generated Create schemas must not expose audit fields. "
+            f"Violations:\n  - " + "\n  - ".join(violations)
+        )
+
+    def test_update_schemas_strip_audit_fields(self, model_registry):
+        """An `Update` Network model must not expose audit fields as writable."""
+        violations: List[str] = []
+        for model_name, registered in model_registry.models.items():
+            update_cls = getattr(registered, "Update", None)
+            if update_cls is None or not hasattr(update_cls, "model_fields"):
+                continue
+            for banned in self.AUDIT_FIELDS_BANNED_ON_INPUT:
+                if banned in update_cls.model_fields:
+                    violations.append(f"{model_name}.Update exposes '{banned}'")
+
+        assert not violations, (
+            "Auto-generated Update schemas must not expose audit fields. "
+            f"Violations:\n  - " + "\n  - ".join(violations)
+        )
+
+    def test_response_schemas_omit_secret_fields(self, model_registry):
+        """Response/Network models must never expose secret-name columns.
+
+        Catches a sloppy DB model that defines `password_hash` etc. without
+        also stripping it from the auto-generated Network model.
+        """
+        violations: List[str] = []
+        for model_name, registered in model_registry.models.items():
+            for response_attr in ("Response", "Network"):
+                response_cls = getattr(registered, response_attr, None)
+                if response_cls is None or not hasattr(
+                    response_cls, "model_fields"
+                ):
+                    continue
+                for banned in self.SECRET_FIELDS_BANNED_ON_OUTPUT:
+                    if banned in response_cls.model_fields:
+                        violations.append(
+                            f"{model_name}.{response_attr} exposes "
+                            f"secret field '{banned}'"
+                        )
+
+        assert not violations, (
+            "Auto-generated Response/Network models must not expose secret "
+            "columns. Violations:\n  - " + "\n  - ".join(violations)
+        )
+
+    def test_x_forwarded_for_not_trusted_without_proxy_config(self, server):
+        """Untrusted X-Forwarded-For must not be accepted as the client IP.
+
+        EXPECTED FAIL today — Pydantic2FastAPI.py:3048 reads X-Forwarded-For
+        unconditionally and prefers it over `request.client.host`. The
+        framework should require a `TRUSTED_PROXIES` allowlist before
+        honouring the header.
+        """
+        # The contract being tested is "the framework refuses to honour
+        # untrusted XFF". In the absence of a trusted-proxy config knob, this
+        # test asserts the env-var exists and is enforced.
+        from lib.Environment import AppSettings
+
+        assert hasattr(AppSettings, "TRUSTED_PROXIES"), (
+            "AppSettings must define TRUSTED_PROXIES so X-Forwarded-For can be "
+            "validated. Currently missing — Pydantic2FastAPI.py:3048 trusts "
+            "the header unconditionally."
+        )

--- a/src/lib/Pydantic2SQLAlchemy_test.py
+++ b/src/lib/Pydantic2SQLAlchemy_test.py
@@ -554,5 +554,68 @@ class TestPydantic2SQLAlchemyReal(unittest.TestCase):
         self.assertIn("Team", team_column.comment)
 
 
+# ----------------------------------------------------------------------
+# Security: filter / sort safety.
+#
+# These exercise AbstractLogicManager search/sort plumbing that ultimately
+# emits SQL via SQLAlchemy. The aim is to prove user-controlled values
+# never escape parameterization and unknown columns are rejected.
+# ----------------------------------------------------------------------
+
+import pytest
+
+
+@pytest.mark.security
+@pytest.mark.db
+class TestSearchInputDeniesInjection:
+    """Negative-path tests for filter/sort handling on list endpoints."""
+
+    def test_sort_order_rejects_arbitrary_string(self, server, admin_a, team_a):
+        """`?sort_order=asc; DROP TABLE users--` must be rejected (422)."""
+        response = server.get(
+            "/v1/team?sort_by=name&sort_order=asc;DROP TABLE users--",
+            headers={"Authorization": f"Bearer {admin_a.jwt}"},
+        )
+        assert response.status_code == 422, (
+            f"Bogus sort_order must be rejected (422); got "
+            f"{response.status_code}: {response.text[:200]}"
+        )
+
+    def test_sort_by_rejects_unknown_column(self, server, admin_a):
+        """`?sort_by=password_hash` must be rejected (422)."""
+        response = server.get(
+            "/v1/team?sort_by=password_hash&sort_order=asc",
+            headers={"Authorization": f"Bearer {admin_a.jwt}"},
+        )
+        # Either rejects (422) or silently ignores (200). Reject is preferred.
+        assert response.status_code in (200, 422), (
+            f"sort_by=password_hash must be 422 or silently ignored 200; "
+            f"got {response.status_code}"
+        )
+
+    def test_filter_value_with_quote_does_not_break_query(
+        self, server, admin_a
+    ):
+        """Filter value containing SQL syntax must be parameterized, not interpolated.
+
+        If parameterization is broken, the request 500s; success is either
+        200 (literal match, no rows) or 422 (rejection).
+        """
+        payload = "'; DROP TABLE teams; --"
+        response = server.get(
+            f"/v1/team?name={payload}",
+            headers={"Authorization": f"Bearer {admin_a.jwt}"},
+        )
+        assert response.status_code != 500, (
+            f"SQL-syntax filter value crashed the query (500). Filter "
+            f"parameterization may be broken. Body: {response.text[:200]}"
+        )
+        assert response.status_code in (
+            200,
+            400,
+            422,
+        ), f"Unexpected status {response.status_code}"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/lib/Pydantic2Strawberry_test.py
+++ b/src/lib/Pydantic2Strawberry_test.py
@@ -712,3 +712,102 @@ class TestEnumHandling(AbstractPydanticTestMixin):
         finally:
             # Restore original behavior
             TestEnumWithIssue.__iter__ = original_iter
+
+
+# ----------------------------------------------------------------------
+# Security: explicit-deny / negative-path GraphQL tests.
+#
+# These run against the live `server` fixture so they exercise the actual
+# Strawberry schema, not a hand-rolled mock.  Most are EXPECTED FAIL today
+# because Pydantic2Strawberry.py:250 builds the schema with no depth or
+# introspection limits.  Surfacing the gaps is the point.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.security
+@pytest.mark.gql
+class TestGraphQLDenyPaths:
+    """Negative-path tests for the auto-generated Strawberry schema."""
+
+    GQL_PATH = "/graphql"
+
+    def _post(self, server, body, headers=None):
+        return server.post(
+            self.GQL_PATH, json={"query": body}, headers=headers or {}
+        )
+
+    def test_unauthenticated_query_rejected(self, server):
+        """A query without an Authorization header must not leak data."""
+        # `users` is a representative team-scoped collection; any team-scoped
+        # type works.
+        response = self._post(server, "{ users { id email } }")
+        # GraphQL conventionally returns 200 with `errors`. Accept either.
+        if response.status_code == 200:
+            body = response.json()
+            assert "errors" in body or body.get("data") in (None, {}), (
+                "Unauthenticated GraphQL query must not return data"
+            )
+        else:
+            assert response.status_code in (
+                401,
+                403,
+            ), f"Got {response.status_code}"
+
+    def test_introspection_disabled_in_production(self, server, monkeypatch):
+        """`__schema` introspection must be disabled when ENVIRONMENT=production.
+
+        EXPECTED FAIL today — Pydantic2Strawberry.py builds the schema with
+        introspection always on.
+        """
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        response = self._post(server, "{ __schema { types { name } } }")
+        if response.status_code == 200:
+            body = response.json()
+            # If data is non-empty, introspection succeeded — fail.
+            data = body.get("data") or {}
+            assert (
+                "__schema" not in data
+            ), "GraphQL introspection must be disabled in production"
+
+    def test_query_depth_limit_enforced(self, server, admin_a):
+        """A maliciously-deep query must be rejected, not OOM the server.
+
+        EXPECTED FAIL today — no depth/complexity limit is configured.
+        """
+        # Build a 30-level nested query.  ``users { teams { users { ... } } }``
+        depth = 30
+        nested = "id"
+        for _ in range(depth):
+            nested = f"users {{ teams {{ {nested} }} }}"
+        body = "{ " + nested + " }"
+        response = self._post(
+            server,
+            body,
+            headers={"Authorization": f"Bearer {admin_a.jwt}"},
+        )
+        if response.status_code == 200:
+            data = response.json()
+            assert "errors" in data, (
+                f"30-level nested query must be rejected by depth-limit; "
+                f"got data={data.get('data') is not None}"
+            )
+
+    def test_secret_field_not_queryable(self, server, admin_a):
+        """A field named `password_hash` (or similar) must not be queryable."""
+        response = self._post(
+            server,
+            "{ user(id: \"%s\") { id passwordHash } }" % admin_a.id,
+            headers={"Authorization": f"Bearer {admin_a.jwt}"},
+        )
+        # Either schema rejects the field outright (errors) or returns null.
+        if response.status_code == 200:
+            data = response.json()
+            errors = data.get("errors") or []
+            field_unknown = any(
+                "passwordHash" in (e.get("message") or "") for e in errors
+            )
+            user_blob = (data.get("data") or {}).get("user") or {}
+            assert field_unknown or user_blob.get("passwordHash") in (
+                None,
+                "",
+            ), "GraphQL response must not surface password_hash"

--- a/src/logic/BLL_Auth_test.py
+++ b/src/logic/BLL_Auth_test.py
@@ -284,6 +284,103 @@ class TestUserManager(AbstractBLLTest):
         # TODO we also need these tests in registration EP tests
         # TODO we also need these tests in invitation acceptance EP tests
 
+    # ------------------------------------------------------------------
+    # Security: BLL-layer explicit-deny tests for UserManager.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_soft_deleted_user_cannot_login(self, admin_a, server, model_registry):
+        """A user whose `deleted_at` is set must not be able to authenticate."""
+        from logic.BLL_Auth import UserModel
+
+        email = f"softdel_{uuid.uuid4().hex[:8]}@example.com"
+        password = "Test1234!"
+        UserManager.register(
+            {
+                "email": email,
+                "password": password,
+                "first_name": "SoftDel",
+                "last_name": "User",
+            },
+            model_registry,
+        )
+
+        # Soft-delete the user directly on the DB.
+        with model_registry.database_manager.get_session() as db:
+            UserDB = UserModel.DB(model_registry.database_manager.Base)
+            user_row = db.query(UserDB).filter(UserDB.email == email).first()
+            assert user_row is not None
+            user_row.deleted_at = datetime.now(timezone.utc)
+            db.commit()
+
+        # Attempt to login should fail.
+        response = server.post(
+            "/v1/user/authorize",
+            json={"email": email, "password": password},
+        )
+        assert response.status_code in (401, 403, 404), (
+            f"Soft-deleted user must not authenticate; got {response.status_code}"
+        )
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_inactive_user_cannot_login(self, server, model_registry):
+        """A user whose `active=False` must not authenticate."""
+        from logic.BLL_Auth import UserModel
+
+        email = f"inactive_{uuid.uuid4().hex[:8]}@example.com"
+        password = "Test1234!"
+        UserManager.register(
+            {
+                "email": email,
+                "password": password,
+                "first_name": "Inactive",
+                "last_name": "User",
+            },
+            model_registry,
+        )
+        with model_registry.database_manager.get_session() as db:
+            UserDB = UserModel.DB(model_registry.database_manager.Base)
+            user_row = db.query(UserDB).filter(UserDB.email == email).first()
+            assert user_row is not None
+            user_row.active = False
+            db.commit()
+
+        response = server.post(
+            "/v1/user/authorize",
+            json={"email": email, "password": password},
+        )
+        assert response.status_code in (401, 403), (
+            f"Inactive user must not authenticate; got {response.status_code}"
+        )
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_register_ignores_caller_supplied_id(self, model_registry):
+        """`register` must not honour a client-supplied `id`; server assigns it."""
+        attacker_uuid = str(uuid.uuid4())
+        user_data = {
+            "id": attacker_uuid,
+            "email": f"id_spoof_{uuid.uuid4().hex[:8]}@example.com",
+            "password": "Test1234!",
+            "first_name": "Spoof",
+            "last_name": "Test",
+        }
+        result = UserManager.register(user_data, model_registry)
+        # The server MUST issue a new id, not honour the caller-supplied one.
+        if isinstance(result, dict):
+            assigned_id = result.get("id") or (
+                result.get("user", {}) or {}
+            ).get("id")
+        else:
+            assigned_id = getattr(result, "id", None)
+        assert assigned_id, "register must return an id"
+        assert assigned_id != attacker_uuid, (
+            "Mass-assignment: register honoured client-supplied id "
+            "(audit-field invariant violated)"
+        )
+
 
 class TestTeamManager(AbstractBLLTest):
     class_under_test = TeamManager
@@ -654,6 +751,66 @@ class TestSessionManager(AbstractBLLTest):
             f"Entity not found when searching {search_field} with operator '{search_operator}' "
             f"and value '{search_value}' (type: {type(search_value).__name__}). Found {len(results)} results."
         )
+
+    # ------------------------------------------------------------------
+    # Security: BLL-layer explicit-deny tests for SessionManager.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_session_key_is_high_entropy(self, admin_a, team_a, model_registry):
+        """Generated session_key must be unguessable: 1k samples must all be unique."""
+        manager = self.class_under_test(
+            requester_id=admin_a.id,
+            target_team_id=team_a.id,
+            model_registry=model_registry,
+        )
+        keys = set()
+        for _ in range(1000):
+            session = manager.create(
+                user_id=admin_a.id,
+                session_key=f"session_{uuid.uuid4().hex}",
+                jwt_issued_at=datetime.now(timezone.utc),
+                last_activity=datetime.now(timezone.utc),
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+            )
+            sk = getattr(session, "session_key", None) or session["session_key"]
+            assert sk not in keys, "Duplicate session_key in 1000 samples"
+            assert len(sk) >= 16, f"session_key too short: {len(sk)} chars"
+            keys.add(sk)
+
+    @pytest.mark.security
+    @pytest.mark.auth
+    def test_user_cannot_revoke_other_users_session(
+        self, admin_a, admin_b, model_registry
+    ):
+        """admin_a must not be able to revoke admin_b's session."""
+        # Create a session owned by admin_b.
+        with SessionManager(
+            requester_id=admin_b.id, model_registry=model_registry
+        ) as mgr_b:
+            session_b = mgr_b.create(
+                user_id=admin_b.id,
+                session_key=f"cross_user_{uuid.uuid4().hex}",
+                jwt_issued_at=datetime.now(timezone.utc),
+                last_activity=datetime.now(timezone.utc),
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+            )
+            session_b_id = getattr(session_b, "id", None) or session_b["id"]
+
+        # admin_a tries to revoke it.
+        with SessionManager(
+            requester_id=admin_a.id, model_registry=model_registry
+        ) as mgr_a:
+            with pytest.raises(HTTPException) as exc_info:
+                mgr_a.delete(id=session_b_id)
+            assert exc_info.value.status_code in (
+                403,
+                404,
+            ), (
+                f"Cross-user session revoke must reject; got "
+                f"{exc_info.value.status_code}"
+            )
 
 
 class TestInvitationManager(AbstractBLLTest):


### PR DESCRIPTION
Audit added explicit-deny coverage for two axes that were under-tested:
external attacker (cross-tenant reads, JWT tampering, lockout, header
injection) and sloppy extension developer (auto-gen invariants, audit-
field stripping, secret-column response leakage, permission filter
defaults). Tests are tagged @pytest.mark.security so they can be run
selectively. Several are EXPECTED FAIL today and are intentional — they
surface real gaps for follow-up fixes (CORS wildcard+credentials, weak
ROOT_API_KEY default, no password strength, no global rate limit, JWT
not bound to session_key, TOTP replay, log redaction, X-Forwarded-For
trust, GraphQL introspection/depth limits, email CRLF injection).
The licensure-guard JWT wrapper is intentionally left untested per
explicit user direction.

https://claude.ai/code/session_011h9pjXwh7RhmKimcP3rm2p