### PR TITLE
Add abstract, parameterized scalability tests (Big-O n-factor assertions)

### DIFF
--- a/src/Framework.Test.md
+++ b/src/Framework.Test.md
@@ -170,6 +170,22 @@ Extension Test → Provider Test (inherits DB + server)
 - **Memory Testing**: Memory usage patterns and leak detection
 - **Concurrency Testing**: Multi-user scenario validation
 
+### Scalability Testing (Big-O assertion)
+
+`lib.Scalability` provides parameterized Big-O assertions consumed by all three layered abstract tests. Every `AbstractDBTest`, `AbstractBLLTest`, and `AbstractEPTest` subclass inherits a `test_scalability_*_n_factor` method parametrized over `{TIME, QUERY_COUNT, MEMORY}`. The test is skipped unless the subclass opts in via `scalability_profile`:
+
+```python
+from lib.Scalability import ScalabilityProfile, ScalingMetric
+
+class TestUserDB(AbstractDBTest):
+    scalability_profile = ScalabilityProfile.default(
+        n_values=[5, 15, 50],
+        metrics=[ScalingMetric.TIME, ScalingMetric.QUERY_COUNT],
+    )
+```
+
+The framework seeds N entities at each `n`, runs the operation under measurement, fits `T(n) = a·n^k` via log-log regression, and asserts `k` stays under the per-metric maximum. Defaults: `k ≤ 1.4` for time/memory, `k ≤ 0.4` for query count — calibrated so that N+1 query patterns (which produce `k ≈ 1`) trip the gate. See [lib/LIB.Scalability.md](lib/LIB.Scalability.md).
+
 ## Testing Tools and Framework
 
 ### Core Testing Stack

--- a/src/database/AbstractDBTest.py
+++ b/src/database/AbstractDBTest.py
@@ -11,6 +11,11 @@ from database.StaticPermissions import check_permission
 from lib.Environment import env
 from lib.Logging import logger
 from lib.Pydantic import obj_to_dict
+from lib.Scalability import (
+    ScalabilityProfile,
+    ScalingMetric,
+    assert_scaling_within_bounds,
+)
 
 # Database lock retries are now handled automatically by pytest hooks in conftest.py
 
@@ -1172,3 +1177,62 @@ class AbstractDBTest(AbstractTest):
         self._ORM_create(admin_a.id, team_a.id, "ORM_delete")
         self._ORM_delete(admin_a.id, team_a.id)
         self._delete_assert(admin_a.id, "ORM_delete")
+
+    # ------------------------------------------------------------------ #
+    # Scalability / Big-O assertions
+    # ------------------------------------------------------------------ #
+    # Subclasses opt in by setting `scalability_profile`. The list-scaling
+    # test seeds N entities at each step and asserts that
+    # sqlalchemy_model.list() scales within the configured Big-O bound for
+    # the chosen metric. Time/query/memory exponents are evaluated
+    # independently so the failure points to the regressing axis.
+
+    scalability_profile: Optional[ScalabilityProfile] = None
+
+    @pytest.mark.parametrize(
+        "metric",
+        sorted(
+            [ScalingMetric.TIME, ScalingMetric.QUERY_COUNT, ScalingMetric.MEMORY],
+            key=lambda m: m.value,
+        ),
+    )
+    def test_scalability_list_n_factor(
+        self, server, admin_a, team_a, metric: ScalingMetric
+    ):
+        """Big-O assertion: sqlalchemy_model.list() must stay within the
+        configured exponent for time, query count, and peak memory as the
+        underlying row count grows. Catches accidental N+1, O(n^2) joins,
+        and per-row materialization regressions."""
+        if self.scalability_profile is None:
+            pytest.skip("scalability_profile not configured on this test class")
+        if metric not in self.scalability_profile.metrics:
+            pytest.skip(f"metric {metric.value} not enabled in scalability_profile")
+
+        self.db = server.app.state.model_registry.database_manager.get_session()
+        self._server = server
+        self.model_registry = server.app.state.model_registry
+        self.ensure_model(server)
+
+        seeded = {"count": 0}
+
+        def setup(target_n: int) -> None:
+            while seeded["count"] < target_n:
+                self._CRUD_create(
+                    return_type="dict",
+                    user_id=admin_a.id,
+                    team_id=team_a.id,
+                    key=f"scalability_seed_{seeded['count']}",
+                )
+                seeded["count"] += 1
+
+        requester = env("SYSTEM_ID") if self.is_system_entity else admin_a.id
+
+        def operation(_n: int) -> None:
+            self.sqlalchemy_model.list(
+                requester, self.model_registry, return_type="dict"
+            )
+
+        engine = self.model_registry.database_manager.engine
+        assert_scaling_within_bounds(
+            operation, self.scalability_profile, metric, engine=engine, setup=setup
+        )

--- a/src/database/DB.Test.md
+++ b/src/database/DB.Test.md
@@ -46,6 +46,7 @@ parent_entities = [...]                # Parent entity dependencies
 - `test_CRUD_delete()` - Soft deletion with access control
 - `test_CRUD_soft_delete()` - Deleted entity accessibility for ROOT_ID
 - `test_ORM_*()` - Direct SQLAlchemy operations for comparison
+- `test_scalability_list_n_factor(metric)` - Big-O assertion (parametrized over `TIME`/`QUERY_COUNT`/`MEMORY`); skipped unless the subclass sets `scalability_profile`. Catches N+1 and super-linear regressions in `sqlalchemy_model.list()`. See [LIB.Scalability.md](../lib/LIB.Scalability.md).
 
 ### AbstractDatabaseEntity Testing (`AbstractDatabaseEntity_test.py`)
 Unit tests for the core database entity functionality:
@@ -192,6 +193,19 @@ class TestEntityName(AbstractDBTest):
         self._server = server  # Store server for access by helper methods
         self.ensure_model(server)  # Automatically determines sqlalchemy_model
 ```
+
+### Scalability Opt-In
+```python
+from lib.Scalability import ScalabilityProfile, ScalingMetric
+
+class TestEntityName(AbstractDBTest):
+    create_fields = {...}
+    scalability_profile = ScalabilityProfile.default(
+        n_values=[5, 15, 50],
+        metrics=[ScalingMetric.TIME, ScalingMetric.QUERY_COUNT],
+    )
+```
+The inherited `test_scalability_list_n_factor` seeds N entities at each step and asserts `sqlalchemy_model.list()` stays within the per-metric Big-O bound. Defaults: `k ≤ 1.4` for time/memory, `k ≤ 0.4` for query count (catches N+1).
 
 ### Parent Entity Pattern
 ```python

--- a/src/database/DB_Auth_test.py
+++ b/src/database/DB_Auth_test.py
@@ -9,6 +9,7 @@ from faker import Faker
 from AbstractTest import ParentEntity
 from database.AbstractDBTest import AbstractDBTest
 from lib.Environment import env
+from lib.Scalability import ScalabilityProfile, ScalingMetric
 
 # Import BLL models which will be converted to SQLAlchemy models via .DB()
 from logic.BLL_Auth import (
@@ -295,6 +296,11 @@ class TestTeam(AbstractDBTest):
         "description": "Updated TeamModel description",
     }
     unique_fields = ["name"]
+    scalability_profile = ScalabilityProfile.default(
+        n_values=[3, 8, 20],
+        metrics=[ScalingMetric.TIME, ScalingMetric.QUERY_COUNT, ScalingMetric.MEMORY],
+        repetitions=2,
+    )
 
 
 class TestMetadataUserOnly(AbstractDBTest):

--- a/src/endpoints/AbstractEPTest.py
+++ b/src/endpoints/AbstractEPTest.py
@@ -30,6 +30,11 @@ from endpoints.AbstractGQLTest import AbstractGraphQLTest
 from lib.Environment import env, inflection
 from lib.Logging import logger
 from lib.Pydantic import PydanticUtility
+from lib.Scalability import (
+    ScalabilityProfile,
+    ScalingMetric,
+    assert_scaling_within_bounds,
+)
 from logic.AbstractBLLTest import AbstractBLLTest
 
 # Using shared inflection instance from Environment
@@ -4424,3 +4429,62 @@ class AbstractEPTest(AbstractTest, AbstractGraphQLTest):
         """Get the endpoint for entity deletion."""
         base = self._build_endpoint(self._get_nesting_level("DETAIL"), parent_ids)
         return f"{base}/{resource_id}"
+
+    # ------------------------------------------------------------------ #
+    # Scalability / Big-O assertions
+    # ------------------------------------------------------------------ #
+    # Subclasses opt in by setting `scalability_profile`. Asserts that the
+    # GET-list endpoint scales within the configured exponent for time,
+    # query count, and peak memory as the underlying entity count grows.
+    # Catches regressions like: list endpoints that materialise full
+    # objects per row, serializers with O(n^2) field walks, or include=
+    # resolvers that fan out one upstream call per item.
+
+    scalability_profile: Optional[ScalabilityProfile] = None
+
+    @pytest.mark.parametrize(
+        "metric",
+        sorted(
+            [ScalingMetric.TIME, ScalingMetric.QUERY_COUNT, ScalingMetric.MEMORY],
+            key=lambda m: m.value,
+        ),
+    )
+    def test_scalability_GET_list_n_factor(
+        self, server: Any, admin_a: Any, team_a: Any, metric: ScalingMetric
+    ):
+        """Big-O assertion: GET /<base_endpoint> must stay within the
+        configured exponent across the request/response stack as row count
+        grows. Time covers handler + serialization, query count covers DB
+        access pattern (N+1 detector), memory covers payload growth."""
+        if self.scalability_profile is None:
+            pytest.skip("scalability_profile not configured on this test class")
+        if metric not in self.scalability_profile.metrics:
+            pytest.skip(f"metric {metric.value} not enabled in scalability_profile")
+
+        seeded = {"count": 0}
+
+        def setup(target_n: int) -> None:
+            while seeded["count"] < target_n:
+                self._create(
+                    server,
+                    admin_a.jwt,
+                    admin_a.id,
+                    team_id=team_a.id,
+                    key=f"scalability_seed_{seeded['count']}",
+                )
+                seeded["count"] += 1
+
+        endpoint = self.get_list_endpoint()
+        headers = self._get_appropriate_headers(admin_a.jwt, None)
+
+        def operation(_n: int) -> None:
+            response = server.get(endpoint, headers=headers)
+            assert response.status_code == 200, (
+                f"GET {endpoint} returned {response.status_code} during "
+                f"scalability probe; cannot measure scaling"
+            )
+
+        engine = server.app.state.model_registry.database_manager.engine
+        assert_scaling_within_bounds(
+            operation, self.scalability_profile, metric, engine=engine, setup=setup
+        )

--- a/src/endpoints/EP.Test.md
+++ b/src/endpoints/EP.Test.md
@@ -88,6 +88,24 @@ class TestItemEndpoints(AbstractEPTest):
 | `test_GQL_mutation_delete` | Delete mutation        |
 | `test_GQL_subscription`    | Real-time subscription |
 
+### Scalability Tests
+
+`test_scalability_GET_list_n_factor` is parametrized over `metric ∈ {TIME, QUERY_COUNT, MEMORY}` and skipped unless the subclass sets `scalability_profile`:
+
+```python
+from lib.Scalability import ScalabilityProfile, ScalingMetric
+
+class TestItemEndpoints(AbstractEPTest):
+    base_endpoint = "item"
+    entity_name = "item"
+    scalability_profile = ScalabilityProfile.default(
+        n_values=[5, 15, 50],
+        metrics=[ScalingMetric.TIME, ScalingMetric.QUERY_COUNT],
+    )
+```
+
+Seeds N entities at each `n`, fires `GET /<base_endpoint>` with admin auth, and asserts the observed Big-O exponent stays within the per-metric threshold. Catches list endpoints that materialize per-row, serializers with O(n²) field walks, and `include=` resolvers that fan out one upstream call per item. See [LIB.Scalability.md](../lib/LIB.Scalability.md).
+
 ## Nested Resources
 
 ### ParentEntity Configuration

--- a/src/endpoints/EP_Auth_test.py
+++ b/src/endpoints/EP_Auth_test.py
@@ -12,6 +12,7 @@ from endpoints.AbstractEPTest import AbstractEPTest, HttpMethod, StatusCode
 from lib.Environment import env
 from lib.Logging import logger
 from lib.Pydantic2Strawberry import convert_field_name
+from lib.Scalability import ScalabilityProfile, ScalingMetric
 from logic.BLL_Auth import InvitationModel, RoleModel, TeamModel, UserModel
 
 
@@ -46,6 +47,11 @@ class TestTeamEndpoints(AbstractEPTest):
         "description": "Updated team description",
     }
     unique_fields = ["name"]
+    scalability_profile = ScalabilityProfile.default(
+        n_values=[3, 8, 20],
+        metrics=[ScalingMetric.TIME, ScalingMetric.QUERY_COUNT, ScalingMetric.MEMORY],
+        repetitions=2,
+    )
 
     def create_payload(
         self,

--- a/src/lib/LIB.Overview.md
+++ b/src/lib/LIB.Overview.md
@@ -22,6 +22,7 @@ The `src/lib` directory contains foundational utilities and abstractions that po
 ### System Utilities
 - **[LIB.Logging.md](./LIB.Logging.md)**: Centralized logging system with custom levels, environment configuration, and structured output
 - **[LIB.RequestContext.md](./LIB.RequestContext.md)**: Context variable management for storing request-specific user information and timezone data
+- **[LIB.Scalability.md](./LIB.Scalability.md)**: Big-O assertion utilities (power-law fit, time/query/memory measurement context managers) consumed by per-layer scalability tests to keep the framework's n-factor within bounds
 
 ## Integration Patterns
 

--- a/src/lib/LIB.Scalability.md
+++ b/src/lib/LIB.Scalability.md
@@ -1,0 +1,85 @@
+# Scalability — Big-O Assertion Utilities
+
+`lib.Scalability` provides the analytic core consumed by per-layer abstract scalability tests (`AbstractDBTest`, `AbstractBLLTest`, `AbstractEPTest`). It fits the workload's `T(n) = a · n^k` curve via log-log linear regression and asserts the observed Big-O exponent `k` stays within configured bounds across three orthogonal metric axes: wall-clock time, SQL query count, and peak memory.
+
+## Why
+
+Algorithmic regressions are silent until they hit production. The most common offenders in this framework:
+
+- **N+1 query patterns** — accidentally fetching one row per related entity instead of joining/eager-loading. Looks fine at n=3 (test fixture sizes), explodes at n=10k.
+- **Quadratic loops in hot paths** — nested iteration over a list that grew from "a few" to "a lot" since the code was written.
+- **Per-row materialization in serializers** — payload memory growing super-linearly as new fields are added.
+
+Catching these in CI requires running the suspect operation at multiple input sizes and asserting the *shape* of the scaling curve, not just an absolute time budget.
+
+## Core Concepts
+
+### `ScalingMetric` enum
+
+Three independent axes; one assertion per axis so failures point at the regressing dimension:
+
+- `TIME` — wall-clock seconds via `time.perf_counter`.
+- `QUERY_COUNT` — SQLAlchemy cursor executions on the engine, via `before_cursor_execute` listener.
+- `MEMORY` — peak `tracemalloc` allocation in bytes.
+
+### `ScalabilityThreshold`
+
+Per-metric bounds. Fields:
+
+- `expected_exponent: float` — the ideal Big-O exponent (1.0 for linear time/memory; 0.0 for constant queries).
+- `max_exponent: float` — the failure threshold; observed `k` above this is a regression.
+- `min_r_squared: float` — minimum log-log-fit quality before the result is trusted (low-quality fits with too few points are passed through).
+- `floor_value: float` — measurements below this are treated as noise and excluded from the fit.
+
+### `DEFAULT_THRESHOLDS`
+
+Reasonable defaults shipped with the module:
+
+| Metric | expected_exponent | max_exponent | rationale |
+|---|---|---|---|
+| TIME | 1.0 | 1.4 | Linear with slack for `O(n·log n)` and JIT/GC noise on small `n`. |
+| QUERY_COUNT | 0.0 | 0.4 | Near-constant. N+1 patterns produce `k ≈ 1.0`; threshold is far below to catch them. |
+| MEMORY | 1.0 | 1.4 | Linear with slack matching TIME. |
+
+Subclasses override per metric via `ScalabilityProfile.threshold_overrides`.
+
+### `ScalabilityProfile`
+
+Parameter bundle for a scalability assertion:
+
+- `n_values: List[int]` — input sizes to probe (typical: `[5, 15, 50]` for integration tests, `[100, 1000, 10000]` for unit-level).
+- `metrics: List[ScalingMetric]` — which axes to evaluate.
+- `repetitions: int` — measurements per `n` for noise smoothing (default `3`).
+- `threshold_overrides: Dict[ScalingMetric, ScalabilityThreshold]` — per-metric overrides.
+
+Use `ScalabilityProfile.default()` for a sensible starting bundle.
+
+### `assert_scaling_within_bounds(operation, profile, metric, engine=None, setup=None, teardown=None)`
+
+User-facing entry point. Calls `setup(n)` once per size, runs `operation(n)` `repetitions` times under the metric's measurement context, fits the curve, and raises `AssertionError` with a human-readable summary if the observed exponent exceeds the configured maximum.
+
+The `setup` hook is the seeding step (e.g., "ensure exactly N entities exist") and runs *outside* the timed/counted region, so seeding overhead never pollutes the measurement.
+
+## Noise-Reduction Choices
+
+- **Time samples**: best-of-runs (`min`) — wall-clock is bounded below by the algorithm and contaminated above by GC, scheduler, and OS jitter.
+- **Query and memory samples**: `statistics.median` — already low-noise; mean would be biased by integer counts and one-time allocator behavior.
+
+## Power-Law Fit
+
+`fit_power_law` performs ordinary least-squares regression on `(log n, log value)` pairs. Returns `coefficient`, `exponent`, `r_squared`, and `point_count`. Zero/negative measurements are filtered (log-undefined). Fewer than 2 usable points returns a zero fit.
+
+## Per-Layer Integration
+
+Each abstract test class accepts an opt-in class attribute:
+
+```python
+class TestUserDB(AbstractDBTest):
+    scalability_profile = ScalabilityProfile.default(n_values=[5, 15, 50])
+```
+
+Subclasses inherit `test_scalability_list_n_factor` (DB / BLL) or `test_scalability_GET_list_n_factor` (EP). Each is parametrized over `metric ∈ {TIME, QUERY_COUNT, MEMORY}` and skips for any metric not in the profile's `metrics` list.
+
+## Testing the Tester
+
+`Scalability_test.py` covers the analytic core with real workloads (linear loops, quadratic loops, constant operations, list construction, in-memory SQLite). No mocks — the philosophy mirrors the framework's no-mock pillar.

--- a/src/lib/Scalability.py
+++ b/src/lib/Scalability.py
@@ -1,0 +1,317 @@
+"""Big-O complexity assertion utilities for scalability tests.
+
+Fits T(n) = a * n^k via log-log linear regression and asserts the observed
+exponent k stays within configured bounds. Per-layer abstract scalability
+tests (database, BLL, endpoints) consume this module to detect algorithmic
+regressions: N+1 queries, accidental O(n^2) loops, memory blow-ups.
+
+Three orthogonal metric axes are supported:
+
+- TIME: wall-clock seconds via time.perf_counter
+- QUERY_COUNT: SQLAlchemy cursor executions per call (catches N+1 explicitly)
+- MEMORY: peak tracemalloc allocation in bytes
+
+The user-facing entry point is `assert_scaling_within_bounds`. Tests pass an
+operation `f(n)` that performs the workload at input size n, plus a
+`ScalabilityProfile` declaring the n values, metrics, and thresholds to use.
+The function executes the workload at every n, fits the curve, and raises
+AssertionError with a human-readable summary if the observed exponent
+exceeds the configured maximum.
+
+Design choices:
+- Time samples are best-of-runs (min) to reduce upward noise from GC / OS;
+  query and memory samples use the median (already low-noise, mean is biased
+  by integer counts).
+- The fit uses ordinary least-squares in log-log space — robust enough for
+  3-5 data points and zero-dependency.
+- Defaults err on the strict side for query count (max k = 0.4, i.e.,
+  near-constant queries) because N+1 regressions look exactly like k = 1
+  scaling and we want them caught.
+"""
+
+import gc
+import math
+import statistics
+import time
+import tracemalloc
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, Iterator, List, Optional
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+
+class ScalingMetric(str, Enum):
+    TIME = "time"
+    QUERY_COUNT = "query_count"
+    MEMORY = "memory"
+
+
+@dataclass(frozen=True)
+class MeasurementSample:
+    n: int
+    metric: ScalingMetric
+    value: float
+
+
+@dataclass(frozen=True)
+class PowerLawFit:
+    coefficient: float
+    exponent: float
+    r_squared: float
+    point_count: int
+
+
+@dataclass(frozen=True)
+class ScalabilityThreshold:
+    metric: ScalingMetric
+    expected_exponent: float
+    max_exponent: float
+    min_r_squared: float = 0.5
+    floor_value: float = 0.0
+
+
+@dataclass(frozen=True)
+class ScalingResult:
+    metric: ScalingMetric
+    samples: List[MeasurementSample]
+    fit: PowerLawFit
+    headroom: float
+    passed: bool
+    threshold: ScalabilityThreshold
+
+    def assertion_message(self) -> str:
+        sample_str = ", ".join(f"n={s.n} -> {s.value:.6g}" for s in self.samples)
+        return (
+            f"{self.metric.value} scaling regressed: observed Big-O exponent "
+            f"k={self.fit.exponent:.3f} (R^2={self.fit.r_squared:.3f}) exceeds "
+            f"max {self.threshold.max_exponent} (ideal "
+            f"{self.threshold.expected_exponent}). Samples: [{sample_str}]"
+        )
+
+
+DEFAULT_THRESHOLDS: Dict[ScalingMetric, ScalabilityThreshold] = {
+    ScalingMetric.TIME: ScalabilityThreshold(
+        metric=ScalingMetric.TIME,
+        expected_exponent=1.0,
+        max_exponent=1.4,
+        min_r_squared=0.5,
+        floor_value=1e-5,
+    ),
+    ScalingMetric.QUERY_COUNT: ScalabilityThreshold(
+        metric=ScalingMetric.QUERY_COUNT,
+        expected_exponent=0.0,
+        max_exponent=0.4,
+        min_r_squared=0.0,
+        floor_value=0.0,
+    ),
+    ScalingMetric.MEMORY: ScalabilityThreshold(
+        metric=ScalingMetric.MEMORY,
+        expected_exponent=1.0,
+        max_exponent=1.4,
+        min_r_squared=0.5,
+        floor_value=1.0,
+    ),
+}
+
+
+def fit_power_law(samples: List[MeasurementSample]) -> PowerLawFit:
+    usable = [s for s in samples if s.n > 0 and s.value > 0]
+    if len(usable) < 2:
+        return PowerLawFit(0.0, 0.0, 0.0, len(usable))
+    log_n = [math.log(s.n) for s in usable]
+    log_v = [math.log(s.value) for s in usable]
+    count = len(usable)
+    mean_x = sum(log_n) / count
+    mean_y = sum(log_v) / count
+    cov = sum((x - mean_x) * (y - mean_y) for x, y in zip(log_n, log_v))
+    var_x = sum((x - mean_x) ** 2 for x in log_n)
+    if var_x == 0:
+        return PowerLawFit(math.exp(mean_y), 0.0, 1.0, count)
+    k = cov / var_x
+    log_a = mean_y - k * mean_x
+    ss_res = sum((y - (log_a + k * x)) ** 2 for x, y in zip(log_n, log_v))
+    ss_tot = sum((y - mean_y) ** 2 for y in log_v)
+    r_squared = 1 - ss_res / ss_tot if ss_tot > 0 else 1.0
+    return PowerLawFit(math.exp(log_a), k, r_squared, count)
+
+
+def evaluate_scaling(
+    samples: List[MeasurementSample], threshold: ScalabilityThreshold
+) -> ScalingResult:
+    if not samples:
+        raise ValueError("evaluate_scaling requires at least one sample")
+    if any(s.metric != threshold.metric for s in samples):
+        raise ValueError(
+            f"sample metric mismatch: threshold is for {threshold.metric.value}"
+        )
+    cleaned = [s for s in samples if s.value > threshold.floor_value]
+    fit = fit_power_law(cleaned if len(cleaned) >= 2 else samples)
+    headroom = threshold.max_exponent - fit.exponent
+    fit_ok = fit.r_squared >= threshold.min_r_squared or fit.point_count < 3
+    passed = fit.exponent <= threshold.max_exponent and fit_ok
+    return ScalingResult(
+        metric=threshold.metric,
+        samples=samples,
+        fit=fit,
+        headroom=headroom,
+        passed=passed,
+        threshold=threshold,
+    )
+
+
+@contextmanager
+def measure_time() -> Iterator[Callable[[], float]]:
+    gc.collect()
+    elapsed = [0.0]
+    start = time.perf_counter()
+    try:
+        yield lambda: elapsed[0]
+    finally:
+        elapsed[0] = time.perf_counter() - start
+
+
+@contextmanager
+def measure_memory() -> Iterator[Callable[[], int]]:
+    started_here = not tracemalloc.is_tracing()
+    if started_here:
+        tracemalloc.start()
+    tracemalloc.reset_peak()
+    peak = [0]
+    try:
+        yield lambda: peak[0]
+    finally:
+        _, peak_now = tracemalloc.get_traced_memory()
+        peak[0] = peak_now
+        if started_here:
+            tracemalloc.stop()
+
+
+class QueryCounter:
+    """Counts SQLAlchemy cursor executions on an engine for the lifetime of
+    the context. Listener is removed on exit so concurrent counters never
+    cross-contaminate."""
+
+    def __init__(self, engine: Engine):
+        self._engine = engine
+        self._count = 0
+        self._listener: Optional[Callable] = None
+
+    def __enter__(self) -> "QueryCounter":
+        self._count = 0
+
+        def _on_execute(conn, cursor, statement, parameters, context, executemany):
+            self._count += 1
+
+        self._listener = _on_execute
+        event.listen(self._engine, "before_cursor_execute", self._listener)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if self._listener is not None:
+            event.remove(self._engine, "before_cursor_execute", self._listener)
+            self._listener = None
+        return False
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+
+def collect_samples(
+    operation: Callable[[int], None],
+    n_values: List[int],
+    metric: ScalingMetric,
+    repetitions: int,
+    engine: Optional[Engine] = None,
+    setup: Optional[Callable[[int], None]] = None,
+    teardown: Optional[Callable[[int], None]] = None,
+) -> List[MeasurementSample]:
+    if repetitions < 1:
+        raise ValueError("repetitions must be >= 1")
+    if len(n_values) < 2:
+        raise ValueError("need at least 2 n_values to fit a curve")
+    if any(n <= 0 for n in n_values):
+        raise ValueError("n_values must be positive")
+    if metric == ScalingMetric.QUERY_COUNT and engine is None:
+        raise ValueError("query_count metric requires a SQLAlchemy engine")
+
+    samples: List[MeasurementSample] = []
+    for n in n_values:
+        if setup is not None:
+            setup(n)
+        runs: List[float] = []
+        for _ in range(repetitions):
+            if metric == ScalingMetric.TIME:
+                with measure_time() as get_value:
+                    operation(n)
+                runs.append(get_value())
+            elif metric == ScalingMetric.MEMORY:
+                with measure_memory() as get_value:
+                    operation(n)
+                runs.append(float(get_value()))
+            else:
+                with QueryCounter(engine) as counter:
+                    operation(n)
+                runs.append(float(counter.count))
+        if teardown is not None:
+            teardown(n)
+        value = min(runs) if metric == ScalingMetric.TIME else statistics.median(runs)
+        samples.append(MeasurementSample(n=n, metric=metric, value=value))
+    return samples
+
+
+@dataclass(frozen=True)
+class ScalabilityProfile:
+    """Parameter bundle for a scalability assertion: the n values to probe,
+    the metrics to measure, repetitions per n for noise smoothing, and
+    optional per-metric threshold overrides."""
+
+    n_values: List[int]
+    metrics: List[ScalingMetric]
+    repetitions: int = 3
+    threshold_overrides: Dict[ScalingMetric, ScalabilityThreshold] = field(
+        default_factory=dict
+    )
+
+    def threshold_for(self, metric: ScalingMetric) -> ScalabilityThreshold:
+        return self.threshold_overrides.get(metric) or DEFAULT_THRESHOLDS[metric]
+
+    @classmethod
+    def default(
+        cls,
+        n_values: Optional[List[int]] = None,
+        metrics: Optional[List[ScalingMetric]] = None,
+        repetitions: int = 3,
+    ) -> "ScalabilityProfile":
+        return cls(
+            n_values=n_values or [10, 25, 50, 100],
+            metrics=metrics
+            or [ScalingMetric.TIME, ScalingMetric.QUERY_COUNT, ScalingMetric.MEMORY],
+            repetitions=repetitions,
+        )
+
+
+def assert_scaling_within_bounds(
+    operation: Callable[[int], None],
+    profile: ScalabilityProfile,
+    metric: ScalingMetric,
+    engine: Optional[Engine] = None,
+    setup: Optional[Callable[[int], None]] = None,
+    teardown: Optional[Callable[[int], None]] = None,
+) -> ScalingResult:
+    samples = collect_samples(
+        operation,
+        profile.n_values,
+        metric,
+        profile.repetitions,
+        engine,
+        setup=setup,
+        teardown=teardown,
+    )
+    result = evaluate_scaling(samples, profile.threshold_for(metric))
+    if not result.passed:
+        raise AssertionError(result.assertion_message())
+    return result

--- a/src/lib/Scalability.py
+++ b/src/lib/Scalability.py
@@ -150,8 +150,12 @@ def evaluate_scaling(
     cleaned = [s for s in samples if s.value > threshold.floor_value]
     fit = fit_power_law(cleaned if len(cleaned) >= 2 else samples)
     headroom = threshold.max_exponent - fit.exponent
-    fit_ok = fit.r_squared >= threshold.min_r_squared or fit.point_count < 3
-    passed = fit.exponent <= threshold.max_exponent and fit_ok
+    if fit.exponent <= threshold.expected_exponent:
+        passed = True
+    elif fit.exponent <= threshold.max_exponent:
+        passed = fit.r_squared >= threshold.min_r_squared or fit.point_count < 3
+    else:
+        passed = False
     return ScalingResult(
         metric=threshold.metric,
         samples=samples,

--- a/src/lib/Scalability_test.py
+++ b/src/lib/Scalability_test.py
@@ -1,0 +1,351 @@
+"""Self-tests for lib.Scalability.
+
+Uses real workloads (linear loops, quadratic loops, constant-time ops, list
+construction) — no mocks. Each test asserts the analytic core correctly
+classifies a known-complexity workload.
+"""
+
+import math
+
+import pytest
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from lib.Scalability import (
+    DEFAULT_THRESHOLDS,
+    MeasurementSample,
+    PowerLawFit,
+    QueryCounter,
+    ScalabilityProfile,
+    ScalabilityThreshold,
+    ScalingMetric,
+    ScalingResult,
+    assert_scaling_within_bounds,
+    collect_samples,
+    evaluate_scaling,
+    fit_power_law,
+    measure_memory,
+    measure_time,
+)
+
+
+class TestFitPowerLaw:
+    def test_perfect_linear(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.TIME, value=2.5 * n)
+            for n in (10, 100, 1000)
+        ]
+        fit = fit_power_law(samples)
+        assert fit.point_count == 3
+        assert math.isclose(fit.exponent, 1.0, abs_tol=1e-9)
+        assert math.isclose(fit.coefficient, 2.5, abs_tol=1e-9)
+        assert math.isclose(fit.r_squared, 1.0, abs_tol=1e-9)
+
+    def test_perfect_quadratic(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.TIME, value=0.001 * n * n)
+            for n in (10, 100, 1000)
+        ]
+        fit = fit_power_law(samples)
+        assert math.isclose(fit.exponent, 2.0, abs_tol=1e-9)
+        assert math.isclose(fit.r_squared, 1.0, abs_tol=1e-9)
+
+    def test_constant(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.QUERY_COUNT, value=3.0)
+            for n in (10, 100, 1000)
+        ]
+        fit = fit_power_law(samples)
+        assert math.isclose(fit.exponent, 0.0, abs_tol=1e-9)
+
+    def test_logarithmic_is_sublinear(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.TIME, value=math.log(n))
+            for n in (10, 100, 1000, 10000)
+        ]
+        fit = fit_power_law(samples)
+        assert 0.0 < fit.exponent < 0.5
+
+    def test_too_few_points(self):
+        samples = [MeasurementSample(n=1, metric=ScalingMetric.TIME, value=0.1)]
+        fit = fit_power_law(samples)
+        assert fit == PowerLawFit(0.0, 0.0, 0.0, 1)
+
+    def test_zero_and_negative_values_filtered(self):
+        samples = [
+            MeasurementSample(n=10, metric=ScalingMetric.TIME, value=0.0),
+            MeasurementSample(n=100, metric=ScalingMetric.TIME, value=1.0),
+            MeasurementSample(n=1000, metric=ScalingMetric.TIME, value=10.0),
+        ]
+        fit = fit_power_law(samples)
+        assert fit.point_count == 2
+        assert math.isclose(fit.exponent, 1.0, abs_tol=1e-9)
+
+
+class TestEvaluateScaling:
+    def test_linear_passes_time_default(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.TIME, value=0.0001 * n)
+            for n in (10, 50, 100, 500)
+        ]
+        result = evaluate_scaling(samples, DEFAULT_THRESHOLDS[ScalingMetric.TIME])
+        assert result.passed
+        assert result.headroom > 0
+        assert math.isclose(result.fit.exponent, 1.0, abs_tol=1e-6)
+
+    def test_quadratic_fails_time_default(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.TIME, value=0.0001 * n * n)
+            for n in (10, 50, 100, 500)
+        ]
+        result = evaluate_scaling(samples, DEFAULT_THRESHOLDS[ScalingMetric.TIME])
+        assert not result.passed
+        assert result.headroom < 0
+        assert "scaling regressed" in result.assertion_message()
+
+    def test_n_plus_one_fails_query_default(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.QUERY_COUNT, value=float(n + 1))
+            for n in (10, 50, 100, 500)
+        ]
+        result = evaluate_scaling(samples, DEFAULT_THRESHOLDS[ScalingMetric.QUERY_COUNT])
+        assert not result.passed
+        assert result.fit.exponent > 0.4
+
+    def test_constant_queries_pass(self):
+        samples = [
+            MeasurementSample(n=n, metric=ScalingMetric.QUERY_COUNT, value=2.0)
+            for n in (10, 50, 100, 500)
+        ]
+        result = evaluate_scaling(samples, DEFAULT_THRESHOLDS[ScalingMetric.QUERY_COUNT])
+        assert result.passed
+
+    def test_metric_mismatch_raises(self):
+        samples = [MeasurementSample(n=10, metric=ScalingMetric.TIME, value=0.1)]
+        with pytest.raises(ValueError, match="metric mismatch"):
+            evaluate_scaling(samples, DEFAULT_THRESHOLDS[ScalingMetric.MEMORY])
+
+    def test_empty_samples_raises(self):
+        with pytest.raises(ValueError, match="at least one sample"):
+            evaluate_scaling([], DEFAULT_THRESHOLDS[ScalingMetric.TIME])
+
+
+class TestMeasureTime:
+    def test_records_elapsed(self):
+        with measure_time() as get_elapsed:
+            sum(range(100_000))
+        elapsed = get_elapsed()
+        assert elapsed > 0
+        assert elapsed < 5.0
+
+    def test_zero_when_unread_during_block(self):
+        with measure_time() as get_elapsed:
+            inside = get_elapsed()
+        assert inside == 0.0
+
+
+class TestMeasureMemory:
+    def test_captures_peak_allocation(self):
+        with measure_memory() as get_peak:
+            big = [i for i in range(50_000)]
+        peak = get_peak()
+        assert peak > 0
+        del big
+
+    def test_nests_safely(self):
+        with measure_memory() as outer:
+            outer_data = list(range(10_000))
+            with measure_memory() as inner:
+                inner_data = list(range(20_000))
+            assert inner() > 0
+        assert outer() > 0
+        del outer_data, inner_data
+
+
+class TestQueryCounter:
+    @pytest.fixture
+    def engine(self):
+        engine = create_engine("sqlite:///:memory:")
+        base = declarative_base()
+
+        class Item(base):
+            __tablename__ = "scaling_test_item"
+            id = Column(Integer, primary_key=True)
+            name = Column(String, nullable=False)
+
+        base.metadata.create_all(engine)
+        return engine, Item
+
+    def test_counts_executes(self, engine):
+        eng, model = engine
+        Session = sessionmaker(bind=eng)
+        with QueryCounter(eng) as counter:
+            with Session() as session:
+                session.add(model(name="a"))
+                session.add(model(name="b"))
+                session.commit()
+                session.query(model).all()
+        assert counter.count >= 2
+
+    def test_listener_removed_on_exit(self, engine):
+        eng, model = engine
+        with QueryCounter(eng) as counter:
+            pass
+        assert counter._listener is None
+        Session = sessionmaker(bind=eng)
+        with Session() as session:
+            session.query(model).all()
+        assert counter.count == 0
+
+
+class TestCollectSamples:
+    def test_time_linear_workload(self):
+        def linear(n: int) -> None:
+            total = 0
+            for i in range(n):
+                total += i
+
+        samples = collect_samples(
+            linear, [100, 1000, 10000], ScalingMetric.TIME, repetitions=3
+        )
+        assert len(samples) == 3
+        assert all(s.metric == ScalingMetric.TIME for s in samples)
+        assert all(s.value > 0 for s in samples)
+
+    def test_memory_linear_workload(self):
+        def alloc(n: int) -> None:
+            data = list(range(n * 10))
+            del data
+
+        samples = collect_samples(
+            alloc, [100, 1000, 10000], ScalingMetric.MEMORY, repetitions=2
+        )
+        fit = fit_power_law(samples)
+        assert 0.5 < fit.exponent < 1.5
+
+    def test_rejects_short_n_values(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            collect_samples(lambda n: None, [10], ScalingMetric.TIME, 1)
+
+    def test_rejects_zero_repetitions(self):
+        with pytest.raises(ValueError, match="repetitions"):
+            collect_samples(lambda n: None, [10, 20], ScalingMetric.TIME, 0)
+
+    def test_query_count_requires_engine(self):
+        with pytest.raises(ValueError, match="engine"):
+            collect_samples(lambda n: None, [10, 20], ScalingMetric.QUERY_COUNT, 1)
+
+    def test_setup_called_once_per_n_before_repetitions(self):
+        setup_log: list = []
+        op_log: list = []
+
+        def setup(n):
+            setup_log.append(n)
+
+        def operation(n):
+            op_log.append(n)
+
+        collect_samples(
+            operation,
+            [10, 20, 30],
+            ScalingMetric.TIME,
+            repetitions=4,
+            setup=setup,
+        )
+        assert setup_log == [10, 20, 30]
+        assert op_log == [10] * 4 + [20] * 4 + [30] * 4
+
+    def test_teardown_called_once_per_n_after_repetitions(self):
+        teardown_log: list = []
+        order: list = []
+
+        def operation(n):
+            order.append(("op", n))
+
+        def teardown(n):
+            order.append(("teardown", n))
+            teardown_log.append(n)
+
+        collect_samples(
+            operation,
+            [10, 20],
+            ScalingMetric.TIME,
+            repetitions=2,
+            teardown=teardown,
+        )
+        assert teardown_log == [10, 20]
+        assert order == [
+            ("op", 10),
+            ("op", 10),
+            ("teardown", 10),
+            ("op", 20),
+            ("op", 20),
+            ("teardown", 20),
+        ]
+
+
+class TestAssertScalingWithinBounds:
+    def test_passes_for_linear(self):
+        def linear(n: int) -> None:
+            sum(range(n))
+
+        result = assert_scaling_within_bounds(
+            linear,
+            ScalabilityProfile.default(
+                n_values=[100, 1000, 10000], metrics=[ScalingMetric.TIME]
+            ),
+            ScalingMetric.TIME,
+        )
+        assert isinstance(result, ScalingResult)
+        assert result.passed
+
+    def test_raises_on_quadratic_with_strict_threshold(self):
+        def quadratic(n: int) -> None:
+            total = 0
+            for i in range(n):
+                for j in range(n):
+                    total += i + j
+
+        profile = ScalabilityProfile(
+            n_values=[50, 100, 200],
+            metrics=[ScalingMetric.TIME],
+            repetitions=2,
+            threshold_overrides={
+                ScalingMetric.TIME: ScalabilityThreshold(
+                    metric=ScalingMetric.TIME,
+                    expected_exponent=1.0,
+                    max_exponent=1.5,
+                    min_r_squared=0.5,
+                    floor_value=1e-5,
+                )
+            },
+        )
+        with pytest.raises(AssertionError, match="scaling regressed"):
+            assert_scaling_within_bounds(quadratic, profile, ScalingMetric.TIME)
+
+
+class TestProfile:
+    def test_default_profile(self):
+        profile = ScalabilityProfile.default()
+        assert len(profile.n_values) >= 2
+        assert ScalingMetric.TIME in profile.metrics
+        assert profile.repetitions >= 1
+
+    def test_threshold_override_takes_precedence(self):
+        custom = ScalabilityThreshold(
+            metric=ScalingMetric.TIME,
+            expected_exponent=1.0,
+            max_exponent=2.0,
+        )
+        profile = ScalabilityProfile(
+            n_values=[10, 20],
+            metrics=[ScalingMetric.TIME],
+            threshold_overrides={ScalingMetric.TIME: custom},
+        )
+        assert profile.threshold_for(ScalingMetric.TIME) is custom
+
+    def test_threshold_falls_back_to_default(self):
+        profile = ScalabilityProfile(n_values=[10, 20], metrics=[ScalingMetric.TIME])
+        assert profile.threshold_for(ScalingMetric.MEMORY) is DEFAULT_THRESHOLDS[
+            ScalingMetric.MEMORY
+        ]

--- a/src/lib/Scalability_test.py
+++ b/src/lib/Scalability_test.py
@@ -129,6 +129,21 @@ class TestEvaluateScaling:
         with pytest.raises(ValueError, match="at least one sample"):
             evaluate_scaling([], DEFAULT_THRESHOLDS[ScalingMetric.TIME])
 
+    def test_flat_data_below_ideal_passes_regardless_of_r_squared(self):
+        # Real-world scenario: at small n, list() is dominated by setup
+        # cost, so timings are essentially flat with noise. Observed k is
+        # near zero (better than the ideal of 1.0) but R^2 is low because
+        # there's no signal. We must pass — flat is what we wanted.
+        samples = [
+            MeasurementSample(n=3, metric=ScalingMetric.TIME, value=0.00769),
+            MeasurementSample(n=8, metric=ScalingMetric.TIME, value=0.00742),
+            MeasurementSample(n=20, metric=ScalingMetric.TIME, value=0.00758),
+        ]
+        result = evaluate_scaling(samples, DEFAULT_THRESHOLDS[ScalingMetric.TIME])
+        assert result.passed
+        assert result.fit.exponent < 0.1
+        assert result.fit.r_squared < 0.5
+
 
 class TestMeasureTime:
     def test_records_elapsed(self):

--- a/src/logic/AbstractBLLTest.py
+++ b/src/logic/AbstractBLLTest.py
@@ -6,6 +6,11 @@ import pytest
 from AbstractTest import AbstractTest, CategoryOfTest, ClassOfTestsConfig
 from lib.Environment import env
 from lib.Logging import logger
+from lib.Scalability import (
+    ScalabilityProfile,
+    ScalingMetric,
+    assert_scaling_within_bounds,
+)
 from logic.AbstractLogicManager import AbstractBLLManager
 
 
@@ -1161,3 +1166,64 @@ class AbstractBLLTest(AbstractTest):
                     assert isinstance(
                         hooks["after"], list
                     ), f"'after' hooks for {method_name} should be a list"
+
+    # ------------------------------------------------------------------ #
+    # Scalability / Big-O assertions
+    # ------------------------------------------------------------------ #
+    # Subclasses opt in by setting `scalability_profile`. Asserts that
+    # `manager.list()` scales within the configured exponent for time,
+    # query count, and peak memory as the underlying entity count grows.
+    # The Big-O exponent caught here is the one driving the framework's
+    # n-factor SLO: regressions surface as a metric-specific assertion
+    # rather than a single opaque pass/fail.
+
+    scalability_profile: Optional[ScalabilityProfile] = None
+
+    @pytest.mark.parametrize(
+        "metric",
+        sorted(
+            [ScalingMetric.TIME, ScalingMetric.QUERY_COUNT, ScalingMetric.MEMORY],
+            key=lambda m: m.value,
+        ),
+    )
+    def test_scalability_list_n_factor(
+        self, admin_a, team_a, server, model_registry, metric: ScalingMetric
+    ):
+        """Big-O assertion: manager.list() must stay within the configured
+        exponent for time, query count, and peak memory as the BLL surface
+        scales out. Catches accidental N+1 in resolver chains, hook-storm
+        regressions, and per-entity fan-out."""
+        if self.scalability_profile is None:
+            pytest.skip("scalability_profile not configured on this test class")
+        if metric not in self.scalability_profile.metrics:
+            pytest.skip(f"metric {metric.value} not enabled in scalability_profile")
+
+        self.server = server
+        self.model_registry = model_registry
+        seeded = {"count": 0}
+
+        def setup(target_n: int) -> None:
+            while seeded["count"] < target_n:
+                self._create(
+                    admin_a.id,
+                    team_a.id,
+                    key=f"scalability_seed_{seeded['count']}",
+                    server=server,
+                    model_registry=model_registry,
+                )
+                seeded["count"] += 1
+
+        requester = env("SYSTEM_ID") if self.is_system_entity else admin_a.id
+
+        def operation(_n: int) -> None:
+            manager = self.class_under_test(
+                requester_id=requester,
+                target_team_id=team_a.id,
+                model_registry=model_registry,
+            )
+            manager.list()
+
+        engine = model_registry.database_manager.engine
+        assert_scaling_within_bounds(
+            operation, self.scalability_profile, metric, engine=engine, setup=setup
+        )

--- a/src/logic/BLL.Test.md
+++ b/src/logic/BLL.Test.md
@@ -155,6 +155,15 @@ The `generate_search_test_parameters()` method:
 - Verifies create hooks have before/after arrays
 - Confirms proper hook discovery system
 
+### Scalability Tests
+
+#### `test_scalability_list_n_factor(admin_a, team_a, server, model_registry, metric)`
+- Parametrized over `metric ∈ {TIME, QUERY_COUNT, MEMORY}`.
+- Skipped unless the subclass sets `scalability_profile` (a `ScalabilityProfile` from `lib.Scalability`).
+- Seeds N entities at each `n` in `scalability_profile.n_values`, then calls `manager.list()` and asserts the observed Big-O exponent stays within the per-metric threshold.
+- Defaults: `k ≤ 1.4` for time/memory, `k ≤ 0.4` for query count (catches N+1 in resolver chains and hook-storm regressions).
+- See [LIB.Scalability.md](../lib/LIB.Scalability.md).
+
 ## Entity Management
 
 ### Tracked Entities System

--- a/src/logic/BLL_Auth_test.py
+++ b/src/logic/BLL_Auth_test.py
@@ -17,6 +17,7 @@ from AbstractTest import (
     SkipThisTest,
 )
 from lib.Environment import env
+from lib.Scalability import ScalabilityProfile, ScalingMetric
 from logic.AbstractBLLTest import AbstractBLLTest
 from logic.BLL_Auth import (
     InvitationManager,
@@ -394,6 +395,11 @@ class TestTeamManager(AbstractBLLTest):
         "description": f"Updated {faker.sentence()}",
     }
     unique_fields = ["name"]
+    scalability_profile = ScalabilityProfile.default(
+        n_values=[3, 8, 20],
+        metrics=[ScalingMetric.TIME, ScalingMetric.QUERY_COUNT, ScalingMetric.MEMORY],
+        repetitions=2,
+    )
 
     def test_create_team_with_empty_name_fails(self, admin_a, model_registry):
         """Test that team creation with empty name fails."""


### PR DESCRIPTION
`lib.Scalability` provides power-law-fit utilities and time/query/memory
measurement context managers. Per-layer abstract tests (DB / BLL / EP)
each gain a `test_scalability_*_n_factor` method parametrized over
{TIME, QUERY_COUNT, MEMORY}; subclasses opt in via `scalability_profile`.

Defaults: k ≤ 1.4 for time/memory, k ≤ 0.4 for query count — calibrated
so N+1 patterns (k ≈ 1) trip the gate. 30 self-tests cover the analytic
core with real workloads (no mocks), per AGENTS.md.