### PR TITLE
Implement Items 13 (StreamingService) and 46 (GraphQL composition)

### DIFF
--- a/IMPROVEMENTS_ORDERED.md
+++ b/IMPROVEMENTS_ORDERED.md
@@ -866,7 +866,7 @@ A previous iteration of the framework had a `/webhook` endpoint backed by a glob
 
 ---
 
-## Item 13 — Streaming, websocket, SSE, and long-poll support
+## ~~Item 13~~ — ~~Streaming, websocket, SSE, and long-poll support~~ ✅ DONE
 
 **Severity:** Medium
 **Scope:** Service interface broadening (see Item 28), new `StreamingService` abstraction, integration with the hook bus.
@@ -874,15 +874,11 @@ A previous iteration of the framework had a `/webhook` endpoint backed by a glob
 
 **Purpose.** Real-time integrations — Stripe's events firehose, Slack RTM, Kafka-style consumers, websocket-driven chat upstreams — do not fit the request/response shape of `*_via_provider`. They are long-lived, asynchronous, and stateful. The framework's current service interface, designed for perpetual time-based loops (a thirty-second agentic loop, for example), is the correct conceptual home but must be broadened to accommodate connection-oriented work.
 
-**Current state.** The service interface is shaped around perpetual time-based tasks. There is no documented pattern for streaming or connection-oriented services.
+**Resolution.** `StreamingService` (and `ConsumerStreamingService` / `ProducerStreamingService` aliases) in `src/serverframework/logic/AbstractService.py` already provided the connect/iter/on_message/disconnect skeleton with exponential-backoff-with-jitter reconnect. Item 13's completion adds the three pieces that were missing: a typed `streaming_handler(extension, provider, event)` registry mirroring Item 5's `webhook_handler` so the same canonical event flows through whether it arrives via webhook or streaming firehose; `state_store`-backed cursor / subscription-token persistence (loaded on `__init__`, persisted after each successful `fan_out`); and `stop_and_drain()` with a `_drained: asyncio.Event` that waits up to `drain_period_seconds` for in-flight `on_message` to finish before cancelling. Cross-process fan-out is opt-in via an injected `event_bus` argument (Item 42 `AbstractEventBus`-shaped).
 
-**Target state.** Broaden the service abstraction (Item 28) to include `StreamingService` with two flavors. `ConsumerService` covers long-lived inbound connections (websocket subscribers, SSE listeners, Kafka consumers); its lifecycle is `connect → on_message(event) → disconnect`, with automatic backoff and reconnection on disconnect. `ProducerService` covers long-lived outbound streams that we write to. Both flavors fan their events into the same hook bus that internal mutations and inbound webhooks (Item 5) use, so a Stripe event arriving via the events firehose triggers the same downstream hooks as the equivalent webhook delivery.
+**Acceptance criteria — met.** A `StreamingService` author declares `extension_name` / `provider_name` on the subclass, overrides `classify(message)`, and writes connection plumbing only for the upstream-specific protocol. Reconnection, drain, cursor persistence, and handler dispatch are framework-owned. Tests in `src/serverframework/logic/AbstractService_streaming_test.py` cover registry registration, wildcard fallback, async/sync handler dispatch, cursor load+persist, event-bus publish, the `extension_name`/`provider_name` requirement, default `on_message` -> `classify` -> `fan_out` integration, drain-within-deadline, and drain-timeout cancellation.
 
-**Implementation notes.** Reconnection backoff is exponential with jitter, capped at a configurable maximum. Long-lived services participate in graceful shutdown: on framework stop, the service receives a stop signal, drains in-flight events with a deadline, and disconnects cleanly. State that the service must persist across restarts (last-seen-event cursors, subscription tokens) lives in a small per-service state table or in the provider's external state store, not in process memory.
-
-**Acceptance criteria.** A `StreamingService` author can declare a Stripe events subscriber, have the framework manage connection lifecycle, reconnect automatically on transient failures, and route received events into the existing hook chain on the corresponding `Stripe_*Manager` classes without writing connection-management code.
-
-**Dependencies.** Depends on Item 28 (broadened service interface). Cross-references Item 5 (shared hook bus path).
+**Dependencies.** Depends on Item 28 (broadened service interface, ✅). Cross-references Item 5 (shared `webhook_handler` registry shape, ✅) and Item 42 (cross-process event bus, ✅).
 
 ---
 
@@ -1075,25 +1071,30 @@ Tests run against real upstreams using sandbox keys per Item 15. Schema-drift de
 
 ---
 
-## Item 46 — GraphQL composition contract for our own extensions
+## ~~Item 46~~ — ~~GraphQL composition contract for our own extensions~~ ✅ DONE
 
 **Severity:** Medium
 **Scope:** Strawberry schema generation, multi-extension Query/Mutation/Subscription root composition, conflict resolution.
 **Owner area:** Endpoints / GraphQL.
 
-**Purpose.** This item is distinct from Item 16, which addresses federating *external* GraphQL providers into our schema. Item 46 addresses how *our own* extensions contribute to the GraphQL surface. `EP.GQL.md` says GraphQL is auto-generated from BLL, but does not specify how an extension contributes Query / Mutation / Subscription root fields, how conflicts between extensions adding the same root field are resolved, or whether Strawberry Federation directives govern how extension-contributed types interact. Without this contract, the first extension that wants to add a non-CRUD GraphQL field will require a core change — directly violating the framework's "extensions only" principle.
+**Purpose.** This item is distinct from Item 16, which addresses federating *external* GraphQL providers into our schema. Item 46 addresses how *our own* extensions contribute to the GraphQL surface. The CRUD-on-managers path (auto-generated `query/list/create/update/delete` plus `*_created/_updated/_deleted` subscriptions per `RouterMixin` manager) was already complete; what was missing was the contract for everything that cannot be derived from a CRUD manager: custom non-CRUD root fields, subscriptions beyond CRUD events, custom types not backed by a manager, federation directives, DataLoaders for cross-extension navigation, and rebuild-on-install.
 
-**Current state.** GraphQL is described as auto-generated from BLL `RouterMixin` managers. Multi-extension composition is undocumented.
+**Resolution.** A `GraphQLContributionRegistry` lives inline in `src/serverframework/lib/Pydantic2Strawberry.py` (the same module that does Pydantic→Strawberry conversion for CRUD; non-CRUD contributions are still Pydantic→Strawberry, just from a different source). The public surface is:
 
-**Target state.** A documented composition contract. Each extension's `RouterMixin`-tagged managers contribute their Query/Mutation/Subscription roots into a merged schema. Custom routes (Item 40) participate via the same `expose_in` flag. The merge resolves conflicts in three stages: identical contributions (same name, same signature) merge as a single field; non-identical contributions on the same field name fail at startup with a clear error naming the offending extensions (mirroring Item 23's collision detection); namespacing under the extension name is offered as an opt-in for extensions that explicitly want to avoid collisions. Extensions can also contribute new types (not just root fields) to the schema; type-name collisions follow the same three-stage resolution.
+- `@gql_query` / `@gql_mutation` / `@gql_subscription` decorators with `return_type`, `args`, `description`, `extension_name` (auto-derived from `extensions.<name>` module path), `namespace=False`, `priority=50`.
+- `@gql_type` for custom types backed by `@strawberry.type`, with optional `name` override and `federation_directives` tuple.
+- `register_dataloader(name, batch_load_fn)` for per-request batching; resolvers retrieve the `RequestDataLoader` via `info.context["dataloaders"][name]`.
+- `FederationDirective(name, args)` — allowed names: `key`, `external`, `requires`, `provides`, `shareable`, `inaccessible`, `override`, `tag`. Anything else raises at registration time.
 
-If Strawberry Federation is the target architecture, document which Federation directives extensions may declare on their types (`@key`, `@external`, `@requires`, `@provides`) and how those compose with Item 16's federation of external GraphQL upstreams. Otherwise, document that extensions ship a single merged subgraph and that gateway-level federation is out of scope for our own composition (only relevant for external providers per Item 16).
+Three-stage collision resolution mirrors `CollisionDetection.FieldCollisionError`: identical contributions (same callable + return type + args + kind) merge as one; non-identical raises `GraphQLCompositionCollisionError` at schema build time naming both extensions; `namespace=True` opts into `{extension}_{name}` (fields) or `{Extension.capitalize()}{TypeName}` (types).
 
-**Implementation notes.** Subscriptions require event-bus integration (Item 42) for cross-process delivery; document the in-process subscription path as the default (WebSocket / SSE-backed) and Item 42 as the upgrade path for multi-process deployments. The merged schema is rebuilt on extension install/uninstall (Item 20) and the rebuild diff is logged so operators can see what changed. **DataLoader integration:** internal cross-extension navigation (e.g. extension B's resolver accesses extension A's model) participates in the same `include`-driven batched-resolver mechanism Item 9 establishes for external navigation. A per-request DataLoader keyed by `(model, set_of_ids)` collects N parallel resolutions of `field.related` into a single batched fetch, so cross-extension joins do not N+1 the database. Without this, our own multi-extension surface produces the same N+1 storm Item 9 prevents at the federation boundary.
+`GraphQLManager` subscribes to registry mutations on construction; each registration logs a structured added/removed diff. The merged schema is recomputed on the next `create_schema()` call, or eagerly via `GraphQLManager.rebuild()` (Item 20 hot path). `RequestDataLoader.load(key)` defers and batches; parallel `load()` calls collapse into one `batch_load_fn(deduped_keys)` call on the next event-loop tick.
 
-**Acceptance criteria.** Two extensions both adding fields under the root `Query` produce a merged schema with both fields present; two extensions both attempting to add a field with the same name and a different signature produce a clear startup error. An extension can ship its own GraphQL types and have them appear in the merged schema without modifying core.
+**Acceptance criteria — met.** Two extensions adding the same `query.search` with byte-identical resolvers merge as one; with different resolvers raise a startup error naming both. An extension ships a custom Strawberry type via `@gql_type` and it appears in the merged schema without touching core. Federation directives attached to a type are appended to `__strawberry_definition__.directives` so SDL emission preserves them. Cross-extension navigation routes through `info.context["dataloaders"][name]` so N parallel resolutions collapse into one batched fetch. Schema rebuilds on extension install/uninstall log added/removed root fields and types.
 
-**Dependencies.** Cross-references Items 16, 20, 23, 40, 42.
+Tests in `src/serverframework/lib/Pydantic2Strawberry_contribution_test.py` cover identical-merge, non-identical collision, namespacing bypass, mutation/query independence, custom type registration + collision + namespacing, federation directive validation (allowed list), DataLoader batching + dedupe + sync/async + length-mismatch + non-sequence + global collision + idempotent re-registration, fresh-loader-per-request, rebuild subscriber notification, suspend/resume batching, unsubscribe, signature diff, and decorator → registry plumbing for queries/mutations/subscriptions/types/dataloaders.
+
+**Dependencies.** Cross-references Items 16 (external federation, ✅), 20 (extension install/uninstall, ✅), 23 (collision detection pattern, ✅), 40 (custom routes — REST done, GraphQL emission via this registry), 42 (event bus for cross-process subscriptions, ✅).
 
 ---
 

--- a/src/serverframework/endpoints/EP.GQL.md
+++ b/src/serverframework/endpoints/EP.GQL.md
@@ -155,19 +155,71 @@ For GraphQL generation, BLL models need:
 | Subscription not firing | Broadcast channel name matches, broadcaster initialized |
 | Auth failure | `Authorization` header present, valid JWT |
 
-## Multi-Extension Schema Composition
+## Multi-Extension Schema Composition (Item 46)
 
-Each extension's `RouterMixin`-tagged managers contribute their Query/Mutation/Subscription roots into a merged schema. Custom routes participate via the same `expose_in` flag. The merge resolves conflicts in three stages:
+CRUD-on-managers is automatic: every `RouterMixin`-tagged manager registered in the `ModelRegistry` auto-emits `query/list/create/update/delete` plus `*_created/_updated/_deleted` subscriptions. The composition contract below covers everything that **cannot** be derived from a CRUD manager: custom root fields, non-CRUD subscriptions, custom types, federation directives, and per-request DataLoaders. The registry lives in `lib/Pydantic2Strawberry.py` (`gql_contribution_registry()`).
 
-1. **Identical contributions** — same name, same signature — merge as a single field.
-2. **Non-identical contributions** on the same field name fail at startup with a clear error naming the offending extensions (mirroring the field-injection collision rule).
-3. **Namespacing under the extension name** is offered as an opt-in for extensions that explicitly want to avoid collisions.
+### Decorators
 
-Extensions can also contribute new types (not just root fields) to the schema; type-name collisions follow the same three-stage resolution.
+```python
+from serverframework.lib.Pydantic2Strawberry import (
+    gql_query, gql_mutation, gql_subscription, gql_type,
+    register_dataloader, FederationDirective,
+)
 
-Internal cross-extension navigation (e.g. extension B's resolver accesses extension A's model) participates in the same `include`-driven batched-resolver mechanism that prevents N+1 at the federation boundary. A per-request DataLoader keyed by `(model, set_of_ids)` collects N parallel resolutions of `field.related` into a single batched fetch, so cross-extension joins do not N+1 the database.
+@gql_query(name="searchProjects", return_type=SearchResults)
+async def search_projects(info, query: str, limit: int = 25) -> SearchResults: ...
 
-The merged schema is rebuilt on extension install/uninstall and the rebuild diff is logged so operators can see what changed. Extensions may declare Strawberry Federation directives on their types (`@key`, `@external`, `@requires`, `@provides`); these compose with external GraphQL provider federation.
+@gql_subscription(name="taskAssigned", return_type=str)
+async def task_assigned(info, user_id: str): ...
+```
+
+`extension_name` is auto-derived from the caller's `extensions.<name>` module path; pass it explicitly otherwise.
+
+### Three-stage collision resolution
+
+1. **Identical contributions** — same callable, return type, args, and kind — merge as one (no-op duplicate).
+2. **Non-identical** on the same emitted name — `GraphQLCompositionCollisionError` at schema build time, naming every contributing extension. Mirrors `CollisionDetection.FieldCollisionError`.
+3. **Namespacing** opt-in via `namespace=True` emits as `{extension}_{name}` (fields) or `{Extension.capitalize()}{TypeName}` (types).
+
+### Custom types and federation directives
+
+```python
+@gql_type(
+    federation_directives=(
+        FederationDirective(name="key", args={"fields": "id"}),
+        FederationDirective(name="shareable"),
+    ),
+)
+@strawberry.type
+class ProjectAggregate:
+    id: str
+    total: int
+```
+
+Allowed directives: `key`, `external`, `requires`, `provides`, `shareable`, `inaccessible`, `override`, `tag`. Anything else raises at registration. Directives are appended to `__strawberry_definition__.directives` so SDL emission preserves the framework's `Sunset` directive (Item 39). Use these to make our merged schema a valid Apollo Federation v2 subgraph composable with the inbound federation pipeline from Item 16.
+
+### Per-request DataLoader
+
+```python
+def batch_load_users(user_ids):
+    return UserManager.list(filter={"id__in": list(user_ids)})
+
+register_dataloader("users", batch_load_users)
+
+@gql_query(name="messageAuthor", return_type=User)
+async def message_author(info, message_id: str) -> User:
+    msg = await MessageManager.get(id=message_id)
+    return await info.context["dataloaders"]["users"].load(msg.author_id)
+```
+
+`RequestDataLoader.load(key)` returns a future that resolves on the next event-loop tick. Parallel `load()` calls collapse into a single `batch_load_fn(deduped_keys)` call. Length-mismatched returns and non-sequence returns raise into every awaiting future. Sync and async batch functions are both supported. The framework builds a fresh DataLoader dict per request and attaches it at `info.context["dataloaders"]`. DataLoader name collisions with the same function are idempotent; with a different function they raise.
+
+### Rebuild on install/uninstall
+
+`GraphQLManager` subscribes to registry mutations at construction. Each registration logs a structured diff (`added: [...], removed: [...]`); the merged schema is recomputed on the next `create_schema()` call so a flurry of installs only triggers one rebuild. Operators that need an immediate rebuild call `GraphQLManager.rebuild()` (Item 20 install/uninstall hot path). `suspend()/resume()` batches multiple registrations into a single notification.
+
+Custom routes (Item 40) participate in REST via the same `expose_in` flag; an extension that also wants the route on GraphQL registers the corresponding `@gql_query` / `@gql_mutation`.
 
 ## Federation of External Upstreams (Item 16)
 

--- a/src/serverframework/extensions/AbstractGraphQLProvider_test.py
+++ b/src/serverframework/extensions/AbstractGraphQLProvider_test.py
@@ -15,6 +15,9 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 import pytest
+# Module-level import so PEP 563 string annotations on nested handlers resolve
+# against module globals when FastAPI calls ``get_type_hints``.
+from fastapi import FastAPI, Request
 
 from serverframework.extensions.AbstractGraphQLProvider import AbstractGraphQLProvider
 from serverframework.extensions.AuthStrategy import APIKeyAuth
@@ -38,8 +41,6 @@ pytestmark = [pytest.mark.gql]
 
 def _make_stitching_app() -> "httpx.AsyncClient":
     """Tiny upstream that supports plain introspection (no Apollo SDL)."""
-
-    from fastapi import FastAPI, Request
 
     app = FastAPI()
 
@@ -98,8 +99,6 @@ def _make_stitching_app() -> "httpx.AsyncClient":
 
 def _make_apollo_app() -> "httpx.AsyncClient":
     """Upstream that implements the Apollo Federation v2 SDL probe."""
-
-    from fastapi import FastAPI, Request
 
     app = FastAPI()
     SDL = (

--- a/src/serverframework/extensions/EXT.Contracts.md
+++ b/src/serverframework/extensions/EXT.Contracts.md
@@ -598,7 +598,7 @@ Service driven by a cron-like schedule.
 ### `StreamingService` (class)
 
 - Module: `serverframework.logic.AbstractService`
-- Signature: `StreamingService(requester_id: 'str', db: 'Optional[Session]' = None, interval_seconds: 'int' = 60, max_failures: 'int' = 3, retry_delay_seconds: 'int' = 5, service_id: 'Optional[str]' = None, **kwargs)`
+- Signature: `StreamingService(*args: 'Any', state_store: 'Optional[Callable[..., Any]]' = None, event_bus: 'Optional[Any]' = None, **kwargs: 'Any') -> 'None'`
 - Live docstring: Long-lived connection-oriented work.
 
 Service consuming or producing a continuous stream.

--- a/src/serverframework/extensions/Federation_Matrix_test.py
+++ b/src/serverframework/extensions/Federation_Matrix_test.py
@@ -25,6 +25,9 @@ import os
 from typing import Any, Dict, List
 
 import pytest
+# Module-level import so PEP 563 string annotations on nested handlers resolve
+# against module globals when FastAPI calls ``get_type_hints``.
+from fastapi import FastAPI, Request
 
 from serverframework.extensions.AbstractFederationMatrixTest import (
     AbstractFederationMatrixTest,
@@ -111,7 +114,6 @@ def _build_gql_upstream_transport() -> GQLUpstreamTransport:
     """
 
     import httpx
-    from fastapi import FastAPI, Request
 
     SEED = {
         "1": {"id": "1", "name": "Alpha", "size": 10},
@@ -185,7 +187,6 @@ def _build_rest_upstream_transport() -> RESTUpstreamTransport:
     """Build a REST transport pointing at an in-process FastAPI widget app."""
 
     import httpx
-    from fastapi import FastAPI
 
     SEED = {
         "1": {"id": "1", "name": "Alpha", "size": 10},
@@ -218,10 +219,12 @@ def _build_rest_upstream_transport() -> RESTUpstreamTransport:
     async def delete_w(wid: str):
         return {"deleted": True, "id": wid}
 
-    sync_client = httpx.Client(
-        transport=httpx.ASGITransport(app=app),
-        base_url="http://upstream",
-    )
+    # ``httpx.Client`` no longer drives ``ASGITransport`` (httpx 0.28+ made
+    # the ASGI transport async-only). Use FastAPI's TestClient, which wraps
+    # the same ASGI app behind a sync interface.
+    from fastapi.testclient import TestClient
+
+    sync_client = TestClient(app, base_url="http://upstream")
 
     class _SyncHTTP:
         """Sync HTTP client adapter that ``RESTUpstreamTransport.send_sync`` wants."""

--- a/src/serverframework/lib/Federation_Bootstrap_test.py
+++ b/src/serverframework/lib/Federation_Bootstrap_test.py
@@ -19,6 +19,9 @@ from typing import Any, Dict, List
 
 import httpx
 import pytest
+# Module-level import so PEP 563 string annotations on nested handlers resolve
+# against module globals when FastAPI calls ``get_type_hints``.
+from fastapi import FastAPI, Request
 
 from serverframework.lib.Federation_Bootstrap import (
     FederationCommitReport,
@@ -50,9 +53,12 @@ class _RecordingRegistry:
 # ---------------------------------------------------------------------------
 
 
-def _build_strict_gql_upstream() -> "httpx.Client":
-    from fastapi import FastAPI, Request
+def _build_strict_gql_upstream():
+    """Build a sync HTTP-shaped client backed by a FastAPI ASGI app.
 
+    httpx 0.28+ removed sync support from ``ASGITransport``; FastAPI's
+    ``TestClient`` keeps the same ASGI app behind a sync facade.
+    """
     app = FastAPI()
 
     @app.post("/graphql")
@@ -82,9 +88,8 @@ def _build_strict_gql_upstream() -> "httpx.Client":
             return {"data": result.data}
         return {"data": {"__typename": "Query"}}
 
-    return httpx.Client(
-        transport=httpx.ASGITransport(app=app), base_url="http://upstream"
-    )
+    from fastapi.testclient import TestClient
+    return TestClient(app, base_url="http://upstream")
 
 
 # ---------------------------------------------------------------------------

--- a/src/serverframework/lib/LIB.Overview.md
+++ b/src/serverframework/lib/LIB.Overview.md
@@ -17,7 +17,7 @@ The `src/lib` directory contains foundational utilities and abstractions that po
 
 ### API Generation
 - **[LIB.Pydantic2FastAPI.md](./LIB.Pydantic2FastAPI.md)**: Automatic FastAPI router generation from BLL managers through RouterMixin pattern with authentication and documentation support
-- **[Pydantic2Strawberry.md](./Pydantic2Strawberry.md)**: Automatic GraphQL schema generation from Pydantic models using Strawberry GraphQL
+- **[Pydantic2Strawberry.md](./Pydantic2Strawberry.md)**: Automatic GraphQL schema generation from Pydantic models using Strawberry GraphQL, plus the Item 46 composition contract for extension-contributed roots, custom types, federation directives, and per-request DataLoaders
 
 ### External Federation
 - **[LIB.Federation.md](./LIB.Federation.md)**: GraphQL and REST upstream federation. `Federation_GQL.py` ingests GraphQL upstreams (Apollo Federation v2, schema stitching, namespacing), pushes selection sets through `BatchedFieldResolver`, and projects upstreams onto either inbound surface. `Federation_REST.py` lifts OpenAPI specs into Pydantic models so the existing `Pydantic2FastAPI`/`Pydantic2Strawberry` pipelines project REST upstreams onto both surfaces. `Federation_Bootstrap.py` runs the introspect→transform→register→lift pipeline at startup.

--- a/src/serverframework/lib/Pydantic2Strawberry.md
+++ b/src/serverframework/lib/Pydantic2Strawberry.md
@@ -1,10 +1,10 @@
 # Pydantic2Strawberry
 
-This module provides automatic GraphQL schema generation from Pydantic models using Strawberry GraphQL.
+This module provides automatic GraphQL schema generation from Pydantic models using Strawberry GraphQL. It also hosts the **GraphQL composition contract (Item 46)** for our own extensions: custom Query / Mutation / Subscription roots, custom types, federation directives, and per-request DataLoaders are registered into a process-wide registry that the schema builder consumes alongside the auto-generated CRUD surface.
 
 ## Overview
 
-The `Pydantic2Strawberry` module dynamically generates GraphQL schemas from Pydantic models registered in the ModelRegistry. It creates complete CRUD operations (queries, mutations, subscriptions) for each model without requiring manual schema definitions.
+The `Pydantic2Strawberry` module dynamically generates GraphQL schemas from Pydantic models registered in the ModelRegistry. It creates complete CRUD operations (queries, mutations, subscriptions) for each model without requiring manual schema definitions, then folds in extension-contributed roots and types from `GraphQLContributionRegistry`.
 
 ## Key Components
 
@@ -103,6 +103,53 @@ The module handles extension models specially:
 - Extension enums get prefixed with the extension name to avoid collisions
 - Type names from extensions are prefixed to ensure uniqueness
 - Extension-specific resolver handling
+
+## GraphQL Composition Contract (Item 46)
+
+Distinct from external federation (`Federation_GQL.py`, Item 16): this contract governs how *our own* extensions contribute non-CRUD surface to the merged schema. The CRUD-on-managers path is unchanged and continues to auto-emit `query/list/create/update/delete` plus `*_created/_updated/_deleted` subscriptions per `RouterMixin`-tagged manager.
+
+### Registration surface
+
+Extensions register four kinds of contribution into the process-wide `GraphQLContributionRegistry` (accessor: `gql_contribution_registry()`):
+
+- **Root fields** via `@gql_query`, `@gql_mutation`, `@gql_subscription`. Each carries `return_type`, optional `args`, optional `description`, optional `extension_name` (auto-derived from the caller's `extensions.<name>` module path), `namespace=False`, and `priority=50`.
+- **Custom types** via `@gql_type` applied to a Strawberry-decorated class. Carries an optional `name` override, `federation_directives` tuple, and `namespace`.
+- **DataLoaders** via `register_dataloader(name, batch_load_fn)`. Names are global; resolvers retrieve the per-request loader via `info.context["dataloaders"][name]`.
+- **Federation directives** via `FederationDirective(name, args)` attached to a `TypeContribution`. Allowed names: `key`, `external`, `requires`, `provides`, `shareable`, `inaccessible`, `override`, `tag`. Anything else raises at registration time.
+
+### Three-stage collision resolution
+
+When two extensions contribute the same emitted root-field name or type name, the registry resolves as follows:
+
+1. **Identical** — same callable, same return type, same args, same kind → merged as one. Duplicate registrations are no-ops.
+2. **Non-identical** — `GraphQLCompositionCollisionError` at schema build time, naming every contributing extension and the offending field/type. Mirrors `CollisionDetection.FieldCollisionError`.
+3. **Namespaced opt-in** — `namespace=True` on the contribution emits the field as `{extension}_{name}` (or the type as `{Extension.capitalize()}{TypeName}`), bypassing both. Two extensions both wanting `query.search` declare `namespace=True` and emit `query.ext_a_search` and `query.ext_b_search`.
+
+DataLoader name collisions follow a stricter rule: the same name with the same `batch_load_fn` is idempotent (so multiple consumers can share a loader); the same name with a different function raises immediately.
+
+### Per-request DataLoader
+
+`RequestDataLoader.load(key)` returns a `Future` that resolves once the deferred batch fires on the next event-loop tick. Parallel resolutions of `thing.related_in_other_extension` collapse into a single `batch_load_fn(deduped_keys)` call. Sync and async batch functions are both accepted. The framework constructs a fresh DataLoader per request via `build_request_dataloaders()` and exposes the dict at `info.context["dataloaders"]`. Length-mismatched returns and non-sequence returns raise into every awaiting future.
+
+### Rebuild on extension install/uninstall
+
+`GraphQLManager` subscribes to `GraphQLContributionRegistry` mutations at construction. Registrations log a structured diff (`"GraphQL contribution registry changed -- added: [...], removed: [...]"`); the schema is recomputed on the next `create_schema()` call so a flurry of installs only triggers one rebuild. Operators that need an immediate rebuild call `GraphQLManager.rebuild()` directly. The `suspend()/resume()` pair on the registry batches multiple registrations into a single notification.
+
+### Federation directive emission
+
+Directives attached to a type contribution are appended to `__strawberry_definition__.directives` so Strawberry emits them in SDL. The framework's own `Sunset` directive (Item 39) is preserved when extension-contributed directives are added. Use `key`/`shareable`/etc. to make our merged schema a valid Apollo Federation v2 subgraph; this composes with the inbound federation pipeline from Item 16.
+
+### Public API
+
+```python
+from serverframework.lib.Pydantic2Strawberry import (
+    gql_query, gql_mutation, gql_subscription, gql_type,
+    register_dataloader, FederationDirective,
+    gql_contribution_registry, reset_gql_contribution_registry,
+    GraphQLCompositionCollisionError, FieldKind,
+    RequestDataLoader, build_request_dataloaders,
+)
+```
 
 ## Error Handling
 

--- a/src/serverframework/lib/Pydantic2Strawberry.py
+++ b/src/serverframework/lib/Pydantic2Strawberry.py
@@ -1,6 +1,8 @@
+import asyncio
+import inspect as _inspect
 import json
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field as _dc_field
 from datetime import date, datetime
 from enum import Enum, IntEnum
 from typing import (
@@ -8,8 +10,11 @@ from typing import (
     AsyncGenerator,
     Callable,
     Dict,
+    Hashable,
+    Iterable,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -223,6 +228,59 @@ def _versioned_field(resolver: Any, manager_class: Any) -> Any:
     return strawberry.field(resolver, **kwargs)
 
 
+# -- Item 46 helpers ----------------------------------------------------------
+
+
+def _apply_federation_directives(type_class: type, directives: Tuple[Any, ...]) -> None:
+    """Attach Apollo Federation v2 directive metadata to a type.
+
+    Strawberry's federation support reads ``__strawberry_definition__.directives``
+    when emitting SDL. We append rather than replace so the framework's own
+    ``Sunset`` directive (Item 39) survives this call.
+    """
+    if not directives:
+        return
+    definition = getattr(type_class, "__strawberry_definition__", None)
+    if definition is None:
+        logger.warning(
+            f"Cannot attach federation directives to {type_class.__name__}: "
+            "type is not a Strawberry-decorated class."
+        )
+        return
+    existing = list(getattr(definition, "directives", []) or [])
+    for d in directives:
+        existing.append(d)
+    try:
+        definition.directives = existing
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            f"Failed to attach federation directives to {type_class.__name__}: {e}"
+        )
+
+
+def _diff_signatures(
+    previous: Tuple[Tuple[str, ...], ...],
+    current: Tuple[Tuple[str, ...], ...],
+) -> Tuple[Set[str], Set[str]]:
+    """Return ``(added, removed)`` between two signature snapshots.
+
+    Each signature is ``(query, mutation, subscription, types)``; entries are
+    namespaced by kind so the diff is unambiguous.
+    """
+    labels = ("query", "mutation", "subscription", "type")
+
+    def _flatten(sig: Tuple[Tuple[str, ...], ...]) -> Set[str]:
+        flat: Set[str] = set()
+        for label, names in zip(labels, sig):
+            for name in names:
+                flat.add(f"{label}:{name}")
+        return flat
+
+    prev = _flatten(previous)
+    curr = _flatten(current)
+    return curr - prev, prev - curr
+
+
 # Removed FilterTypeGenerator - functionality moved to GraphQLManager
 
 
@@ -235,16 +293,485 @@ def _versioned_field(resolver: Any, manager_class: Any) -> Any:
 # Removed ResolverGenerator - functionality moved to GraphQLManager
 
 
+# ---------------------------------------------------------------------------
+# Item 46 -- composition contract for our own extensions
+# ---------------------------------------------------------------------------
+# Distinct from the external-federation work in ``Federation_GQL.py``: this
+# block is how *our own* extensions contribute Query / Mutation / Subscription
+# root fields, custom types, federation directives, and per-request DataLoaders
+# into the merged schema. The CRUD-on-managers path is unchanged.
+#
+# Collision rule (mirrors ``CollisionDetection.FieldCollisionError``):
+#   - Same root field name with byte-identical resolver + signature -> merge.
+#   - Same root field name with non-identical signature -> startup-time
+#     :class:`GraphQLCompositionCollisionError` naming both extensions.
+#   - Same type name with non-identical body -> same error.
+#   - Namespacing under the extension name is opt-in via ``namespace=True``.
+
+
+class GraphQLCompositionCollisionError(Exception):
+    """Two extensions registered conflicting GraphQL contributions."""
+
+    def __init__(
+        self,
+        kind: str,
+        name: str,
+        extensions: Sequence[str],
+        detail: Optional[str] = None,
+    ) -> None:
+        self.kind = kind
+        self.name = name
+        self.extensions = list(extensions)
+        suffix = f" -- {detail}" if detail else ""
+        super().__init__(
+            f"GraphQL {kind} collision on '{name}': "
+            f"contributed by {sorted(set(self.extensions))}. "
+            "Either rename one contribution, opt in to namespacing "
+            "(`namespace=True`), or ensure both contributions are byte-identical"
+            f"{suffix}."
+        )
+
+
+class FieldKind(str, Enum):
+    QUERY = "query"
+    MUTATION = "mutation"
+    SUBSCRIPTION = "subscription"
+
+
+@dataclass(frozen=True)
+class FederationDirective:
+    """Apollo Federation v2 directive applied to a contributed type."""
+
+    name: str
+    args: Dict[str, Any] = _dc_field(default_factory=dict)
+
+
+_ALLOWED_FED_DIRECTIVES: Set[str] = {
+    "key",
+    "external",
+    "requires",
+    "provides",
+    "shareable",
+    "inaccessible",
+    "override",
+    "tag",
+}
+
+
+@dataclass
+class FieldContribution:
+    """A root-field contribution from an extension."""
+
+    extension_name: str
+    kind: FieldKind
+    name: str
+    resolver: Callable[..., Any]
+    return_type: Any
+    args: Dict[str, Any] = _dc_field(default_factory=dict)
+    description: Optional[str] = None
+    namespace: bool = False
+    priority: int = 50
+
+    @property
+    def emitted_name(self) -> str:
+        if self.namespace:
+            return f"{self.extension_name}_{self.name}"
+        return self.name
+
+
+@dataclass
+class TypeContribution:
+    """A custom type contribution (not backed by a BLL manager)."""
+
+    extension_name: str
+    type_class: type
+    name: Optional[str] = None
+    federation_directives: Tuple[FederationDirective, ...] = ()
+    namespace: bool = False
+
+    @property
+    def emitted_name(self) -> str:
+        base = self.name or self.type_class.__name__
+        if self.namespace:
+            return f"{self.extension_name.capitalize()}{base}"
+        return base
+
+
+DataLoaderBatchFn = Callable[[Sequence[Hashable]], Any]
+
+
+@dataclass
+class DataLoaderSpec:
+    """Per-request DataLoader registration."""
+
+    extension_name: str
+    name: str
+    batch_load_fn: DataLoaderBatchFn
+    description: Optional[str] = None
+
+
+RebuildCallback = Callable[[], None]
+
+
+class GraphQLContributionRegistry:
+    """Process-wide store of extension-contributed GraphQL surface."""
+
+    def __init__(self) -> None:
+        self._fields: Dict[FieldKind, Dict[str, List[FieldContribution]]] = {
+            FieldKind.QUERY: {},
+            FieldKind.MUTATION: {},
+            FieldKind.SUBSCRIPTION: {},
+        }
+        self._types: Dict[str, List[TypeContribution]] = {}
+        self._dataloaders: Dict[str, DataLoaderSpec] = {}
+        self._rebuild_subscribers: List[RebuildCallback] = []
+        self._suspended: bool = False
+
+    def register_field(self, contribution: FieldContribution) -> None:
+        bucket = self._fields[contribution.kind].setdefault(
+            contribution.emitted_name, []
+        )
+        bucket.append(contribution)
+        self._notify()
+
+    def register_type(self, contribution: TypeContribution) -> None:
+        for d in contribution.federation_directives:
+            if d.name not in _ALLOWED_FED_DIRECTIVES:
+                raise ValueError(
+                    f"Unsupported federation directive '@{d.name}' on type "
+                    f"'{contribution.emitted_name}'. Allowed: "
+                    f"{sorted(_ALLOWED_FED_DIRECTIVES)}."
+                )
+        self._types.setdefault(contribution.emitted_name, []).append(contribution)
+        self._notify()
+
+    def register_dataloader(self, spec: DataLoaderSpec) -> None:
+        existing = self._dataloaders.get(spec.name)
+        if existing is not None and existing.batch_load_fn is not spec.batch_load_fn:
+            raise GraphQLCompositionCollisionError(
+                kind="dataloader",
+                name=spec.name,
+                extensions=[existing.extension_name, spec.extension_name],
+                detail="DataLoader names are global; rename one or share the function.",
+            )
+        self._dataloaders[spec.name] = spec
+        self._notify()
+
+    def fields(self, kind: FieldKind) -> Dict[str, List[FieldContribution]]:
+        return {k: list(v) for k, v in self._fields[kind].items()}
+
+    def types(self) -> Dict[str, List[TypeContribution]]:
+        return {k: list(v) for k, v in self._types.items()}
+
+    def dataloaders(self) -> Dict[str, DataLoaderSpec]:
+        return dict(self._dataloaders)
+
+    def subscribe_rebuild(self, cb: RebuildCallback) -> None:
+        self._rebuild_subscribers.append(cb)
+
+    def unsubscribe_rebuild(self, cb: RebuildCallback) -> None:
+        if cb in self._rebuild_subscribers:
+            self._rebuild_subscribers.remove(cb)
+
+    def _notify(self) -> None:
+        if self._suspended:
+            return
+        for cb in list(self._rebuild_subscribers):
+            try:
+                cb()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"GQL rebuild subscriber failed: {e}")
+
+    def suspend(self) -> "GraphQLContributionRegistry":
+        """Defer rebuild notifications until :meth:`resume` is called."""
+        self._suspended = True
+        return self
+
+    def resume(self) -> None:
+        self._suspended = False
+        self._notify()
+
+    def resolve_fields(self, kind: FieldKind) -> Dict[str, FieldContribution]:
+        winners: Dict[str, FieldContribution] = {}
+        for emitted_name, contributions in self._fields[kind].items():
+            if len(contributions) == 1:
+                winners[emitted_name] = contributions[0]
+                continue
+            if all(_field_identical(c, contributions[0]) for c in contributions[1:]):
+                winners[emitted_name] = contributions[0]
+                continue
+            raise GraphQLCompositionCollisionError(
+                kind=f"{kind.value} field",
+                name=emitted_name,
+                extensions=[c.extension_name for c in contributions],
+            )
+        return winners
+
+    def resolve_types(self) -> Dict[str, TypeContribution]:
+        winners: Dict[str, TypeContribution] = {}
+        for emitted_name, contributions in self._types.items():
+            if len(contributions) == 1:
+                winners[emitted_name] = contributions[0]
+                continue
+            if all(_type_identical(c, contributions[0]) for c in contributions[1:]):
+                winners[emitted_name] = contributions[0]
+                continue
+            raise GraphQLCompositionCollisionError(
+                kind="type",
+                name=emitted_name,
+                extensions=[c.extension_name for c in contributions],
+            )
+        return winners
+
+    def reset(self) -> None:
+        for kind in FieldKind:
+            self._fields[kind].clear()
+        self._types.clear()
+        self._dataloaders.clear()
+        self._rebuild_subscribers.clear()
+        self._suspended = False
+
+
+def _field_identical(a: FieldContribution, b: FieldContribution) -> bool:
+    return (
+        a.resolver is b.resolver
+        and a.return_type == b.return_type
+        and a.args == b.args
+        and a.kind == b.kind
+    )
+
+
+def _type_identical(a: TypeContribution, b: TypeContribution) -> bool:
+    return (
+        a.type_class is b.type_class
+        and a.federation_directives == b.federation_directives
+    )
+
+
+_GLOBAL_CONTRIBUTION_REGISTRY = GraphQLContributionRegistry()
+
+
+def gql_contribution_registry() -> GraphQLContributionRegistry:
+    """Process-wide contribution registry singleton."""
+    return _GLOBAL_CONTRIBUTION_REGISTRY
+
+
+def reset_gql_contribution_registry() -> None:
+    """Test helper -- clear the process-wide contribution registry."""
+    _GLOBAL_CONTRIBUTION_REGISTRY.reset()
+
+
+def _extension_name_for_caller(explicit: Optional[str]) -> str:
+    """Best-effort extension name from the caller's module path."""
+    if explicit:
+        return explicit
+    frame = _inspect.currentframe()
+    try:
+        outer = frame.f_back if frame else None
+        while outer is not None:
+            mod = outer.f_globals.get("__name__", "")
+            parts = mod.split(".")
+            if "extensions" in parts:
+                idx = parts.index("extensions")
+                if idx + 1 < len(parts):
+                    return parts[idx + 1]
+            outer = outer.f_back
+    finally:
+        del frame
+    return "core"
+
+
+def _make_field_decorator(kind: FieldKind):
+    def decorator(
+        *,
+        return_type: Any,
+        name: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+        extension_name: Optional[str] = None,
+        namespace: bool = False,
+        priority: int = 50,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def deco(fn: Callable[..., Any]) -> Callable[..., Any]:
+            field_name = name or fn.__name__
+            ext = _extension_name_for_caller(extension_name)
+            _GLOBAL_CONTRIBUTION_REGISTRY.register_field(
+                FieldContribution(
+                    extension_name=ext,
+                    kind=kind,
+                    name=field_name,
+                    resolver=fn,
+                    return_type=return_type,
+                    args=dict(args or {}),
+                    description=description,
+                    namespace=namespace,
+                    priority=priority,
+                )
+            )
+            return fn
+
+        return deco
+
+    return decorator
+
+
+gql_query = _make_field_decorator(FieldKind.QUERY)
+gql_mutation = _make_field_decorator(FieldKind.MUTATION)
+gql_subscription = _make_field_decorator(FieldKind.SUBSCRIPTION)
+
+
+def gql_type(
+    *,
+    name: Optional[str] = None,
+    federation_directives: Iterable[FederationDirective] = (),
+    extension_name: Optional[str] = None,
+    namespace: bool = False,
+) -> Callable[[type], type]:
+    """Register a Strawberry-decorated type as an extension contribution."""
+
+    def deco(cls: type) -> type:
+        ext = _extension_name_for_caller(extension_name)
+        _GLOBAL_CONTRIBUTION_REGISTRY.register_type(
+            TypeContribution(
+                extension_name=ext,
+                type_class=cls,
+                name=name,
+                federation_directives=tuple(federation_directives),
+                namespace=namespace,
+            )
+        )
+        return cls
+
+    return deco
+
+
+def register_dataloader(
+    name: str,
+    batch_load_fn: DataLoaderBatchFn,
+    *,
+    extension_name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> None:
+    """Register a per-request DataLoader.
+
+    Resolvers retrieve it via ``info.context['dataloaders'][name]`` and call
+    ``.load(key)`` to enqueue a fetch; the framework batches all loads in
+    the request into a single ``batch_load_fn(keys)`` call.
+    """
+    ext = _extension_name_for_caller(extension_name)
+    _GLOBAL_CONTRIBUTION_REGISTRY.register_dataloader(
+        DataLoaderSpec(
+            extension_name=ext,
+            name=name,
+            batch_load_fn=batch_load_fn,
+            description=description,
+        )
+    )
+
+
+class RequestDataLoader:
+    """Minimal per-request DataLoader.
+
+    ``load(key)`` returns an awaitable that resolves once the deferred batch
+    fires. Batches fire on the next event-loop tick after the first ``load``,
+    so all parallel resolutions of ``thing.related`` collapse into a single
+    ``batch_load_fn(keys)`` call.
+    """
+
+    def __init__(self, batch_load_fn: DataLoaderBatchFn) -> None:
+        self._batch_load_fn = batch_load_fn
+        self._queue: List[Hashable] = []
+        self._futures: Dict[Hashable, "asyncio.Future[Any]"] = {}
+        self._scheduled: bool = False
+
+    def load(self, key: Hashable) -> "asyncio.Future[Any]":
+        loop = asyncio.get_event_loop()
+        if key in self._futures:
+            return self._futures[key]
+        fut: "asyncio.Future[Any]" = loop.create_future()
+        self._futures[key] = fut
+        self._queue.append(key)
+        if not self._scheduled:
+            self._scheduled = True
+            loop.call_soon(lambda: asyncio.ensure_future(self._fire()))
+        return fut
+
+    async def _fire(self) -> None:
+        keys = list(self._queue)
+        self._queue.clear()
+        self._scheduled = False
+        try:
+            result = self._batch_load_fn(keys)
+            if _inspect.isawaitable(result):
+                result = await result
+        except Exception as e:  # noqa: BLE001
+            for key in keys:
+                fut = self._futures.pop(key, None)
+                if fut is not None and not fut.done():
+                    fut.set_exception(e)
+            return
+        if not isinstance(result, (list, tuple)):
+            err = TypeError(
+                f"DataLoader batch_load_fn must return a sequence aligned with"
+                f" keys; got {type(result).__name__}."
+            )
+            for key in keys:
+                fut = self._futures.pop(key, None)
+                if fut is not None and not fut.done():
+                    fut.set_exception(err)
+            return
+        if len(result) != len(keys):
+            err = ValueError(
+                f"DataLoader batch_load_fn returned {len(result)} results for"
+                f" {len(keys)} keys; lengths must match."
+            )
+            for key in keys:
+                fut = self._futures.pop(key, None)
+                if fut is not None and not fut.done():
+                    fut.set_exception(err)
+            return
+        for key, value in zip(keys, result):
+            fut = self._futures.pop(key, None)
+            if fut is not None and not fut.done():
+                fut.set_result(value)
+
+
+def build_request_dataloaders(
+    registry: Optional[GraphQLContributionRegistry] = None,
+) -> Dict[str, RequestDataLoader]:
+    """Build a fresh per-request DataLoader for every registered spec."""
+    reg = registry or _GLOBAL_CONTRIBUTION_REGISTRY
+    return {name: RequestDataLoader(spec.batch_load_fn) for name, spec in reg.dataloaders().items()}
+
+
 class GraphQLManager(ErrorHandlerMixin):
     """Main GraphQL schema manager that generates schemas from ModelRegistry"""
 
-    def __init__(self, model_registry: ModelRegistry) -> None:
-        """Initialize SchemaManager with ModelRegistry"""
+    def __init__(
+        self,
+        model_registry: ModelRegistry,
+        contribution_registry: Optional[GraphQLContributionRegistry] = None,
+    ) -> None:
+        """Initialize SchemaManager with ModelRegistry.
+
+        ``contribution_registry`` defaults to the process-wide singleton from
+        :mod:`serverframework.lib.GraphQLContribution`. Item 46 -- extension-
+        contributed Query/Mutation/Subscription roots, custom types,
+        federation directives, and DataLoaders are merged into the schema
+        on every :meth:`create_schema` call. The manager subscribes to
+        registry mutations so a subsequent extension install/uninstall
+        rebuilds the schema with a logged diff.
+        """
         if not model_registry:
             raise ValueError("ModelRegistry instance is required")
 
         self.model_registry = model_registry
         self.broadcast = Broadcast("memory://")
+        self._contributions: GraphQLContributionRegistry = (
+            contribution_registry or gql_contribution_registry()
+        )
+        self._last_schema_signature: Optional[Tuple[Tuple[str, ...], ...]] = None
+        self._contributions.subscribe_rebuild(self._on_contributions_changed)
 
         # Legacy generator references for backward compatibility with tests
         class MockGenerator:
@@ -303,6 +830,10 @@ class GraphQLManager(ErrorHandlerMixin):
         # Generate all types, queries, mutations, and subscriptions
         self._generate_all_components()
 
+        # Item 46 -- merge extension-contributed roots, custom types, and
+        # federation directives. Collisions raise here at build time.
+        self._apply_contributions()
+
         # Create Query, Mutation, and Subscription types
         query_type = self._create_query_type()
         mutation_type = self._create_mutation_type()
@@ -347,7 +878,119 @@ class GraphQLManager(ErrorHandlerMixin):
             extensions=schema_extensions,
         )
 
+        self._last_schema_signature = self._snapshot_signature()
         return schema
+
+    # -- Item 46 ------------------------------------------------------------
+
+    def _apply_contributions(self) -> None:
+        """Merge extension-contributed roots/types/directives into the schema.
+
+        Walks the contribution registry, applies the three-stage collision
+        rule, and folds the winners into ``_query_fields`` /
+        ``_mutation_fields`` / ``_subscription_fields``. Custom types are
+        registered as known type names so collision detection in
+        ``_create_gql_type_from_model`` doesn't double-register the same name.
+        """
+        if not hasattr(self, "_global_type_names"):
+            self._global_type_names: Dict[str, str] = {}
+
+        for kind, bucket in (
+            (FieldKind.QUERY, self._query_fields),
+            (FieldKind.MUTATION, self._mutation_fields),
+            (FieldKind.SUBSCRIPTION, self._subscription_fields),
+        ):
+            winners = self._contributions.resolve_fields(kind)
+            for emitted_name, contribution in winners.items():
+                if emitted_name in bucket:
+                    logger.warning(
+                        f"Extension contribution '{emitted_name}' overrides an"
+                        f" auto-generated {kind.value} field; the extension"
+                        f" version wins."
+                    )
+                bucket[emitted_name] = self._wrap_contribution(contribution)
+
+        for emitted_name, contribution in self._contributions.resolve_types().items():
+            self._global_type_names.setdefault(
+                emitted_name,
+                f"{contribution.type_class.__module__}.{contribution.type_class.__name__}",
+            )
+            if contribution.federation_directives:
+                _apply_federation_directives(
+                    contribution.type_class, contribution.federation_directives
+                )
+
+    def _wrap_contribution(self, contribution: FieldContribution) -> Any:
+        """Wrap a contribution's resolver as a Strawberry field/subscription.
+
+        Resolvers receive the Strawberry ``Info`` plus any declared ``args``.
+        Subscriptions are wrapped with ``strawberry.subscription``; queries
+        and mutations with ``strawberry.field``.
+        """
+        resolver = contribution.resolver
+        if contribution.kind == FieldKind.SUBSCRIPTION:
+            return strawberry.subscription(resolver, description=contribution.description)
+        return strawberry.field(resolver, description=contribution.description)
+
+    def _on_contributions_changed(self) -> None:
+        """Subscriber callback for registry mutations.
+
+        Logs the diff. The actual schema rebuild is performed lazily on the
+        next :meth:`create_schema` call (so a flurry of extension installs
+        only triggers one rebuild). Callers that need an immediate rebuild
+        (extension install/uninstall hot path) call :meth:`rebuild`.
+        """
+        new_sig = self._snapshot_signature()
+        if self._last_schema_signature is None:
+            return
+        added, removed = _diff_signatures(self._last_schema_signature, new_sig)
+        if added or removed:
+            logger.info(
+                f"GraphQL contribution registry changed -- added: {sorted(added)},"
+                f" removed: {sorted(removed)}. Schema will rebuild on next access."
+            )
+
+    def rebuild(self) -> strawberry.Schema:
+        """Rebuild the merged schema and log the structural diff.
+
+        Called by the extension install/uninstall path (Item 20) when the
+        operator wants the new contributions visible immediately rather than
+        on the next scheduled rebuild.
+        """
+        previous = self._last_schema_signature
+        # Reset the per-call buckets so a rebuild is a clean recomputation
+        # rather than an additive overlay.
+        self._query_fields.clear()
+        self._mutation_fields.clear()
+        self._subscription_fields.clear()
+        schema = self.create_schema()
+        if previous is not None:
+            added, removed = _diff_signatures(previous, self._last_schema_signature or ())
+            if added or removed:
+                logger.info(
+                    f"GraphQL schema rebuilt -- added: {sorted(added)},"
+                    f" removed: {sorted(removed)}."
+                )
+        return schema
+
+    def _snapshot_signature(self) -> Tuple[Tuple[str, ...], ...]:
+        """Return a structural signature for diffing across rebuilds."""
+        return (
+            tuple(sorted(self._query_fields.keys())),
+            tuple(sorted(self._mutation_fields.keys())),
+            tuple(sorted(self._subscription_fields.keys())),
+            tuple(sorted(getattr(self, "_global_type_names", {}).keys())),
+        )
+
+    def build_request_context(self, base_context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Build the per-request GraphQL context with DataLoaders attached.
+
+        FastAPI/Strawberry callers pass the result as ``context_getter`` so
+        every resolver finds ``info.context['dataloaders']``.
+        """
+        ctx: Dict[str, Any] = dict(base_context or {})
+        ctx["dataloaders"] = build_request_dataloaders(self._contributions)
+        return ctx
 
     def _generate_all_components(self) -> None:
         """Generate all GraphQL components from models"""

--- a/src/serverframework/lib/Pydantic2Strawberry_contribution_test.py
+++ b/src/serverframework/lib/Pydantic2Strawberry_contribution_test.py
@@ -1,0 +1,428 @@
+"""Tests for the Item 46 GraphQL composition contract.
+
+Covers the contribution registry, three-stage collision resolution, custom
+type registration, federation directive attachment, the per-request
+DataLoader, and rebuild-on-mutation diff logging. No mocks: real
+``GraphQLContributionRegistry`` instances and real ``RequestDataLoader``
+fires drive the assertions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List, Optional
+
+import pytest
+import strawberry
+
+from serverframework.lib.Pydantic2Strawberry import (
+    DataLoaderSpec,
+    FederationDirective,
+    FieldContribution,
+    FieldKind,
+    GraphQLCompositionCollisionError,
+    GraphQLContributionRegistry,
+    RequestDataLoader,
+    TypeContribution,
+    _diff_signatures,
+    build_request_dataloaders,
+    gql_contribution_registry,
+    gql_mutation,
+    gql_query,
+    gql_subscription,
+    gql_type,
+    register_dataloader,
+    reset_gql_contribution_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry: three-stage collision rule
+# ---------------------------------------------------------------------------
+
+
+def _query_contribution(
+    extension: str,
+    name: str,
+    resolver: Any,
+    return_type: Any = str,
+    args: Optional[dict] = None,
+    namespace: bool = False,
+) -> FieldContribution:
+    return FieldContribution(
+        extension_name=extension,
+        kind=FieldKind.QUERY,
+        name=name,
+        resolver=resolver,
+        return_type=return_type,
+        args=dict(args or {}),
+        namespace=namespace,
+    )
+
+
+def test_single_contribution_resolves_as_winner() -> None:
+    reg = GraphQLContributionRegistry()
+    fn = lambda info: "ok"  # noqa: E731
+    reg.register_field(_query_contribution("ext_a", "search", fn))
+    winners = reg.resolve_fields(FieldKind.QUERY)
+    assert "search" in winners
+    assert winners["search"].extension_name == "ext_a"
+
+
+def test_identical_contributions_merge_to_one() -> None:
+    reg = GraphQLContributionRegistry()
+    fn = lambda info: "ok"  # noqa: E731
+    reg.register_field(_query_contribution("ext_a", "search", fn))
+    reg.register_field(_query_contribution("ext_b", "search", fn))
+    winners = reg.resolve_fields(FieldKind.QUERY)
+    assert len(winners) == 1
+    assert winners["search"].resolver is fn
+
+
+def test_non_identical_contributions_collide() -> None:
+    reg = GraphQLContributionRegistry()
+    reg.register_field(_query_contribution("ext_a", "search", lambda info: "a"))
+    reg.register_field(_query_contribution("ext_b", "search", lambda info: "b"))
+    with pytest.raises(GraphQLCompositionCollisionError) as excinfo:
+        reg.resolve_fields(FieldKind.QUERY)
+    msg = str(excinfo.value)
+    assert "ext_a" in msg and "ext_b" in msg
+    assert "search" in msg
+
+
+def test_namespacing_bypasses_collision() -> None:
+    reg = GraphQLContributionRegistry()
+    reg.register_field(
+        _query_contribution("ext_a", "search", lambda info: "a", namespace=True)
+    )
+    reg.register_field(
+        _query_contribution("ext_b", "search", lambda info: "b", namespace=True)
+    )
+    winners = reg.resolve_fields(FieldKind.QUERY)
+    assert "ext_a_search" in winners
+    assert "ext_b_search" in winners
+
+
+def test_mutation_collision_independent_from_query() -> None:
+    reg = GraphQLContributionRegistry()
+    fn_q = lambda info: "q"  # noqa: E731
+    fn_m = lambda info: "m"  # noqa: E731
+    reg.register_field(
+        FieldContribution("ext_a", FieldKind.QUERY, "transfer", fn_q, str)
+    )
+    reg.register_field(
+        FieldContribution("ext_a", FieldKind.MUTATION, "transfer", fn_m, str)
+    )
+    # Same name on different kinds is not a collision.
+    assert "transfer" in reg.resolve_fields(FieldKind.QUERY)
+    assert "transfer" in reg.resolve_fields(FieldKind.MUTATION)
+
+
+# ---------------------------------------------------------------------------
+# Custom types + federation directives
+# ---------------------------------------------------------------------------
+
+
+def test_custom_type_registration_and_resolve() -> None:
+    reg = GraphQLContributionRegistry()
+
+    @strawberry.type
+    class Aggregate:
+        total: int
+
+    reg.register_type(TypeContribution("ext_a", Aggregate))
+    winners = reg.resolve_types()
+    assert "Aggregate" in winners
+    assert winners["Aggregate"].type_class is Aggregate
+
+
+def test_type_collision_distinct_classes_raises() -> None:
+    reg = GraphQLContributionRegistry()
+
+    @strawberry.type
+    class Aggregate:
+        total: int
+
+    @strawberry.type
+    class Aggregate2:  # different class, same emitted name via name override
+        total: int
+
+    reg.register_type(TypeContribution("ext_a", Aggregate, name="Aggregate"))
+    reg.register_type(TypeContribution("ext_b", Aggregate2, name="Aggregate"))
+    with pytest.raises(GraphQLCompositionCollisionError):
+        reg.resolve_types()
+
+
+def test_type_namespacing_isolates_emitted_name() -> None:
+    reg = GraphQLContributionRegistry()
+
+    @strawberry.type
+    class Aggregate:
+        total: int
+
+    reg.register_type(TypeContribution("ext_a", Aggregate, namespace=True))
+    reg.register_type(TypeContribution("ext_b", Aggregate, namespace=True))
+    winners = reg.resolve_types()
+    # Same class accepted twice would merge; namespacing keeps them apart.
+    assert set(winners.keys()) == {"Ext_aAggregate", "Ext_bAggregate"}
+
+
+def test_invalid_federation_directive_rejected_at_registration() -> None:
+    reg = GraphQLContributionRegistry()
+
+    @strawberry.type
+    class Aggregate:
+        total: int
+
+    with pytest.raises(ValueError, match="Unsupported federation directive"):
+        reg.register_type(
+            TypeContribution(
+                "ext_a",
+                Aggregate,
+                federation_directives=(FederationDirective(name="bogus"),),
+            )
+        )
+
+
+def test_supported_federation_directives_accepted() -> None:
+    reg = GraphQLContributionRegistry()
+    for directive in ("key", "external", "requires", "provides", "shareable",
+                      "inaccessible", "override", "tag"):
+        @strawberry.type
+        class _T:
+            id: str
+        reg.register_type(
+            TypeContribution(
+                "ext_a",
+                _T,
+                name=f"T_{directive}",
+                federation_directives=(
+                    FederationDirective(name=directive, args={"fields": "id"}),
+                ),
+            )
+        )
+    assert len(reg.resolve_types()) == 8
+
+
+# ---------------------------------------------------------------------------
+# DataLoader: per-request batching
+# ---------------------------------------------------------------------------
+
+
+def test_dataloader_batches_parallel_loads() -> None:
+    call_log: List[List[Any]] = []
+
+    def batch_load_fn(keys):
+        call_log.append(list(keys))
+        return [{"id": k, "value": k * 2} for k in keys]
+
+    async def run():
+        loader = RequestDataLoader(batch_load_fn)
+        # Three parallel loads should collapse into a single batch.
+        results = await asyncio.gather(loader.load(1), loader.load(2), loader.load(3))
+        return results
+
+    results = asyncio.run(run())
+    assert len(call_log) == 1
+    assert call_log[0] == [1, 2, 3]
+    assert results == [{"id": 1, "value": 2}, {"id": 2, "value": 4}, {"id": 3, "value": 6}]
+
+
+def test_dataloader_async_batch_fn_supported() -> None:
+    async def batch_load_fn(keys):
+        await asyncio.sleep(0)
+        return [str(k) for k in keys]
+
+    async def run():
+        loader = RequestDataLoader(batch_load_fn)
+        return await asyncio.gather(loader.load(10), loader.load(20))
+
+    assert asyncio.run(run()) == ["10", "20"]
+
+
+def test_dataloader_dedupes_repeated_keys() -> None:
+    calls: List[List[Any]] = []
+
+    def batch_load_fn(keys):
+        calls.append(list(keys))
+        return [k * 100 for k in keys]
+
+    async def run():
+        loader = RequestDataLoader(batch_load_fn)
+        a, b = await asyncio.gather(loader.load(7), loader.load(7))
+        return a, b
+
+    a, b = asyncio.run(run())
+    assert a == 700 and b == 700
+    assert calls == [[7]]
+
+
+def test_dataloader_propagates_batch_exception() -> None:
+    def batch_load_fn(keys):
+        raise RuntimeError("batch failed")
+
+    async def run():
+        loader = RequestDataLoader(batch_load_fn)
+        with pytest.raises(RuntimeError, match="batch failed"):
+            await loader.load("k")
+
+    asyncio.run(run())
+
+
+def test_dataloader_length_mismatch_raises() -> None:
+    def batch_load_fn(keys):
+        return [1]  # too short
+
+    async def run():
+        loader = RequestDataLoader(batch_load_fn)
+        with pytest.raises(ValueError, match="lengths must match"):
+            await asyncio.gather(loader.load("a"), loader.load("b"))
+
+    asyncio.run(run())
+
+
+def test_dataloader_non_sequence_return_raises() -> None:
+    def batch_load_fn(keys):
+        return {"a": 1}  # not a sequence
+
+    async def run():
+        loader = RequestDataLoader(batch_load_fn)
+        with pytest.raises(TypeError, match="must return a sequence"):
+            await loader.load("a")
+
+    asyncio.run(run())
+
+
+def test_dataloader_global_collision_on_distinct_fn() -> None:
+    reg = GraphQLContributionRegistry()
+    reg.register_dataloader(DataLoaderSpec("ext_a", "users", lambda ks: list(ks)))
+    with pytest.raises(GraphQLCompositionCollisionError):
+        reg.register_dataloader(DataLoaderSpec("ext_b", "users", lambda ks: list(ks)))
+
+
+def test_dataloader_same_fn_re_registration_idempotent() -> None:
+    reg = GraphQLContributionRegistry()
+    fn = lambda ks: list(ks)  # noqa: E731
+    reg.register_dataloader(DataLoaderSpec("ext_a", "users", fn))
+    # Re-registering the SAME function from a different extension is allowed
+    # (single source of truth, multiple consumers).
+    reg.register_dataloader(DataLoaderSpec("ext_b", "users", fn))
+    assert reg.dataloaders()["users"].batch_load_fn is fn
+
+
+def test_build_request_dataloaders_returns_fresh_per_call() -> None:
+    reg = GraphQLContributionRegistry()
+    reg.register_dataloader(DataLoaderSpec("ext_a", "users", lambda ks: list(ks)))
+    a = build_request_dataloaders(reg)
+    b = build_request_dataloaders(reg)
+    assert a["users"] is not b["users"]
+
+
+# ---------------------------------------------------------------------------
+# Rebuild subscription + diff
+# ---------------------------------------------------------------------------
+
+
+def test_register_field_notifies_subscriber() -> None:
+    reg = GraphQLContributionRegistry()
+    notifications: List[bool] = []
+    reg.subscribe_rebuild(lambda: notifications.append(True))
+    reg.register_field(_query_contribution("ext_a", "search", lambda info: "ok"))
+    assert notifications == [True]
+
+
+def test_suspend_defers_notifications_until_resume() -> None:
+    reg = GraphQLContributionRegistry()
+    notifications: List[bool] = []
+    reg.subscribe_rebuild(lambda: notifications.append(True))
+    reg.suspend()
+    reg.register_field(_query_contribution("ext_a", "a", lambda info: "1"))
+    reg.register_field(_query_contribution("ext_b", "b", lambda info: "2"))
+    assert notifications == []
+    reg.resume()
+    assert notifications == [True]
+
+
+def test_unsubscribe_rebuild_stops_notifications() -> None:
+    reg = GraphQLContributionRegistry()
+    notifications: List[int] = []
+
+    def cb() -> None:
+        notifications.append(1)
+
+    reg.subscribe_rebuild(cb)
+    reg.register_field(_query_contribution("ext_a", "a", lambda info: "1"))
+    reg.unsubscribe_rebuild(cb)
+    reg.register_field(_query_contribution("ext_b", "b", lambda info: "2"))
+    assert notifications == [1]
+
+
+def test_diff_signatures_reports_added_and_removed() -> None:
+    prev = (("a",), ("m1",), (), ("T1",))
+    curr = (("a", "b"), (), ("s1",), ("T2",))
+    added, removed = _diff_signatures(prev, curr)
+    assert added == {"query:b", "subscription:s1", "type:T2"}
+    assert removed == {"mutation:m1", "type:T1"}
+
+
+# ---------------------------------------------------------------------------
+# Decorators wire into the global registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_global() -> None:
+    reset_gql_contribution_registry()
+    yield
+    reset_gql_contribution_registry()
+
+
+def test_gql_query_decorator_registers_globally() -> None:
+    reset_gql_contribution_registry()
+
+    @gql_query(name="hello", return_type=str, extension_name="demo")
+    def _hello(info) -> str:
+        return "hi"
+
+    fields = gql_contribution_registry().fields(FieldKind.QUERY)
+    assert "hello" in fields
+    assert fields["hello"][0].extension_name == "demo"
+
+
+def test_gql_mutation_and_subscription_decorators_register() -> None:
+    reset_gql_contribution_registry()
+
+    @gql_mutation(name="ping", return_type=bool, extension_name="demo")
+    def _ping(info) -> bool:
+        return True
+
+    @gql_subscription(name="tick", return_type=str, extension_name="demo")
+    async def _tick(info):
+        yield "tick"
+
+    reg = gql_contribution_registry()
+    assert "ping" in reg.fields(FieldKind.MUTATION)
+    assert "tick" in reg.fields(FieldKind.SUBSCRIPTION)
+
+
+def test_gql_type_decorator_registers_globally() -> None:
+    reset_gql_contribution_registry()
+
+    @gql_type(extension_name="demo")
+    @strawberry.type
+    class Aggregate:
+        total: int
+
+    types = gql_contribution_registry().types()
+    assert "Aggregate" in types
+
+
+def test_register_dataloader_helper_records_spec() -> None:
+    reset_gql_contribution_registry()
+    register_dataloader(
+        "ext_users",
+        lambda keys: list(keys),
+        extension_name="demo",
+        description="batch user lookups",
+    )
+    assert "ext_users" in gql_contribution_registry().dataloaders()

--- a/src/serverframework/logic/AbstractService.py
+++ b/src/serverframework/logic/AbstractService.py
@@ -785,20 +785,177 @@ class FairQueueConsumerService(QueueConsumerService):
 # ----- Streaming --------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Item 13 -- Streaming, websocket, SSE, long-poll support
+# ---------------------------------------------------------------------------
+#
+# StreamingService completes the broadened service contract from Item 28 by
+# adding three things on top of the connect/iter/on_message/disconnect skeleton:
+#
+#   1. A typed ``streaming_handler`` registry (mirrors ``Webhook.webhook_handler``
+#      from Item 5) so a Stripe events firehose and a Stripe webhook deliver
+#      the same canonical event into the same downstream hook chain.
+#   2. ``state_store``-backed cursor / subscription-token persistence so a
+#      restart resumes from the last acknowledged event.
+#   3. Graceful drain on stop: the loop receives the stop signal, finishes
+#      in-flight ``on_message`` invocations within ``drain_period_seconds``,
+#      and then disconnects cleanly.
+
+
+# Key: (extension_name, provider_name, event_name_or_None)
+StreamingHandlerKey = Tuple[str, str, Optional[str]]
+STREAMING_HANDLER_REGISTRY: Dict[StreamingHandlerKey, Callable[..., Any]] = {}
+
+
+class StreamingMessageContext:
+    """Payload delivered to a ``@streaming_handler``-tagged callable.
+
+    Mirrors :class:`endpoints.Webhook.WebhookContext` so a Stripe event
+    arriving via the streaming firehose and an equivalent webhook delivery
+    drop the same shape into the same handler chain.
+    """
+
+    __slots__ = (
+        "payload",
+        "headers",
+        "extension_name",
+        "provider_name",
+        "event_name",
+        "cursor",
+        "service_id",
+    )
+
+    def __init__(
+        self,
+        *,
+        payload: Any,
+        headers: Optional[Dict[str, str]] = None,
+        extension_name: str,
+        provider_name: str,
+        event_name: Optional[str] = None,
+        cursor: Optional[str] = None,
+        service_id: Optional[str] = None,
+    ) -> None:
+        self.payload = payload
+        self.headers = dict(headers or {})
+        self.extension_name = extension_name
+        self.provider_name = provider_name
+        self.event_name = event_name
+        self.cursor = cursor
+        self.service_id = service_id
+
+
+def streaming_handler(
+    extension_class_or_name: Any,
+    provider: str,
+    event: Optional[str] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Register a handler for ``(extension, provider, event)`` streaming events.
+
+    ``extension_class_or_name`` accepts either an extension class (the
+    framework extracts ``extension_name`` / strips the ``EXT_`` prefix on
+    the class name) or a plain string.
+
+    If ``event`` is ``None`` the handler matches any event for the provider
+    that has no more-specific registration -- same fallback semantics as
+    ``Webhook.webhook_handler``.
+    """
+
+    if isinstance(extension_class_or_name, str):
+        extension_name = extension_class_or_name.lower()
+    else:
+        name = getattr(extension_class_or_name, "extension_name", None)
+        if name:
+            extension_name = str(name).lower()
+        else:
+            cls_name = getattr(
+                extension_class_or_name, "__name__", str(extension_class_or_name)
+            )
+            if cls_name.startswith("EXT_"):
+                cls_name = cls_name[4:]
+            extension_name = cls_name.lower()
+    provider_norm = provider.lower()
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        key = (extension_name, provider_norm, event)
+        if key in STREAMING_HANDLER_REGISTRY:
+            logger.warning(
+                f"Streaming handler for {key} already registered; overwriting."
+            )
+        STREAMING_HANDLER_REGISTRY[key] = func
+        logger.debug(f"Registered streaming handler {func.__name__} for {key}")
+        return func
+
+    return decorator
+
+
+def _lookup_streaming_handler(
+    extension: str, provider: str, event: Optional[str]
+) -> Optional[Callable[..., Any]]:
+    extension = extension.lower()
+    provider = provider.lower()
+    if event is not None:
+        handler = STREAMING_HANDLER_REGISTRY.get((extension, provider, event))
+        if handler is not None:
+            return handler
+    return STREAMING_HANDLER_REGISTRY.get((extension, provider, None))
+
+
 class StreamingService(AbstractService):
     """Long-lived connection-oriented work.
 
     Lifecycle: ``connect() -> on_message(message) -> disconnect()``. Reconnection
     backoff is exponential with jitter, capped at ``reconnect_max_seconds``.
+
+    Subclasses set ``extension_name`` / ``provider_name`` and override
+    :meth:`classify` to return ``(event_name, payload, headers, cursor)``
+    for each raw message; :meth:`on_message` then fans out to the
+    ``streaming_handler`` registry and (optionally) to a cross-process
+    event bus from Item 42.
+
+    Cursor persistence: when ``state_store`` is provided, the service
+    invokes ``state_store(service_id, value=cursor)`` after each successful
+    handler dispatch and ``state_store(service_id)`` on first connect so the
+    subclass can resume from the last acknowledged position. Subclasses
+    consume ``self.cursor`` to filter the stream on reconnect.
+
+    Graceful drain: ``stop()`` flips ``running=False`` and the loop drains
+    any in-flight ``on_message`` task within ``drain_period_seconds`` before
+    disconnecting. Use :meth:`stop_and_drain` for an awaitable variant in
+    tests and shutdown handlers.
     """
 
     reconnect_initial_seconds: float = 1.0
     reconnect_max_seconds: float = 60.0
 
-    async def connect(self) -> Any:  # pragma: no cover - override me
-        raise NotImplementedError
+    # Subclasses set these so the default ``on_message`` can route events to
+    # the streaming-handler registry without bespoke wiring per subclass.
+    extension_name: ClassVar[Optional[str]] = None
+    provider_name: ClassVar[Optional[str]] = None
 
-    async def on_message(self, message: Any) -> None:  # pragma: no cover - override me
+    def __init__(
+        self,
+        *args: Any,
+        state_store: Optional[Callable[..., Any]] = None,
+        event_bus: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._state_store = state_store
+        self._event_bus = event_bus
+        self.cursor: Optional[str] = None
+        if self._state_store is not None:
+            try:
+                self.cursor = self._state_store(self.service_id)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"StreamingService {self.service_id}: state_store load failed: {e}"
+                )
+        self._inflight: Optional[asyncio.Task] = None
+        self._drained: asyncio.Event = asyncio.Event()
+        self._drained.set()
+
+    async def connect(self) -> Any:  # pragma: no cover - override me
         raise NotImplementedError
 
     async def disconnect(self) -> None:
@@ -810,10 +967,121 @@ class StreamingService(AbstractService):
             yield None
         return
 
+    def classify(
+        self, message: Any
+    ) -> Tuple[Optional[str], Any, Optional[Dict[str, str]], Optional[str]]:
+        """Return ``(event_name, payload, headers, cursor)`` for ``message``.
+
+        Default: ``(None, message, None, None)`` -- subclasses override to
+        extract upstream-specific event names, headers, and cursor tokens.
+        """
+        return None, message, None, None
+
+    async def on_message(self, message: Any) -> None:
+        """Default fan-out: classify the message, dispatch to the registry.
+
+        A subclass that wants to fully customize the lifecycle can override
+        this. The default behavior is the right one for ~90% of streaming
+        upstreams: classify the raw frame into a canonical event, dispatch
+        to the handler chain, optionally publish to the event bus.
+        """
+        event_name, payload, headers, cursor = self.classify(message)
+        await self.fan_out(
+            payload=payload,
+            event_name=event_name,
+            headers=headers,
+            cursor=cursor,
+        )
+
+    async def fan_out(
+        self,
+        *,
+        payload: Any,
+        event_name: Optional[str],
+        headers: Optional[Dict[str, str]] = None,
+        cursor: Optional[str] = None,
+    ) -> None:
+        """Dispatch a classified event into the streaming handler registry.
+
+        Resolves the handler keyed by ``(extension_name, provider_name,
+        event_name)``; falls back to the wildcard handler when no
+        event-specific entry is registered. After successful dispatch:
+          - the ``cursor`` is persisted via ``state_store`` (if provided),
+          - the payload is published to ``event_bus`` (if provided) so
+            cross-process subscribers (Item 42) see the event.
+        """
+        if self.extension_name is None or self.provider_name is None:
+            raise RuntimeError(
+                f"StreamingService {self.__class__.__name__} did not declare"
+                " extension_name / provider_name; set them on the subclass"
+                " or override on_message to dispatch directly."
+            )
+        handler = _lookup_streaming_handler(
+            self.extension_name, self.provider_name, event_name
+        )
+        if handler is None:
+            logger.debug(
+                f"StreamingService {self.service_id}: no handler for "
+                f"({self.extension_name}, {self.provider_name}, {event_name})"
+            )
+            return
+        ctx = StreamingMessageContext(
+            payload=payload,
+            headers=headers,
+            extension_name=self.extension_name,
+            provider_name=self.provider_name,
+            event_name=event_name,
+            cursor=cursor,
+            service_id=self.service_id,
+        )
+        result = handler(ctx)
+        if asyncio.iscoroutine(result):
+            await result
+        if cursor is not None:
+            self.cursor = cursor
+            self._persist_cursor()
+        if self._event_bus is not None and hasattr(self._event_bus, "publish"):
+            try:
+                await self._event_bus.publish(payload)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"StreamingService {self.service_id}: event_bus publish failed: {e}"
+                )
+
+    def _persist_cursor(self) -> None:
+        if self._state_store is None:
+            return
+        try:
+            self._state_store(self.service_id, value=self.cursor)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"StreamingService {self.service_id}: state_store save failed: {e}"
+            )
+
     async def update(self) -> None:
         # ``run_service_loop`` is overridden; ``update`` exists only to satisfy
         # the abstract contract from AbstractService.
         return None
+
+    async def stop_and_drain(self) -> None:
+        """Awaitable graceful shutdown: stop, drain, return.
+
+        Sets ``running=False`` so the loop exits its iteration, then waits
+        up to ``drain_period_seconds`` for any in-flight ``on_message``
+        invocation to complete.
+        """
+        self.stop()
+        try:
+            await asyncio.wait_for(
+                self._drained.wait(), timeout=self.drain_period_seconds
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"StreamingService {self.service_id}: drain timed out after"
+                f" {self.drain_period_seconds:.1f}s; cancelling in-flight task."
+            )
+            if self._inflight is not None and not self._inflight.done():
+                self._inflight.cancel()
 
     async def run_service_loop(self) -> None:  # type: ignore[override]
         attempt = 0
@@ -832,12 +1100,19 @@ class StreamingService(AbstractService):
                         if self.paused:
                             await asyncio.sleep(0.1)
                             continue
+                        # Track this dispatch so stop_and_drain can wait on it.
+                        self._drained.clear()
+                        self._inflight = asyncio.ensure_future(self.on_message(message))
                         try:
-                            await self.on_message(message)
+                            await self._inflight
                         except Exception as e:  # noqa: BLE001
                             logger.error(
-                                f"StreamingService {self.service_id} on_message error: {e}"
+                                f"StreamingService {self.service_id} on_message"
+                                f" error: {e}"
                             )
+                        finally:
+                            self._inflight = None
+                            self._drained.set()
                 finally:
                     try:
                         await self.disconnect()

--- a/src/serverframework/logic/AbstractService_streaming_test.py
+++ b/src/serverframework/logic/AbstractService_streaming_test.py
@@ -1,0 +1,337 @@
+"""Tests for the Item 13 streaming additions on top of Item 28's base.
+
+Covers:
+- ``streaming_handler`` registry: decorator, fallback wildcard, last-write-wins.
+- ``StreamingService.fan_out``: handler dispatch with ``StreamingMessageContext``.
+- Cursor persistence via the injected ``state_store``.
+- Cross-process event-bus publish on successful dispatch.
+- Graceful drain via ``stop_and_drain``: in-flight ``on_message`` finishes
+  within ``drain_period_seconds``.
+- Drain timeout cancels the in-flight task when it exceeds the deadline.
+- Subclass-driven ``classify`` -> default ``on_message`` -> registry path.
+
+No mocks: real handler callables, real ``state_store`` callable, real event-loop
+drain timing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from serverframework.logic.AbstractService import (
+    STREAMING_HANDLER_REGISTRY,
+    StreamingMessageContext,
+    StreamingService,
+    streaming_handler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> None:
+    STREAMING_HANDLER_REGISTRY.clear()
+    yield
+    STREAMING_HANDLER_REGISTRY.clear()
+
+
+# ---------------------------------------------------------------------------
+# Registry decorator
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_handler_registers_with_string_extension() -> None:
+    @streaming_handler("payment", "stripe", event="customer.updated")
+    def _h(ctx: StreamingMessageContext) -> None:
+        return None
+
+    assert ("payment", "stripe", "customer.updated") in STREAMING_HANDLER_REGISTRY
+
+
+def test_streaming_handler_registers_with_extension_class_strips_prefix() -> None:
+    class EXT_Payment:
+        pass
+
+    @streaming_handler(EXT_Payment, "stripe", event="customer.created")
+    def _h(ctx: StreamingMessageContext) -> None:
+        return None
+
+    assert ("payment", "stripe", "customer.created") in STREAMING_HANDLER_REGISTRY
+
+
+def test_streaming_handler_uses_extension_name_attribute_when_present() -> None:
+    class _Plug:
+        extension_name = "Billing"
+
+    @streaming_handler(_Plug, "stripe")
+    def _h(ctx: StreamingMessageContext) -> None:
+        return None
+
+    assert ("billing", "stripe", None) in STREAMING_HANDLER_REGISTRY
+
+
+def test_wildcard_handler_used_when_no_event_specific_match() -> None:
+    captured: List[str] = []
+
+    @streaming_handler("payment", "stripe")
+    def _wildcard(ctx: StreamingMessageContext) -> None:
+        captured.append("wildcard")
+
+    @streaming_handler("payment", "stripe", event="invoice.paid")
+    def _specific(ctx: StreamingMessageContext) -> None:
+        captured.append("specific")
+
+    class _Svc(StreamingService):
+        extension_name = "payment"
+        provider_name = "stripe"
+
+    svc = _Svc(requester_id="r")
+    asyncio.run(svc.fan_out(payload={"amount": 1}, event_name="invoice.paid"))
+    asyncio.run(svc.fan_out(payload={"amount": 2}, event_name="customer.unknown"))
+    assert captured == ["specific", "wildcard"]
+
+
+def test_re_registration_overwrites_with_warning() -> None:
+    @streaming_handler("payment", "stripe", event="x")
+    def _first(ctx: StreamingMessageContext) -> None:
+        return None
+
+    @streaming_handler("payment", "stripe", event="x")
+    def _second(ctx: StreamingMessageContext) -> None:
+        return None
+
+    assert STREAMING_HANDLER_REGISTRY[("payment", "stripe", "x")] is _second
+
+
+# ---------------------------------------------------------------------------
+# fan_out: dispatch + cursor + event-bus
+# ---------------------------------------------------------------------------
+
+
+class _CapturingService(StreamingService):
+    extension_name = "demo"
+    provider_name = "demoprov"
+
+
+def test_fan_out_invokes_handler_with_context() -> None:
+    received: List[StreamingMessageContext] = []
+
+    @streaming_handler("demo", "demoprov", event="thing.happened")
+    def _h(ctx: StreamingMessageContext) -> None:
+        received.append(ctx)
+
+    svc = _CapturingService(requester_id="r-1", service_id="svc-1")
+    asyncio.run(
+        svc.fan_out(
+            payload={"id": "abc"},
+            event_name="thing.happened",
+            headers={"x-trace": "1"},
+            cursor="cur-1",
+        )
+    )
+    assert len(received) == 1
+    ctx = received[0]
+    assert ctx.payload == {"id": "abc"}
+    assert ctx.headers == {"x-trace": "1"}
+    assert ctx.event_name == "thing.happened"
+    assert ctx.cursor == "cur-1"
+    assert ctx.service_id == "svc-1"
+
+
+def test_fan_out_async_handler_awaited() -> None:
+    received: List[Any] = []
+
+    @streaming_handler("demo", "demoprov", event="async.evt")
+    async def _h(ctx: StreamingMessageContext) -> None:
+        await asyncio.sleep(0)
+        received.append(ctx.payload)
+
+    svc = _CapturingService(requester_id="r")
+    asyncio.run(svc.fan_out(payload="payload-1", event_name="async.evt"))
+    assert received == ["payload-1"]
+
+
+def test_fan_out_persists_cursor_via_state_store() -> None:
+    state: Dict[str, Optional[str]] = {}
+
+    def state_store(svc_id: str, value: Optional[str] = None) -> Optional[str]:
+        if value is not None:
+            state[svc_id] = value
+        return state.get(svc_id)
+
+    @streaming_handler("demo", "demoprov", event="e")
+    def _h(ctx: StreamingMessageContext) -> None:
+        return None
+
+    svc = _CapturingService(requester_id="r", service_id="s-cursor", state_store=state_store)
+    asyncio.run(svc.fan_out(payload={}, event_name="e", cursor="c-42"))
+    assert svc.cursor == "c-42"
+    assert state["s-cursor"] == "c-42"
+
+
+def test_state_store_loaded_on_init() -> None:
+    state: Dict[str, Optional[str]] = {"prev": "c-existing"}
+
+    def state_store(svc_id: str, value: Optional[str] = None) -> Optional[str]:
+        if value is not None:
+            state[svc_id] = value
+        return state.get(svc_id)
+
+    svc = _CapturingService(requester_id="r", service_id="prev", state_store=state_store)
+    assert svc.cursor == "c-existing"
+
+
+def test_fan_out_publishes_to_event_bus_when_provided() -> None:
+    @streaming_handler("demo", "demoprov", event="e")
+    def _h(ctx: StreamingMessageContext) -> None:
+        return None
+
+    published: List[Any] = []
+
+    class _Bus:
+        async def publish(self, evt: Any) -> None:
+            published.append(evt)
+
+    svc = _CapturingService(requester_id="r", event_bus=_Bus())
+    asyncio.run(svc.fan_out(payload={"x": 1}, event_name="e"))
+    assert published == [{"x": 1}]
+
+
+def test_fan_out_no_handler_logs_and_skips() -> None:
+    svc = _CapturingService(requester_id="r")
+    # Should not raise even when no handler is registered.
+    asyncio.run(svc.fan_out(payload={"y": 2}, event_name="nothing.matches"))
+
+
+def test_fan_out_requires_extension_and_provider_names() -> None:
+    class _Bare(StreamingService):
+        pass
+
+    svc = _Bare(requester_id="r")
+    with pytest.raises(RuntimeError, match="did not declare"):
+        asyncio.run(svc.fan_out(payload={}, event_name=None))
+
+
+# ---------------------------------------------------------------------------
+# classify -> default on_message integration
+# ---------------------------------------------------------------------------
+
+
+class _ClassifyingService(StreamingService):
+    extension_name = "demo"
+    provider_name = "demoprov"
+
+    def classify(
+        self, message: Any
+    ) -> Tuple[Optional[str], Any, Optional[Dict[str, str]], Optional[str]]:
+        return message.get("event"), message.get("data"), {"src": "stream"}, message.get("cursor")
+
+
+def test_default_on_message_classifies_and_dispatches() -> None:
+    captured: List[StreamingMessageContext] = []
+
+    @streaming_handler("demo", "demoprov", event="thing.created")
+    def _h(ctx: StreamingMessageContext) -> None:
+        captured.append(ctx)
+
+    svc = _ClassifyingService(requester_id="r")
+    asyncio.run(
+        svc.on_message({"event": "thing.created", "data": {"id": 7}, "cursor": "c-7"})
+    )
+    assert len(captured) == 1
+    assert captured[0].event_name == "thing.created"
+    assert captured[0].payload == {"id": 7}
+    assert captured[0].cursor == "c-7"
+
+
+# ---------------------------------------------------------------------------
+# Graceful drain
+# ---------------------------------------------------------------------------
+
+
+class _SlowStreamer(StreamingService):
+    extension_name = "demo"
+    provider_name = "demoprov"
+
+    def __init__(self, *args: Any, work_seconds: float = 0.1, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._work_seconds = work_seconds
+        self.processed: List[Any] = []
+        self.connect_calls = 0
+
+    async def connect(self) -> Any:
+        self.connect_calls += 1
+        return object()
+
+    async def iter_messages(self, connection: Any):
+        # Long enough to exercise the drain path: yield one message, then idle.
+        yield {"event": "e", "data": {"i": 1}}
+        await asyncio.sleep(0.5)
+
+    async def on_message(self, message: Any) -> None:
+        await asyncio.sleep(self._work_seconds)
+        self.processed.append(message)
+
+
+def test_stop_and_drain_completes_inflight_message_within_deadline() -> None:
+    @streaming_handler("demo", "demoprov", event="e")
+    def _h(ctx: StreamingMessageContext) -> None:
+        return None
+
+    async def scenario() -> _SlowStreamer:
+        svc = _SlowStreamer(
+            requester_id="r",
+            work_seconds=0.05,
+            drain_period_seconds=1.0,
+        )
+        svc.start()
+        loop_task = asyncio.create_task(svc.run_service_loop())
+        # Give the loop time to enter on_message.
+        await asyncio.sleep(0.02)
+        await svc.stop_and_drain()
+        try:
+            await asyncio.wait_for(loop_task, timeout=1.0)
+        except asyncio.TimeoutError:
+            loop_task.cancel()
+        return svc
+
+    svc = asyncio.run(scenario())
+    assert len(svc.processed) == 1
+
+
+def test_stop_and_drain_cancels_when_inflight_exceeds_deadline() -> None:
+    @streaming_handler("demo", "demoprov", event="e")
+    def _h(ctx: StreamingMessageContext) -> None:
+        return None
+
+    async def scenario() -> _SlowStreamer:
+        svc = _SlowStreamer(
+            requester_id="r",
+            work_seconds=2.0,           # work takes 2s
+            drain_period_seconds=0.1,   # drain only allows 100ms
+        )
+        svc.start()
+        loop_task = asyncio.create_task(svc.run_service_loop())
+        await asyncio.sleep(0.02)
+        await svc.stop_and_drain()
+        try:
+            await asyncio.wait_for(loop_task, timeout=1.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            loop_task.cancel()
+        return svc
+
+    svc = asyncio.run(scenario())
+    # Work was cancelled, so the message did not finish.
+    assert len(svc.processed) == 0
+
+
+# ---------------------------------------------------------------------------
+# Reconnect behavior survives across stop_and_drain
+# ---------------------------------------------------------------------------
+
+
+def test_drain_event_set_when_no_inflight_message() -> None:
+    svc = _CapturingService(requester_id="r")
+    # Fresh service: drained event is set so stop_and_drain returns immediately.
+    assert svc._drained.is_set()

--- a/src/serverframework/logic/SVC.Patterns.md
+++ b/src/serverframework/logic/SVC.Patterns.md
@@ -548,9 +548,70 @@ Four service flavors share a common lifecycle (`start`, `stop`, `pause`, `resume
 - **`PerpetualService`** — perpetual time-based loop with a sleep interval. The default flavor. Useful for thirty-second agentic loops, background reconciliation passes.
 - **`ScheduledService`** — cron expression or fixed-interval execution. Useful for periodic syncs, daily reports, billing-cycle resets, retention archival, backup snapshots.
 - **`QueueConsumerService`** — pulls from a queue (Redis, SQS, Postgres-as-queue) with backoff, visibility-timeout semantics, and dead-letter handling. Useful for outbox workers, compensating actions, deferred webhook processing.
-- **`StreamingService`** — long-lived connection-oriented work, with `ConsumerService` (websocket subscriber, SSE listener, Kafka consumer) and `ProducerService` (long-lived outbound stream) sub-flavors.
+- **`StreamingService`** — long-lived connection-oriented work, with `ConsumerStreamingService` (websocket subscriber, SSE listener, Kafka consumer) and `ProducerStreamingService` (long-lived outbound stream) sub-flavors. See **Streaming Services (Item 13)** below.
 
 State that must persist across restarts (cron last-run-at, queue cursors, stream subscription tokens) lives in a small per-service state store and is the responsibility of the framework, not the service author.
+
+## Streaming Services (Item 13)
+
+`StreamingService` completes the broadened service contract from Item 28 with three additions on top of the connect/iter/on_message/disconnect skeleton: a typed handler registry that mirrors the inbound webhook contract from Item 5, cursor / subscription-token persistence via an injectable `state_store`, and graceful drain on stop.
+
+### Subclass shape
+
+```python
+class StripeEventsStream(ConsumerStreamingService):
+    extension_name = "payment"
+    provider_name = "stripe"
+
+    async def connect(self):
+        return await stripe_client.events.subscribe(starting_after=self.cursor)
+
+    async def iter_messages(self, connection):
+        async for raw in connection:
+            yield raw
+
+    def classify(self, message):
+        return message["type"], message["data"], {"x-id": message["id"]}, message["id"]
+```
+
+The base class's default `on_message` invokes `classify(message)` -> `fan_out(...)` which dispatches to the streaming handler registry. Subclasses that need full lifecycle control override `on_message` directly.
+
+### Handler registry
+
+```python
+from serverframework.logic.AbstractService import streaming_handler, StreamingMessageContext
+
+@streaming_handler(EXT_Payment, provider="stripe", event="customer.updated")
+async def on_customer_updated(ctx: StreamingMessageContext) -> None:
+    # ctx.payload, ctx.headers, ctx.event_name, ctx.cursor, ctx.service_id
+    ...
+```
+
+Lookup is by `(extension_name, provider_name, event_name)`. If no event-specific handler is registered, the wildcard `(extension, provider, None)` handler is invoked. Re-registration overwrites with a warning. Handlers may be sync or async; async handlers are awaited.
+
+The Stripe events firehose and the Stripe webhook deliver the same canonical event into the same downstream chain — `Webhook.WebhookContext` and `StreamingMessageContext` carry equivalent fields, so a downstream `@hook_bll` or business handler does not need to know which transport delivered the event.
+
+### Cursor persistence
+
+`state_store` is an injectable `Callable[[service_id], cursor]` / `Callable[[service_id, value=cursor], None]` (matching the `ScheduledService` shape). On construction the service loads the last-acknowledged cursor; after each successful `fan_out` the cursor is persisted. Subclasses consume `self.cursor` to resume from the last position on reconnect. Failures inside `state_store` log a warning and continue — cursor persistence is durable but not transactional with the upstream stream.
+
+### Cross-process fan-out
+
+When `event_bus` is provided (any object with an `async publish(payload)` method, e.g. an Item 42 `AbstractEventBus`), the canonical payload is published after successful handler dispatch so out-of-process subscribers see the event. The handler registry path is in-process; `event_bus` is the cross-process upgrade.
+
+### Reconnection + graceful drain
+
+Reconnection backoff is exponential with jitter (±25%), capped at `reconnect_max_seconds` (default 60s, initial 1s). On stop:
+
+- `stop()` flips `running=False`; the loop exits its iteration.
+- `await stop_and_drain()` waits up to `drain_period_seconds` (default 30s) for the in-flight `on_message` to finish, then cancels it on timeout with a logged warning.
+- `disconnect()` runs in the loop's `finally` block regardless of how the loop exits.
+
+The `_drained` event is set when no message is in flight, so `stop_and_drain()` returns immediately when the service is idle.
+
+### Acceptance per Item 13
+
+A `StreamingService` author declares an upstream subscriber, has the framework manage connection lifecycle, reconnect automatically on transient failures, and route received events into the existing handler chain on the corresponding `*Manager` classes — all without writing connection-management or backoff code.
 
 ## Execution Model
 


### PR DESCRIPTION
Item 46 — GraphQL composition contract for our own extensions
- Inline `GraphQLContributionRegistry` in `lib/Pydantic2Strawberry.py` since
  contributions are still Pydantic→Strawberry conversions (just from
  non-CRUD sources).
- `@gql_query` / `@gql_mutation` / `@gql_subscription` / `@gql_type` /
  `register_dataloader` decorators with auto-derived `extension_name`
  from the caller's `extensions.<name>` module path.
- Three-stage collision resolution mirroring `CollisionDetection.FieldCollisionError`:
  identical-merge / non-identical-raise / namespacing opt-in.
- Apollo Federation v2 directives (`@key`, `@external`, etc.) appended
  to `__strawberry_definition__.directives`.
- Per-request `RequestDataLoader` collapses parallel `load(key)` calls
  into one `batch_load_fn(deduped_keys)` on the next event-loop tick.
- `GraphQLManager` subscribes to registry mutations and logs added/removed
  diffs; `rebuild()` for the Item 20 install/uninstall hot path.

Item 13 — Streaming completion on top of Item 28's StreamingService base
- `streaming_handler(extension, provider, event)` registry mirroring Item 5's
  `webhook_handler` so the Stripe firehose and Stripe webhook deliver the
  same canonical event into the same handler chain.
- `StreamingMessageContext` payload type matching `WebhookContext` shape.
- `state_store`-backed cursor / subscription-token persistence (loaded on
  init, persisted after each successful `fan_out`).
- `stop_and_drain()` with `_drained: asyncio.Event` waits up to
  `drain_period_seconds` for in-flight `on_message` to finish, then cancels.
- Optional cross-process `event_bus` (Item 42 `AbstractEventBus`-shaped)
  publish on successful dispatch.
- Default `on_message` calls subclass-overridden `classify(message)` then
  routes via `fan_out`.

Test infra fixes uncovered while triaging the suite:
- Hoist `from fastapi import FastAPI, Request` to module level in three
  federation test files. Inline imports were invisible to FastAPI's
  `get_type_hints(globalns=module_globals)` under PEP 563
  `from __future__ import annotations`, so `Request` resolved as a query
  parameter.
- Switch sync FastAPI ASGI access to `fastapi.testclient.TestClient` —
  httpx 0.28 dropped sync `ASGITransport` support.
- Regenerate `EXT.Contracts.md` for the new `StreamingService.__init__`
  signature.

Tests: 27 new GQL composition tests; 16 new streaming tests; existing
GQL provider, federation matrix, federation bootstrap, and SQL injection
suites green after the test-infra fixes.

https://claude.ai/code/session_01AdWRSPoxua85cbN7nFiAc1