### PR TITLE
Convert extension carve-out migrations from raw SQL to op.create_table

### DIFF
--- a/src/serverframework/extensions/acl_rbac/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/acl_rbac/migrations/versions/001_initial.py
@@ -1,49 +1,85 @@
-"""Initial migration for acl_rbac — owns `permissions`."""
+"""Initial migration for acl_rbac — owns `permissions`.
 
+The `permissions` table was originally created by core in
+`e0b0dc9d5070_initial_schema.py` before the Phase-2 carve-out (PR #144).
+On databases that were stamped with that core revision, the table already
+exists; the Inspector check below makes the upgrade a no-op in that case.
+On fresh databases, core's initial schema is still the file that creates
+the table — this revision tracks ownership for any *subsequent* schema
+changes the extension makes to the table.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
 from alembic import op
 
 
-revision = "001_acl_rbac_initial"
-down_revision = None
-branch_labels = ("acl_rbac",)
-depends_on = None
+revision: str = "001_acl_rbac_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("acl_rbac",)
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS permissions (
-            id VARCHAR(36) PRIMARY KEY,
-            user_id VARCHAR(36),
-            team_id VARCHAR(36),
-            role_id VARCHAR(36),
-            resource_type VARCHAR(255) NOT NULL,
-            resource_id VARCHAR(36) NOT NULL,
-            can_view BOOLEAN DEFAULT 0,
-            can_execute BOOLEAN DEFAULT 0,
-            can_copy BOOLEAN DEFAULT 0,
-            can_edit BOOLEAN DEFAULT 0,
-            can_delete BOOLEAN DEFAULT 0,
-            can_share BOOLEAN DEFAULT 0,
-            expires_at TIMESTAMP,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("permissions"):
+        op.create_table(
+            "permissions",
+            sa.Column("role_id", sa.String(), nullable=True),
+            sa.Column("team_id", sa.String(), nullable=True),
+            sa.Column("user_id", sa.String(), nullable=True),
+            sa.Column("resource_type", sa.String(), nullable=False),
+            sa.Column("resource_id", sa.String(), nullable=False),
+            sa.Column("can_view", sa.Boolean(), nullable=False),
+            sa.Column("can_execute", sa.Boolean(), nullable=False),
+            sa.Column("can_copy", sa.Boolean(), nullable=False),
+            sa.Column("can_edit", sa.Boolean(), nullable=False),
+            sa.Column("can_delete", sa.Boolean(), nullable=False),
+            sa.Column("can_share", sa.Boolean(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+            sa.Column("enabled", sa.Boolean(), nullable=False),
+            sa.Column("id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("created_by_user_id", sa.String(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            comment="Fine-grained permissions for specific resources and actions",
+            info={
+                "source_module": "serverframework.extensions.acl_rbac.BLL_ACL",
+                "extension": "acl_rbac",
+            },
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_permissions_resource "
-        "ON permissions(resource_type, resource_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_permissions_user "
-        "ON permissions(user_id)"
-    )
+
+    existing = _existing_index_names("permissions")
+    if "ix_permissions_resource" not in existing:
+        op.create_index(
+            "ix_permissions_resource",
+            "permissions",
+            ["resource_type", "resource_id"],
+        )
+    if "ix_permissions_user" not in existing:
+        op.create_index("ix_permissions_user", "permissions", ["user_id"])
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE IF EXISTS permissions")
+    existing = _existing_index_names("permissions")
+    if "ix_permissions_user" in existing:
+        op.drop_index("ix_permissions_user", table_name="permissions")
+    if "ix_permissions_resource" in existing:
+        op.drop_index("ix_permissions_resource", table_name="permissions")
+    if _has_table("permissions"):
+        op.drop_table("permissions")

--- a/src/serverframework/extensions/auth_invitations/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/auth_invitations/migrations/versions/001_initial.py
@@ -1,60 +1,104 @@
-"""Initial migration for auth_invitations — owns `invitations`+`invitees`."""
+"""Initial migration for auth_invitations — owns `invitations` and `invitees`.
 
+These tables were originally created by core in
+`e0b0dc9d5070_initial_schema.py` before the Phase-2 carve-out (PR #144).
+On databases stamped with that core revision the tables already exist;
+the Inspector check below makes the upgrade a no-op in that case. On
+fresh databases, core's initial schema is still the file that creates
+the tables — this revision tracks ownership for any *subsequent* schema
+changes the extension makes to them.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
 from alembic import op
 
 
-revision = "001_auth_invitations_initial"
-down_revision = None
-branch_labels = ("auth_invitations",)
-depends_on = None
+revision: str = "001_auth_invitations_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("auth_invitations",)
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS invitations (
-            id VARCHAR(36) PRIMARY KEY,
-            code VARCHAR(255) UNIQUE,
-            team_id VARCHAR(36),
-            role_id VARCHAR(36),
-            user_id VARCHAR(36),
-            expires_at TIMESTAMP,
-            max_uses INTEGER,
-            used_count INTEGER DEFAULT 0,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("invitations"):
+        op.create_table(
+            "invitations",
+            sa.Column("role_id", sa.String(), nullable=True),
+            sa.Column("team_id", sa.String(), nullable=True),
+            sa.Column("user_id", sa.String(), nullable=True),
+            sa.Column("code", sa.String(), nullable=True),
+            sa.Column("max_uses", sa.Integer(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+            sa.Column("id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("created_by_user_id", sa.String(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            comment="Invitations to join teams, can be direct or via invitation code",
+            info={
+                "source_module": "serverframework.extensions.auth_invitations.BLL_Invitations",
+                "extension": "auth_invitations",
+            },
         )
-        """
-    )
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS invitees (
-            id VARCHAR(36) PRIMARY KEY,
-            invitation_id VARCHAR(36) NOT NULL,
-            email VARCHAR(320),
-            user_id VARCHAR(36),
-            accepted_at TIMESTAMP,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+
+    if not _has_table("invitees"):
+        op.create_table(
+            "invitees",
+            sa.Column("invitation_id", sa.String(), nullable=True),
+            sa.Column("user_id", sa.String(), nullable=True),
+            sa.Column("email", sa.String(), nullable=False),
+            sa.Column("declined_at", sa.DateTime(), nullable=True),
+            sa.Column("accepted_at", sa.DateTime(), nullable=True),
+            sa.Column("id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("created_by_user_id", sa.String(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            comment="Tracks specific individuals invited to join a team",
+            info={
+                "source_module": "serverframework.extensions.auth_invitations.BLL_Invitations",
+                "extension": "auth_invitations",
+            },
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_invitations_team ON invitations(team_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_invitees_invitation ON invitees(invitation_id)"
-    )
+
+    invitations_idx = _existing_index_names("invitations")
+    if "ix_invitations_team" not in invitations_idx:
+        op.create_index("ix_invitations_team", "invitations", ["team_id"])
+
+    invitees_idx = _existing_index_names("invitees")
+    if "ix_invitees_invitation" not in invitees_idx:
+        op.create_index("ix_invitees_invitation", "invitees", ["invitation_id"])
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE IF EXISTS invitees")
-    op.execute("DROP TABLE IF EXISTS invitations")
+    invitees_idx = _existing_index_names("invitees")
+    if "ix_invitees_invitation" in invitees_idx:
+        op.drop_index("ix_invitees_invitation", table_name="invitees")
+
+    invitations_idx = _existing_index_names("invitations")
+    if "ix_invitations_team" in invitations_idx:
+        op.drop_index("ix_invitations_team", table_name="invitations")
+
+    if _has_table("invitees"):
+        op.drop_table("invitees")
+    if _has_table("invitations"):
+        op.drop_table("invitations")

--- a/src/serverframework/extensions/auth_lockout/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/auth_lockout/migrations/versions/001_initial.py
@@ -1,35 +1,69 @@
-"""Initial migration for auth_lockout — owns `failed_login_attempts`."""
+"""Initial migration for auth_lockout — owns `failed_login_attempts`.
 
+The `failed_login_attempts` table was originally created by core in
+`e0b0dc9d5070_initial_schema.py` before the Phase-2 carve-out (PR #144).
+On databases stamped with that core revision the table already exists;
+the Inspector check below makes the upgrade a no-op in that case. On
+fresh databases, core's initial schema is still the file that creates
+the table — this revision tracks ownership for any *subsequent* schema
+changes the extension makes to it.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
 from alembic import op
 
 
-revision = "001_auth_lockout_initial"
-down_revision = None
-branch_labels = ("auth_lockout",)
-depends_on = None
+revision: str = "001_auth_lockout_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("auth_lockout",)
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS failed_login_attempts (
-            id VARCHAR(36) PRIMARY KEY,
-            user_id VARCHAR(36),
-            ip_address VARCHAR(64),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("failed_login_attempts"):
+        op.create_table(
+            "failed_login_attempts",
+            sa.Column("user_id", sa.String(), nullable=True),
+            sa.Column("ip_address", sa.String(), nullable=True),
+            sa.Column("id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("created_by_user_id", sa.String(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            comment="Failed login attempts for rate limiting and lockout",
+            info={
+                "source_module": "serverframework.extensions.auth_lockout.BLL_Lockout",
+                "extension": "auth_lockout",
+            },
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_failed_login_attempts_user_created "
-        "ON failed_login_attempts(user_id, created_at)"
-    )
+
+    existing = _existing_index_names("failed_login_attempts")
+    if "ix_failed_login_attempts_user_created" not in existing:
+        op.create_index(
+            "ix_failed_login_attempts_user_created",
+            "failed_login_attempts",
+            ["user_id", "created_at"],
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE IF EXISTS failed_login_attempts")
+    existing = _existing_index_names("failed_login_attempts")
+    if "ix_failed_login_attempts_user_created" in existing:
+        op.drop_index(
+            "ix_failed_login_attempts_user_created",
+            table_name="failed_login_attempts",
+        )
+    if _has_table("failed_login_attempts"):
+        op.drop_table("failed_login_attempts")

--- a/src/serverframework/extensions/auth_recovery_questions/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/auth_recovery_questions/migrations/versions/001_initial.py
@@ -1,42 +1,75 @@
-"""Initial migration — owns the `user_recovery_questions` table.
+"""Initial migration for auth_recovery_questions — owns `user_recovery_questions`.
 
-Extension carve-out from core (Scope #1). The table previously lived in
-core migrations; this migration takes ownership without rebuilding it
-(idempotent CREATE IF NOT EXISTS).
+The `user_recovery_questions` table was originally created by core in
+`e0b0dc9d5070_initial_schema.py` before the Phase-2 carve-out (PR #144).
+On databases stamped with that core revision the table already exists;
+the Inspector check below makes the upgrade a no-op in that case. On
+fresh databases, core's initial schema is still the file that creates
+the table — this revision tracks ownership for any *subsequent* schema
+changes the extension makes to it.
 """
 
-from alembic import op
+from typing import Sequence, Union
+
 import sqlalchemy as sa
+from alembic import op
 
 
-revision = "001_auth_recovery_questions_initial"
-down_revision = None
-branch_labels = ("auth_recovery_questions",)
-depends_on = None
+revision: str = "001_auth_recovery_questions_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("auth_recovery_questions",)
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS user_recovery_questions (
-            id VARCHAR(36) PRIMARY KEY,
-            user_id VARCHAR(36) NOT NULL,
-            question VARCHAR(512) NOT NULL,
-            answer VARCHAR(255) NOT NULL,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("user_recovery_questions"):
+        op.create_table(
+            "user_recovery_questions",
+            sa.Column("user_id", sa.String(), nullable=True),
+            sa.Column("question", sa.String(), nullable=False),
+            sa.Column("answer", sa.String(), nullable=False),
+            sa.Column("id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("created_by_user_id", sa.String(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            comment="Per-user recovery question/answer pairs",
+            info={
+                "source_module": "serverframework.extensions.auth_recovery_questions.BLL_Recovery_Questions",
+                "extension": "auth_recovery_questions",
+            },
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_user_recovery_questions_user_id "
-        "ON user_recovery_questions(user_id)"
-    )
+
+    existing = _existing_index_names("user_recovery_questions")
+    if "ix_user_recovery_questions_user_id" not in existing:
+        op.create_index(
+            "ix_user_recovery_questions_user_id",
+            "user_recovery_questions",
+            ["user_id"],
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE IF EXISTS user_recovery_questions")
+    existing = _existing_index_names("user_recovery_questions")
+    if "ix_user_recovery_questions_user_id" in existing:
+        op.drop_index(
+            "ix_user_recovery_questions_user_id",
+            table_name="user_recovery_questions",
+        )
+    if _has_table("user_recovery_questions"):
+        op.drop_table("user_recovery_questions")

--- a/src/serverframework/extensions/metadata/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/metadata/migrations/versions/001_initial.py
@@ -1,39 +1,72 @@
-"""Initial migration for metadata — owns the `metadata` table."""
+"""Initial migration for metadata — owns the `metadata` table.
 
+The `metadata` table was originally created by core in
+`e0b0dc9d5070_initial_schema.py` before the Phase-2 carve-out (PR #144).
+On databases stamped with that core revision the table already exists;
+the Inspector check below makes the upgrade a no-op in that case. On
+fresh databases, core's initial schema is still the file that creates
+the table — this revision tracks ownership for any *subsequent* schema
+changes the extension makes to it.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
 from alembic import op
 
 
-revision = "001_metadata_initial"
-down_revision = None
-branch_labels = ("metadata",)
-depends_on = None
+revision: str = "001_metadata_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("metadata",)
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS metadata (
-            id VARCHAR(36) PRIMARY KEY,
-            user_id VARCHAR(36),
-            team_id VARCHAR(36),
-            key VARCHAR(255) NOT NULL,
-            value TEXT,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("metadata"):
+        op.create_table(
+            "metadata",
+            sa.Column("user_id", sa.String(), nullable=True),
+            sa.Column("team_id", sa.String(), nullable=True),
+            sa.Column("key", sa.String(), nullable=False),
+            sa.Column("value", sa.String(), nullable=True),
+            sa.Column("id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("created_by_user_id", sa.String(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            comment="Unified metadata table for users and teams",
+            info={
+                "source_module": "serverframework.extensions.metadata.BLL_Metadata",
+                "extension": "metadata",
+            },
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_metadata_user_key ON metadata(user_id, key)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_metadata_team_key ON metadata(team_id, key)"
-    )
+
+    existing = _existing_index_names("metadata")
+    if "ix_metadata_user_key" not in existing:
+        op.create_index("ix_metadata_user_key", "metadata", ["user_id", "key"])
+    if "ix_metadata_team_key" not in existing:
+        op.create_index("ix_metadata_team_key", "metadata", ["team_id", "key"])
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE IF EXISTS metadata")
+    existing = _existing_index_names("metadata")
+    if "ix_metadata_team_key" in existing:
+        op.drop_index("ix_metadata_team_key", table_name="metadata")
+    if "ix_metadata_user_key" in existing:
+        op.drop_index("ix_metadata_user_key", table_name="metadata")
+    if _has_table("metadata"):
+        op.drop_table("metadata")


### PR DESCRIPTION
The five Phase-2 carve-out migrations introduced in #144 were written as
op.execute("CREATE TABLE ...") with hardcoded `VARCHAR`, `BOOLEAN DEFAULT 0`
and `TIMESTAMP` literals. That bypasses SQLAlchemy's dialect translation
(BOOLEAN DEFAULT 0 fails on PostgreSQL), drops Alembic's batch/inspect
machinery, and dropped at least one column on the way through (`enabled`
on `permissions`).

This rewrites all five to use `op.create_table(...)` with `sa.Column` types
matching the canonical core initial schema (e0b0dc9d5070), and gates the
table/index DDL behind a SQLAlchemy Inspector check so the upgrade is a
no-op on legacy databases where core's pre-carve-out initial schema
already created the tables.

Files:
  extensions/acl_rbac/migrations/versions/001_initial.py
  extensions/auth_invitations/migrations/versions/001_initial.py
  extensions/auth_lockout/migrations/versions/001_initial.py
  extensions/auth_recovery_questions/migrations/versions/001_initial.py
  extensions/metadata/migrations/versions/001_initial.py