### PR TITLE
Add rpg_state and rpg_log extensions

### DIFF
--- a/src/serverframework/extensions/rpg_log/BLL_RPGLog.py
+++ b/src/serverframework/extensions/rpg_log/BLL_RPGLog.py
@@ -1,0 +1,499 @@
+"""rpg_log — event log models and managers for RPG campaigns.
+
+Sibling to ``rpg_state``. Every log row carries:
+- ``campaign_id`` (Reference to rpg_state.CampaignModel)
+- ``occurred_at`` — in-game time the event happened, distinct from the
+  audit ``created_at`` (when the row was logged).
+- ``session_id`` — optional grouping by play session.
+
+Logs are editable (UpdateMixinModel) so GMs can fix typos and retcon;
+the standard ``updated_at`` / ``updated_by_user_id`` audit fields
+preserve the change trail.
+
+Multiple FKs to the same target table (e.g. attacker / defender both
+referencing characters; from / to both referencing locations) are
+declared as plain ``Optional[str]`` columns rather than via the
+``Reference`` mixin, since the metaclass keys field-name generation off
+the target model name and would collide.
+"""
+
+from datetime import datetime
+from typing import ClassVar, List, Optional, Type
+
+from pydantic import Field
+
+from serverframework.extensions.rpg_state.BLL_RPGState import (
+    CampaignModel,
+    CharacterModel,
+    ItemInstanceModel,
+    LocationModel,
+    TraitModel,
+)
+from serverframework.lib.Pydantic import BaseModel
+from serverframework.lib.Pydantic2FastAPI import RouterMixin
+from serverframework.logic.AbstractLogicManager import (
+    AbstractBLLManager,
+    ApplicationModel,
+    DateSearchModel,
+    DescriptionMixinModel,
+    ModelMeta,
+    NameMixinModel,
+    NumericalSearchModel,
+    StringSearchModel,
+    UpdateMixinModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Encounters & participation
+# ---------------------------------------------------------------------------
+
+
+class EncounterLogModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    LocationModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["EncounterLogManager"]] = None
+    occurred_at: Optional[datetime] = Field(
+        None, description="In-game time the encounter began"
+    )
+    session_id: Optional[str] = Field(None, description="Optional play-session group")
+    started_at: Optional[datetime] = Field(None)
+    ended_at: Optional[datetime] = Field(None)
+    outcome: Optional[str] = Field(
+        None, description="Free-form summary (won|fled|negotiated|...)"
+    )
+    table_comment: ClassVar[str] = "Top-level encounter log (combat or otherwise)"
+
+    class Create(
+        BaseModel,
+        CampaignModel.Reference.ID.Optional,
+        LocationModel.Reference.ID.Optional,
+    ):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        occurred_at: Optional[datetime] = None
+        session_id: Optional[str] = None
+        started_at: Optional[datetime] = None
+        ended_at: Optional[datetime] = None
+        outcome: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        ended_at: Optional[datetime] = None
+        outcome: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CampaignModel.Reference.ID.Search,
+        LocationModel.Reference.ID.Search,
+    ):
+        occurred_at: Optional[DateSearchModel] = None
+        session_id: Optional[StringSearchModel] = None
+        outcome: Optional[StringSearchModel] = None
+
+
+class EncounterLogManager(AbstractBLLManager, RouterMixin):
+    _model = EncounterLogModel
+
+
+EncounterLogModel.Manager = EncounterLogManager
+
+
+class EncounterParticipantModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    EncounterLogModel.Reference.Optional,
+    CharacterModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["EncounterParticipantManager"]] = None
+    # Free-form side label so multi-side fights work
+    # (attackers / defenders / wildlife / bystanders / ...).
+    side: Optional[str] = Field(None, description="Side / faction-of-convenience label")
+    # Faction at encounter time. Manual to avoid a Reference collision —
+    # the participant table doesn't need a back-resolved Faction object.
+    faction_id: Optional[str] = Field(None)
+    initiative: Optional[float] = Field(None)
+    table_comment: ClassVar[str] = (
+        "Roster of an encounter. Faction inferable; explicit faction_id "
+        "captures the snapshot at encounter time."
+    )
+
+    class Create(
+        BaseModel,
+        EncounterLogModel.Reference.ID.Optional,
+        CharacterModel.Reference.ID.Optional,
+    ):
+        side: Optional[str] = None
+        faction_id: Optional[str] = None
+        initiative: Optional[float] = None
+
+    class Update(BaseModel):
+        side: Optional[str] = None
+        faction_id: Optional[str] = None
+        initiative: Optional[float] = None
+
+    class Search(
+        ApplicationModel.Search,
+        EncounterLogModel.Reference.ID.Search,
+        CharacterModel.Reference.ID.Search,
+    ):
+        side: Optional[StringSearchModel] = None
+        faction_id: Optional[StringSearchModel] = None
+
+
+class EncounterParticipantManager(AbstractBLLManager, RouterMixin):
+    _model = EncounterParticipantModel
+
+
+EncounterParticipantModel.Manager = EncounterParticipantManager
+
+
+# ---------------------------------------------------------------------------
+# Combat
+# ---------------------------------------------------------------------------
+
+
+class CombatActionLogModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    EncounterLogModel.Reference.Optional,
+    CampaignModel.Reference.Optional,
+    ItemInstanceModel.Reference.Optional,
+    TraitModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CombatActionLogManager"]] = None
+    # Two characters per action (actor + target); declared manually since
+    # CharacterModel.Reference would collide.
+    actor_character_id: Optional[str] = Field(None)
+    target_character_id: Optional[str] = Field(None)
+    action_type: Optional[str] = Field(
+        None, description="attack|cast|defend|item_use|movement|other"
+    )
+    result: Optional[str] = Field(
+        None, description="hit|miss|crit|saved|... (free-form)"
+    )
+    damage_amount: Optional[float] = Field(None)
+    round_number: Optional[int] = Field(None)
+    occurred_at: Optional[datetime] = Field(None)
+    session_id: Optional[str] = Field(None)
+    table_comment: ClassVar[str] = (
+        "One row per combat action. trait_id = spell/skill used (unified Trait); "
+        "item_instance_id = weapon/consumable used."
+    )
+
+    class Create(
+        BaseModel,
+        EncounterLogModel.Reference.ID.Optional,
+        CampaignModel.Reference.ID.Optional,
+        ItemInstanceModel.Reference.ID.Optional,
+        TraitModel.Reference.ID.Optional,
+    ):
+        actor_character_id: Optional[str] = None
+        target_character_id: Optional[str] = None
+        action_type: Optional[str] = None
+        result: Optional[str] = None
+        damage_amount: Optional[float] = None
+        round_number: Optional[int] = None
+        occurred_at: Optional[datetime] = None
+        session_id: Optional[str] = None
+
+    class Update(BaseModel):
+        action_type: Optional[str] = None
+        result: Optional[str] = None
+        damage_amount: Optional[float] = None
+        round_number: Optional[int] = None
+
+    class Search(
+        ApplicationModel.Search,
+        EncounterLogModel.Reference.ID.Search,
+        CampaignModel.Reference.ID.Search,
+    ):
+        actor_character_id: Optional[StringSearchModel] = None
+        target_character_id: Optional[StringSearchModel] = None
+        action_type: Optional[StringSearchModel] = None
+        damage_amount: Optional[NumericalSearchModel] = None
+        round_number: Optional[NumericalSearchModel] = None
+        occurred_at: Optional[DateSearchModel] = None
+
+
+class CombatActionLogManager(AbstractBLLManager, RouterMixin):
+    _model = CombatActionLogModel
+
+
+CombatActionLogModel.Manager = CombatActionLogManager
+
+
+# ---------------------------------------------------------------------------
+# Dialogue (with group support)
+# ---------------------------------------------------------------------------
+
+
+class DialogueLogModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    LocationModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["DialogueLogManager"]] = None
+    actor_character_id: Optional[str] = Field(None, description="Speaker")
+    target_character_id: Optional[str] = Field(
+        None, description="Primary addressee (null for group / monologue)"
+    )
+    text: Optional[str] = Field(None)
+    tone: Optional[str] = Field(None, description="hostile|friendly|sarcastic|...")
+    occurred_at: Optional[datetime] = Field(None)
+    session_id: Optional[str] = Field(None)
+    table_comment: ClassVar[str] = (
+        "One uttered line. DialogueParticipant carries the full audience "
+        "for group conversations."
+    )
+
+    class Create(
+        BaseModel,
+        CampaignModel.Reference.ID.Optional,
+        LocationModel.Reference.ID.Optional,
+    ):
+        actor_character_id: Optional[str] = None
+        target_character_id: Optional[str] = None
+        text: Optional[str] = None
+        tone: Optional[str] = None
+        occurred_at: Optional[datetime] = None
+        session_id: Optional[str] = None
+
+    class Update(BaseModel):
+        text: Optional[str] = None
+        tone: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CampaignModel.Reference.ID.Search,
+        LocationModel.Reference.ID.Search,
+    ):
+        actor_character_id: Optional[StringSearchModel] = None
+        target_character_id: Optional[StringSearchModel] = None
+        tone: Optional[StringSearchModel] = None
+        occurred_at: Optional[DateSearchModel] = None
+
+
+class DialogueLogManager(AbstractBLLManager, RouterMixin):
+    _model = DialogueLogModel
+
+
+DialogueLogModel.Manager = DialogueLogManager
+
+
+class DialogueParticipantModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    DialogueLogModel.Reference.Optional,
+    CharacterModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["DialogueParticipantManager"]] = None
+    role: Optional[str] = Field(
+        None, description="speaker|addressee|overhearer"
+    )
+    table_comment: ClassVar[str] = (
+        "Audience join for DialogueLog (group conversations, eavesdroppers)."
+    )
+
+    class Create(
+        BaseModel,
+        DialogueLogModel.Reference.ID.Optional,
+        CharacterModel.Reference.ID.Optional,
+    ):
+        role: Optional[str] = None
+
+    class Update(BaseModel):
+        role: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        DialogueLogModel.Reference.ID.Search,
+        CharacterModel.Reference.ID.Search,
+    ):
+        role: Optional[StringSearchModel] = None
+
+
+class DialogueParticipantManager(AbstractBLLManager, RouterMixin):
+    _model = DialogueParticipantModel
+
+
+DialogueParticipantModel.Manager = DialogueParticipantManager
+
+
+# ---------------------------------------------------------------------------
+# Interactions (use / examine / pickup / open / lock / ...)
+# ---------------------------------------------------------------------------
+
+
+class InteractionLogModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    LocationModel.Reference.Optional,
+    ItemInstanceModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["InteractionLogManager"]] = None
+    actor_character_id: Optional[str] = Field(None)
+    interaction_type: Optional[str] = Field(
+        None,
+        description="examine|use|open|pickup|drop|lock|unlock|read|...",
+    )
+    notes: Optional[str] = Field(None)
+    occurred_at: Optional[datetime] = Field(None)
+    session_id: Optional[str] = Field(None)
+    table_comment: ClassVar[str] = (
+        "Non-combat / non-dialogue interactions with the world or items."
+    )
+
+    class Create(
+        BaseModel,
+        CampaignModel.Reference.ID.Optional,
+        LocationModel.Reference.ID.Optional,
+        ItemInstanceModel.Reference.ID.Optional,
+    ):
+        actor_character_id: Optional[str] = None
+        interaction_type: Optional[str] = None
+        notes: Optional[str] = None
+        occurred_at: Optional[datetime] = None
+        session_id: Optional[str] = None
+
+    class Update(BaseModel):
+        interaction_type: Optional[str] = None
+        notes: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CampaignModel.Reference.ID.Search,
+        LocationModel.Reference.ID.Search,
+        ItemInstanceModel.Reference.ID.Search,
+    ):
+        actor_character_id: Optional[StringSearchModel] = None
+        interaction_type: Optional[StringSearchModel] = None
+        occurred_at: Optional[DateSearchModel] = None
+
+
+class InteractionLogManager(AbstractBLLManager, RouterMixin):
+    _model = InteractionLogModel
+
+
+InteractionLogModel.Manager = InteractionLogManager
+
+
+# ---------------------------------------------------------------------------
+# Transactions (trade, theft, looting, gifts)
+# ---------------------------------------------------------------------------
+
+
+class TransactionLogModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    ItemInstanceModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["TransactionLogManager"]] = None
+    quantity: Optional[int] = Field(1)
+    # From / to. Manual columns since both reference the same target tables.
+    from_location_id: Optional[str] = Field(None)
+    to_location_id: Optional[str] = Field(None)
+    from_owner_character_id: Optional[str] = Field(None)
+    to_owner_character_id: Optional[str] = Field(None)
+    from_owner_faction_id: Optional[str] = Field(None)
+    to_owner_faction_id: Optional[str] = Field(None)
+    price: Optional[float] = Field(None, description="Sale price (null = non-monetary)")
+    kind: Optional[str] = Field(
+        None, description="trade|gift|theft|loot|inheritance|..."
+    )
+    occurred_at: Optional[datetime] = Field(None)
+    session_id: Optional[str] = Field(None)
+    table_comment: ClassVar[str] = (
+        "One row per item movement. captures trade, theft, looting, and gifts."
+    )
+
+    class Create(
+        BaseModel,
+        CampaignModel.Reference.ID.Optional,
+        ItemInstanceModel.Reference.ID.Optional,
+    ):
+        quantity: Optional[int] = None
+        from_location_id: Optional[str] = None
+        to_location_id: Optional[str] = None
+        from_owner_character_id: Optional[str] = None
+        to_owner_character_id: Optional[str] = None
+        from_owner_faction_id: Optional[str] = None
+        to_owner_faction_id: Optional[str] = None
+        price: Optional[float] = None
+        kind: Optional[str] = None
+        occurred_at: Optional[datetime] = None
+        session_id: Optional[str] = None
+
+    class Update(BaseModel):
+        kind: Optional[str] = None
+        price: Optional[float] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CampaignModel.Reference.ID.Search,
+        ItemInstanceModel.Reference.ID.Search,
+    ):
+        kind: Optional[StringSearchModel] = None
+        from_owner_character_id: Optional[StringSearchModel] = None
+        to_owner_character_id: Optional[StringSearchModel] = None
+        from_owner_faction_id: Optional[StringSearchModel] = None
+        to_owner_faction_id: Optional[StringSearchModel] = None
+        occurred_at: Optional[DateSearchModel] = None
+
+
+class TransactionLogManager(AbstractBLLManager, RouterMixin):
+    _model = TransactionLogModel
+
+
+TransactionLogModel.Manager = TransactionLogManager
+
+
+# ---------------------------------------------------------------------------
+# Public roster
+# ---------------------------------------------------------------------------
+
+
+ALL_MODELS: List[type] = [
+    EncounterLogModel,
+    EncounterParticipantModel,
+    CombatActionLogModel,
+    DialogueLogModel,
+    DialogueParticipantModel,
+    InteractionLogModel,
+    TransactionLogModel,
+]
+
+
+__all__ = [
+    "EncounterLogModel",
+    "EncounterLogManager",
+    "EncounterParticipantModel",
+    "EncounterParticipantManager",
+    "CombatActionLogModel",
+    "CombatActionLogManager",
+    "DialogueLogModel",
+    "DialogueLogManager",
+    "DialogueParticipantModel",
+    "DialogueParticipantManager",
+    "InteractionLogModel",
+    "InteractionLogManager",
+    "TransactionLogModel",
+    "TransactionLogManager",
+    "ALL_MODELS",
+]

--- a/src/serverframework/extensions/rpg_log/BLL_RPGLog_test.py
+++ b/src/serverframework/extensions/rpg_log/BLL_RPGLog_test.py
@@ -1,0 +1,175 @@
+"""Structural tests for the rpg_log extension's BLL surface."""
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "x" * 32)
+os.environ.setdefault("PYTEST_CURRENT_TEST", "rpg_log_test")
+
+from serverframework.extensions.rpg_log.BLL_RPGLog import (
+    ALL_MODELS,
+    CombatActionLogManager,
+    CombatActionLogModel,
+    DialogueLogManager,
+    DialogueLogModel,
+    DialogueParticipantManager,
+    DialogueParticipantModel,
+    EncounterLogManager,
+    EncounterLogModel,
+    EncounterParticipantManager,
+    EncounterParticipantModel,
+    InteractionLogManager,
+    InteractionLogModel,
+    TransactionLogManager,
+    TransactionLogModel,
+)
+
+
+class TestModelManagerWiring:
+    PAIRS = [
+        (EncounterLogModel, EncounterLogManager),
+        (EncounterParticipantModel, EncounterParticipantManager),
+        (CombatActionLogModel, CombatActionLogManager),
+        (DialogueLogModel, DialogueLogManager),
+        (DialogueParticipantModel, DialogueParticipantManager),
+        (InteractionLogModel, InteractionLogManager),
+        (TransactionLogModel, TransactionLogManager),
+    ]
+
+    def test_each_model_has_its_manager(self):
+        for model, manager in self.PAIRS:
+            assert model.Manager is manager
+            assert manager._model is model
+
+    def test_all_models_listed(self):
+        assert set(ALL_MODELS) == {model for model, _ in self.PAIRS}
+
+
+class TestCreateUpdateSearchPresent:
+    def test_nested_classes_exist(self):
+        for model in ALL_MODELS:
+            assert hasattr(model, "Create"), f"{model.__name__} missing Create"
+            assert hasattr(model, "Update"), f"{model.__name__} missing Update"
+            assert hasattr(model, "Search"), f"{model.__name__} missing Search"
+
+
+class TestEncounterParticipation:
+    """Multi-faction encounters are expressed via EncounterParticipant
+    rows with free-form side labels, not a single FactionID on
+    EncounterLog."""
+
+    def test_encounter_log_has_no_faction_field(self):
+        # The model deliberately omits a faction_id on EncounterLog itself.
+        ep = EncounterLogModel.Create(name="Tavern brawl")
+        assert not hasattr(ep, "faction_id")
+
+    def test_participant_carries_side_and_faction(self):
+        p = EncounterParticipantModel.Create(
+            encounter_log_id="enc-1",
+            character_id="bob",
+            faction_id="party",
+            side="defenders",
+            initiative=14.0,
+        )
+        assert p.side == "defenders"
+        assert p.faction_id == "party"
+
+
+class TestCombatActionShape:
+    """A combat action has actor + (optional) target characters and may
+    reference a weapon (item_instance) and/or a spell/skill (trait)."""
+
+    def test_attack_with_weapon(self):
+        a = CombatActionLogModel.Create(
+            encounter_log_id="enc-1",
+            actor_character_id="bob",
+            target_character_id="orc-1",
+            item_instance_id="ii-sword",
+            action_type="attack",
+            result="hit",
+            damage_amount=8.0,
+            round_number=2,
+        )
+        assert a.actor_character_id == "bob"
+        assert a.item_instance_id == "ii-sword"
+        assert a.damage_amount == 8.0
+
+    def test_spell_uses_trait_id(self):
+        # A spell IS a Trait (kind='spell') in the unified model.
+        a = CombatActionLogModel.Create(
+            encounter_log_id="enc-1",
+            actor_character_id="wizard",
+            target_character_id="orc-2",
+            trait_id="spell-fireball",
+            action_type="cast",
+            result="hit",
+            damage_amount=24.0,
+        )
+        assert a.trait_id == "spell-fireball"
+
+
+class TestDialogueGroupSupport:
+    def test_dialogue_log_basic(self):
+        d = DialogueLogModel.Create(
+            actor_character_id="bob",
+            target_character_id="innkeep",
+            text="One ale, please.",
+            tone="friendly",
+        )
+        assert d.actor_character_id == "bob"
+        assert d.text == "One ale, please."
+
+    def test_dialogue_participant_for_eavesdroppers(self):
+        # A bard secretly listening from the next table.
+        p = DialogueParticipantModel.Create(
+            dialogue_log_id="dl-1",
+            character_id="bard",
+            role="overhearer",
+        )
+        assert p.role == "overhearer"
+
+
+class TestTransactionShape:
+    """TransactionLog captures the full from→to delta in a single row."""
+
+    def test_trade_carries_both_endpoints(self):
+        t = TransactionLogModel.Create(
+            item_instance_id="ii-sword",
+            quantity=1,
+            from_owner_character_id="merchant",
+            to_owner_character_id="bob",
+            from_location_id="loc-shop",
+            to_location_id="loc-bob-pack",
+            price=50.0,
+            kind="trade",
+        )
+        assert t.from_owner_character_id == "merchant"
+        assert t.to_owner_character_id == "bob"
+        assert t.price == 50.0
+        assert t.kind == "trade"
+
+    def test_theft_has_no_consensual_owner_handoff(self):
+        # Stolen: location moves but legal owner doesn't.
+        t = TransactionLogModel.Create(
+            item_instance_id="ii-amulet",
+            quantity=1,
+            from_location_id="loc-altar",
+            to_location_id="loc-thief-pack",
+            kind="theft",
+        )
+        assert t.from_owner_character_id is None
+        assert t.to_owner_character_id is None
+        assert t.kind == "theft"
+
+
+class TestLogsAreEditable:
+    """Logs use UpdateMixinModel — the user opted for editable logs over
+    append-only. The Update class on each log model exposes mutable fields."""
+
+    def test_combat_action_update_present(self):
+        u = CombatActionLogModel.Update(damage_amount=10.0, result="crit")
+        assert u.damage_amount == 10.0
+        assert u.result == "crit"
+
+    def test_dialogue_text_editable(self):
+        u = DialogueLogModel.Update(text="One ale, on the house.")
+        assert u.text == "One ale, on the house."

--- a/src/serverframework/extensions/rpg_log/EXT_RPGLog.py
+++ b/src/serverframework/extensions/rpg_log/EXT_RPGLog.py
@@ -1,0 +1,25 @@
+"""rpg_log extension definition.
+
+Owns event-log tables. Depends on rpg_state for character / location /
+item / trait / campaign references.
+"""
+
+from typing import ClassVar, List, Type
+
+from serverframework.extensions.AbstractExtensionProvider import (
+    AbstractStaticExtension,
+)
+
+
+class RPGLogExtension(AbstractStaticExtension):
+    name: ClassVar[str] = "rpg_log"
+    description: ClassVar[str] = (
+        "Event-log schema for RPG campaigns (combat, dialogue, transactions)"
+    )
+    extension_dependencies: ClassVar[List[str]] = ["rpg_state"]
+
+    @classmethod
+    def models(cls) -> List[Type]:
+        from serverframework.extensions.rpg_log.BLL_RPGLog import ALL_MODELS
+
+        return list(ALL_MODELS)

--- a/src/serverframework/extensions/rpg_log/EXT_RPGLog_test.py
+++ b/src/serverframework/extensions/rpg_log/EXT_RPGLog_test.py
@@ -1,0 +1,23 @@
+"""Extension-level tests for rpg_log."""
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "x" * 32)
+os.environ.setdefault("PYTEST_CURRENT_TEST", "rpg_log_ext_test")
+
+from serverframework.extensions.rpg_log.BLL_RPGLog import ALL_MODELS
+from serverframework.extensions.rpg_log.EXT_RPGLog import RPGLogExtension
+
+
+class TestExtensionMetadata:
+    def test_name_and_description(self):
+        assert RPGLogExtension.name == "rpg_log"
+        assert "log" in RPGLogExtension.description.lower()
+
+    def test_depends_on_rpg_state(self):
+        assert RPGLogExtension.extension_dependencies == ["rpg_state"]
+
+    def test_models_returns_full_roster(self):
+        models = RPGLogExtension.models()
+        assert set(models) == set(ALL_MODELS)
+        assert len(models) == 7  # bump when adding log tables.

--- a/src/serverframework/extensions/rpg_log/__init__.py
+++ b/src/serverframework/extensions/rpg_log/__init__.py
@@ -1,0 +1,11 @@
+"""rpg_log extension.
+
+Owns the event-log tables for an RPG campaign: encounters, combat
+actions, dialogue, interactions, and item transactions. Reads the
+present-state shape from the sibling ``rpg_state`` extension and depends
+on it.
+
+Logs are editable (standard ``UpdateMixinModel`` audit fields) so GMs
+can correct typos and retcon. The ``created_at`` / ``updated_at`` audit
+trail preserves history.
+"""

--- a/src/serverframework/extensions/rpg_log/manifest.toml
+++ b/src/serverframework/extensions/rpg_log/manifest.toml
@@ -1,0 +1,9 @@
+name = "rpg_log"
+version = "0.1.0"
+description = "Event-log schema for RPG campaigns — encounters, combat, dialogue, interactions, transactions"
+
+[[extension_dependencies]]
+name = "rpg_state"
+optional = false
+
+[python_dependencies]

--- a/src/serverframework/extensions/rpg_log/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_log/migrations/versions/001_initial.py
@@ -1,0 +1,225 @@
+"""Initial migration for rpg_log — owns the event-log tables.
+
+Schema is loose (no SQL FK constraints) to match existing extension
+migrations. Referential integrity is enforced at the ORM/manager layer.
+"""
+
+from alembic import op
+
+
+revision = "001_rpg_log_initial"
+down_revision = None
+branch_labels = ("rpg_log",)
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS encounter_logs (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            campaign_id VARCHAR(36),
+            location_id VARCHAR(36),
+            occurred_at TIMESTAMP,
+            session_id VARCHAR(36),
+            started_at TIMESTAMP,
+            ended_at TIMESTAMP,
+            outcome VARCHAR(255),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_enc_campaign ON encounter_logs(campaign_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_enc_session ON encounter_logs(session_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS encounter_participants (
+            id VARCHAR(36) PRIMARY KEY,
+            encounter_log_id VARCHAR(36),
+            character_id VARCHAR(36),
+            faction_id VARCHAR(36),
+            side VARCHAR(64),
+            initiative REAL,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ep_encounter "
+        "ON encounter_participants(encounter_log_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ep_character "
+        "ON encounter_participants(character_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS combat_action_logs (
+            id VARCHAR(36) PRIMARY KEY,
+            encounter_log_id VARCHAR(36),
+            campaign_id VARCHAR(36),
+            actor_character_id VARCHAR(36),
+            target_character_id VARCHAR(36),
+            item_instance_id VARCHAR(36),
+            trait_id VARCHAR(36),
+            action_type VARCHAR(64),
+            result VARCHAR(64),
+            damage_amount REAL,
+            round_number INTEGER,
+            occurred_at TIMESTAMP,
+            session_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cal_encounter "
+        "ON combat_action_logs(encounter_log_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cal_actor "
+        "ON combat_action_logs(actor_character_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cal_target "
+        "ON combat_action_logs(target_character_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dialogue_logs (
+            id VARCHAR(36) PRIMARY KEY,
+            campaign_id VARCHAR(36),
+            location_id VARCHAR(36),
+            actor_character_id VARCHAR(36),
+            target_character_id VARCHAR(36),
+            text TEXT,
+            tone VARCHAR(64),
+            occurred_at TIMESTAMP,
+            session_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dl_actor "
+        "ON dialogue_logs(actor_character_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dialogue_participants (
+            id VARCHAR(36) PRIMARY KEY,
+            dialogue_log_id VARCHAR(36),
+            character_id VARCHAR(36),
+            role VARCHAR(64),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_dp_dialogue "
+        "ON dialogue_participants(dialogue_log_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS interaction_logs (
+            id VARCHAR(36) PRIMARY KEY,
+            campaign_id VARCHAR(36),
+            location_id VARCHAR(36),
+            item_instance_id VARCHAR(36),
+            actor_character_id VARCHAR(36),
+            interaction_type VARCHAR(64),
+            notes TEXT,
+            occurred_at TIMESTAMP,
+            session_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_il_actor "
+        "ON interaction_logs(actor_character_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS transaction_logs (
+            id VARCHAR(36) PRIMARY KEY,
+            campaign_id VARCHAR(36),
+            item_instance_id VARCHAR(36),
+            quantity INTEGER DEFAULT 1,
+            from_location_id VARCHAR(36),
+            to_location_id VARCHAR(36),
+            from_owner_character_id VARCHAR(36),
+            to_owner_character_id VARCHAR(36),
+            from_owner_faction_id VARCHAR(36),
+            to_owner_faction_id VARCHAR(36),
+            price REAL,
+            kind VARCHAR(64),
+            occurred_at TIMESTAMP,
+            session_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_tl_item ON transaction_logs(item_instance_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_tl_kind ON transaction_logs(kind)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS transaction_logs")
+    op.execute("DROP TABLE IF EXISTS interaction_logs")
+    op.execute("DROP TABLE IF EXISTS dialogue_participants")
+    op.execute("DROP TABLE IF EXISTS dialogue_logs")
+    op.execute("DROP TABLE IF EXISTS combat_action_logs")
+    op.execute("DROP TABLE IF EXISTS encounter_participants")
+    op.execute("DROP TABLE IF EXISTS encounter_logs")

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState.py
@@ -1,0 +1,999 @@
+"""rpg_state — present-state models and managers for RPG campaigns.
+
+Model groups (declared in dependency order so ``.Reference`` mixins resolve):
+
+1. ``GameSystemModel`` — reference catalog ("DnD 5e", "Pathfinder 2e", ...).
+2. ``CampaignModel`` — root of campaign-scoped data; ``user_id`` is the GM.
+3. Trait / StatusEffect templates — system-agnostic property catalog. The
+   unified ``TraitModel`` carries a ``kind`` discriminator
+   (attribute / skill / spell / talent / feat / language / ability) so the
+   same calculation surface handles permanent learnings and transient buffs.
+4. ``CharacterModel`` — PCs, NPCs, monsters; ``user_id`` is the controlling
+   player when one exists (NPCs leave it null).
+5. Per-character joins (``CharacterTraitModel``,
+   ``CharacterStatusEffectModel``). Magnitude lives on the join: a
+   character's STR=16 is a row on ``CharacterTraitModel.value``; the
+   "+2 STR" granted by Bull's Strength is a ``StatusEffectTraitModel``
+   row with operation='additive', value=2.
+6. Faction hierarchy. ``FactionModel`` uses ``parent_id`` (from
+   ``ParentMixinModel``) to model squads-within-platoons / parties-as-
+   sub-guilds without a separate Party entity.
+7. Spatial model. ``LocationModel`` is recursive (``parent_id``) and may
+   itself be the inside of a container item via
+   ``container_item_instance_id``. Equipment is modelled as a Location
+   bound to a character (``associated_character_id``); equipping is a
+   spatial move, no IsEquipped flag.
+8. Quest / Objective templates separated from per-character /
+   per-faction instances. Objectives carry an optional
+   ``prerequisite_objective_id`` for branching / linear chains.
+
+Ownership semantics on ``ItemInstanceModel``:
+- ``owner_faction_id`` = de jure / "in principle" owner (the Guild owns
+  this sword).
+- ``owner_character_id`` = de facto / "in practice" bearer (Bob carries
+  it). Either, both, or neither may be set; theft is the natural state of
+  having ``owner_character_id`` differ from the legal owner without an
+  intermediate ``TransactionLog``.
+"""
+
+from datetime import datetime
+from typing import ClassVar, List, Optional, Type
+
+from pydantic import Field
+
+from serverframework.lib.Pydantic import BaseModel
+from serverframework.lib.Pydantic2FastAPI import RouterMixin
+from serverframework.logic.AbstractLogicManager import (
+    AbstractBLLManager,
+    ApplicationModel,
+    DateSearchModel,
+    DescriptionMixinModel,
+    ModelMeta,
+    NameMixinModel,
+    NumericalSearchModel,
+    ParentMixinModel,
+    StringSearchModel,
+    UpdateMixinModel,
+)
+from serverframework.logic.BLL_Auth import UserModel
+
+
+# ---------------------------------------------------------------------------
+# 1. GameSystem — reference catalog
+# ---------------------------------------------------------------------------
+
+
+class GameSystemModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["GameSystemManager"]] = None
+    table_comment: ClassVar[str] = (
+        "Reference catalog of supported RPG systems (DnD 5e, Pathfinder 2e, ...)"
+    )
+
+    class Create(BaseModel):
+        name: str = Field(..., description="Display name of the system")
+        description: Optional[str] = Field(None)
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+
+    class Search(ApplicationModel.Search):
+        name: Optional[StringSearchModel] = None
+
+
+class GameSystemManager(AbstractBLLManager, RouterMixin):
+    _model = GameSystemModel
+
+
+GameSystemModel.Manager = GameSystemManager
+
+
+# ---------------------------------------------------------------------------
+# 2. Campaign — tenant root
+# ---------------------------------------------------------------------------
+
+
+class CampaignModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    GameSystemModel.Reference.Optional,
+    UserModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CampaignManager"]] = None
+    table_comment: ClassVar[str] = (
+        "Top-level campaign owning all in-game state. user_id = GM/owner."
+    )
+
+    class Create(
+        BaseModel,
+        GameSystemModel.Reference.ID.Optional,
+        UserModel.Reference.ID.Optional,
+    ):
+        name: str = Field(...)
+        description: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        GameSystemModel.Reference.ID.Search,
+        UserModel.Reference.ID.Search,
+    ):
+        name: Optional[StringSearchModel] = None
+
+
+class CampaignManager(AbstractBLLManager, RouterMixin):
+    _model = CampaignModel
+
+
+CampaignModel.Manager = CampaignManager
+
+
+# ---------------------------------------------------------------------------
+# 3. Trait, StatusEffect, StatusEffectTrait — property catalog
+# ---------------------------------------------------------------------------
+
+
+class TraitModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    GameSystemModel.Reference.Optional,
+    CampaignModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["TraitManager"]] = None
+    # Unified discriminator: attribute|skill|spell|talent|feat|language|ability.
+    # Free string so downstream systems can extend without a schema change.
+    kind: Optional[str] = Field(
+        None,
+        description="attribute|skill|spell|talent|feat|language|ability|...",
+    )
+    # campaign_id null = global template; set = campaign-specific override.
+    table_comment: ClassVar[str] = (
+        "Unified property catalog: stats, skills, spells, talents, feats. "
+        "campaign_id=NULL means a globally-shared template."
+    )
+
+    class Create(
+        BaseModel,
+        GameSystemModel.Reference.ID.Optional,
+        CampaignModel.Reference.ID.Optional,
+    ):
+        name: str = Field(...)
+        description: Optional[str] = None
+        kind: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        kind: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        GameSystemModel.Reference.ID.Search,
+        CampaignModel.Reference.ID.Search,
+    ):
+        name: Optional[StringSearchModel] = None
+        kind: Optional[StringSearchModel] = None
+
+
+class TraitManager(AbstractBLLManager, RouterMixin):
+    _model = TraitModel
+
+
+TraitModel.Manager = TraitManager
+
+
+class StatusEffectModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    GameSystemModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["StatusEffectManager"]] = None
+    default_duration_seconds: Optional[int] = Field(
+        None,
+        description="Default lifetime when applied; null = until removed",
+    )
+    table_comment: ClassVar[str] = (
+        "Status effect templates (buffs, debuffs, conditions). "
+        "Per-trait modifiers live on StatusEffectTrait."
+    )
+
+    class Create(BaseModel, GameSystemModel.Reference.ID.Optional):
+        name: str = Field(...)
+        description: Optional[str] = None
+        default_duration_seconds: Optional[int] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        default_duration_seconds: Optional[int] = None
+
+    class Search(ApplicationModel.Search, GameSystemModel.Reference.ID.Search):
+        name: Optional[StringSearchModel] = None
+
+
+class StatusEffectManager(AbstractBLLManager, RouterMixin):
+    _model = StatusEffectModel
+
+
+StatusEffectModel.Manager = StatusEffectManager
+
+
+class StatusEffectTraitModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    StatusEffectModel.Reference.Optional,
+    TraitModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["StatusEffectTraitManager"]] = None
+    operation: Optional[str] = Field(
+        None,
+        description="additive|multiplicative|set",
+    )
+    value: Optional[float] = Field(
+        None,
+        description="Modifier magnitude (e.g. +2 for additive, x1.5 for multiplicative)",
+    )
+    table_comment: ClassVar[str] = (
+        "Per-trait modifiers contributed by a StatusEffect template. "
+        "Bull's Strength → (status_effect=BullsStrength, trait=STR, "
+        "operation='additive', value=2.0)."
+    )
+
+    class Create(
+        BaseModel,
+        StatusEffectModel.Reference.ID.Optional,
+        TraitModel.Reference.ID.Optional,
+    ):
+        operation: Optional[str] = None
+        value: Optional[float] = None
+
+    class Update(BaseModel):
+        operation: Optional[str] = None
+        value: Optional[float] = None
+
+    class Search(
+        ApplicationModel.Search,
+        StatusEffectModel.Reference.ID.Search,
+        TraitModel.Reference.ID.Search,
+    ):
+        operation: Optional[StringSearchModel] = None
+        value: Optional[NumericalSearchModel] = None
+
+
+class StatusEffectTraitManager(AbstractBLLManager, RouterMixin):
+    _model = StatusEffectTraitModel
+
+
+StatusEffectTraitModel.Manager = StatusEffectTraitManager
+
+
+# ---------------------------------------------------------------------------
+# 4. Character
+# ---------------------------------------------------------------------------
+
+
+class CharacterModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    UserModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CharacterManager"]] = None
+    # pc|npc|monster|creature|vehicle|construct — free-form for system flex.
+    kind: Optional[str] = Field(None, description="pc|npc|monster|creature|...")
+    level: Optional[int] = Field(None, description="System-defined level/tier")
+    table_comment: ClassVar[str] = (
+        "Any in-game actor. user_id = controlling player (PC); null = NPC."
+    )
+
+    class Create(
+        BaseModel,
+        CampaignModel.Reference.ID.Optional,
+        UserModel.Reference.ID.Optional,
+    ):
+        name: str = Field(...)
+        description: Optional[str] = None
+        kind: Optional[str] = None
+        level: Optional[int] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        kind: Optional[str] = None
+        level: Optional[int] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CampaignModel.Reference.ID.Search,
+        UserModel.Reference.ID.Search,
+    ):
+        name: Optional[StringSearchModel] = None
+        kind: Optional[StringSearchModel] = None
+
+
+class CharacterManager(AbstractBLLManager, RouterMixin):
+    _model = CharacterModel
+
+
+CharacterModel.Manager = CharacterManager
+
+
+# ---------------------------------------------------------------------------
+# 5. Per-character joins
+# ---------------------------------------------------------------------------
+
+
+class CharacterTraitModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CharacterModel.Reference.Optional,
+    TraitModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CharacterTraitManager"]] = None
+    value: Optional[float] = Field(
+        None,
+        description="Base magnitude (e.g. STR=16). Active modifiers stack on top.",
+    )
+    rank: Optional[int] = Field(
+        None,
+        description="Optional discrete rank (e.g. proficiency tier)",
+    )
+    notes: Optional[str] = Field(None)
+    table_comment: ClassVar[str] = (
+        "Per-character base trait values. Effective value = this.value + "
+        "Σ active StatusEffectTrait modifiers via CharacterStatusEffect."
+    )
+
+    class Create(
+        BaseModel,
+        CharacterModel.Reference.ID.Optional,
+        TraitModel.Reference.ID.Optional,
+    ):
+        value: Optional[float] = None
+        rank: Optional[int] = None
+        notes: Optional[str] = None
+
+    class Update(BaseModel):
+        value: Optional[float] = None
+        rank: Optional[int] = None
+        notes: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CharacterModel.Reference.ID.Search,
+        TraitModel.Reference.ID.Search,
+    ):
+        value: Optional[NumericalSearchModel] = None
+        rank: Optional[NumericalSearchModel] = None
+
+
+class CharacterTraitManager(AbstractBLLManager, RouterMixin):
+    _model = CharacterTraitModel
+
+
+CharacterTraitModel.Manager = CharacterTraitManager
+
+
+class CharacterStatusEffectModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CharacterModel.Reference.Optional,
+    StatusEffectModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CharacterStatusEffectManager"]] = None
+    started_at: Optional[datetime] = Field(None)
+    expires_at: Optional[datetime] = Field(
+        None,
+        description="Effect end; null = persists until manually removed",
+    )
+    # Caster / source. Manual columns (Character already used for the
+    # affected character; ItemInstance.Reference would create a cycle).
+    source_character_id: Optional[str] = Field(
+        None, description="The caster / applier"
+    )
+    source_item_instance_id: Optional[str] = Field(
+        None, description="Item consumed to apply the effect"
+    )
+    table_comment: ClassVar[str] = (
+        "Active StatusEffect attachments per character. "
+        "The effect's per-trait modifiers come from StatusEffectTrait."
+    )
+
+    class Create(
+        BaseModel,
+        CharacterModel.Reference.ID.Optional,
+        StatusEffectModel.Reference.ID.Optional,
+    ):
+        started_at: Optional[datetime] = None
+        expires_at: Optional[datetime] = None
+        source_character_id: Optional[str] = None
+        source_item_instance_id: Optional[str] = None
+
+    class Update(BaseModel):
+        expires_at: Optional[datetime] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CharacterModel.Reference.ID.Search,
+        StatusEffectModel.Reference.ID.Search,
+    ):
+        expires_at: Optional[DateSearchModel] = None
+
+
+class CharacterStatusEffectManager(AbstractBLLManager, RouterMixin):
+    _model = CharacterStatusEffectModel
+
+
+CharacterStatusEffectModel.Manager = CharacterStatusEffectManager
+
+
+# ---------------------------------------------------------------------------
+# 6. Faction hierarchy
+# ---------------------------------------------------------------------------
+
+
+class FactionModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    ParentMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["FactionManager"]] = None
+    table_comment: ClassVar[str] = (
+        "Hierarchical faction (parent_id self-FK). A 'party' is a "
+        "Faction with a Guild parent or no parent."
+    )
+
+    class Create(BaseModel, CampaignModel.Reference.ID.Optional):
+        name: str = Field(...)
+        description: Optional[str] = None
+        parent_id: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        parent_id: Optional[str] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CampaignModel.Reference.ID.Search,
+    ):
+        name: Optional[StringSearchModel] = None
+        parent_id: Optional[StringSearchModel] = None
+
+
+class FactionManager(AbstractBLLManager, RouterMixin):
+    _model = FactionModel
+
+
+FactionModel.Manager = FactionManager
+
+
+class CharacterFactionModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CharacterModel.Reference.Optional,
+    FactionModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CharacterFactionManager"]] = None
+    role: Optional[str] = Field(
+        None, description="member|leader|enemy|ally|... (free-form)"
+    )
+    reputation: Optional[float] = Field(
+        None, description="Standing within the faction"
+    )
+    table_comment: ClassVar[str] = "Character↔Faction membership join"
+
+    class Create(
+        BaseModel,
+        CharacterModel.Reference.ID.Optional,
+        FactionModel.Reference.ID.Optional,
+    ):
+        role: Optional[str] = None
+        reputation: Optional[float] = None
+
+    class Update(BaseModel):
+        role: Optional[str] = None
+        reputation: Optional[float] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CharacterModel.Reference.ID.Search,
+        FactionModel.Reference.ID.Search,
+    ):
+        role: Optional[StringSearchModel] = None
+
+
+class CharacterFactionManager(AbstractBLLManager, RouterMixin):
+    _model = CharacterFactionModel
+
+
+CharacterFactionModel.Manager = CharacterFactionManager
+
+
+# ---------------------------------------------------------------------------
+# 7. Spatial: Location / Item / ItemInstance
+# ---------------------------------------------------------------------------
+
+
+class LocationModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    ParentMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["LocationManager"]] = None
+    # When this Location IS the inside of a container item (a satchel's
+    # interior is a Location whose container_item_instance_id points to
+    # the satchel ItemInstance). Manual column to avoid the cyclic
+    # ItemInstance ↔ Location reference at class-definition time.
+    container_item_instance_id: Optional[str] = Field(
+        None,
+        description="Set when this Location represents the inside of a container item",
+    )
+    associated_character_id: Optional[str] = Field(
+        None,
+        description="Set when this Location is an equipment slot bound to a character",
+    )
+    kind: Optional[str] = Field(
+        None,
+        description="region|room|container|equipment_slot|inventory|... (free-form)",
+    )
+    table_comment: ClassVar[str] = (
+        "Recursive spatial node. parent_id = parent location; "
+        "container_item_instance_id = container that this is the inside of; "
+        "associated_character_id = equipment-slot owner. Equipping is a move."
+    )
+
+    class Create(BaseModel, CampaignModel.Reference.ID.Optional):
+        name: str = Field(...)
+        description: Optional[str] = None
+        parent_id: Optional[str] = None
+        container_item_instance_id: Optional[str] = None
+        associated_character_id: Optional[str] = None
+        kind: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        parent_id: Optional[str] = None
+        container_item_instance_id: Optional[str] = None
+        associated_character_id: Optional[str] = None
+        kind: Optional[str] = None
+
+    class Search(ApplicationModel.Search, CampaignModel.Reference.ID.Search):
+        name: Optional[StringSearchModel] = None
+        kind: Optional[StringSearchModel] = None
+        parent_id: Optional[StringSearchModel] = None
+
+
+class LocationManager(AbstractBLLManager, RouterMixin):
+    _model = LocationModel
+
+
+LocationModel.Manager = LocationManager
+
+
+class ItemModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    GameSystemModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["ItemManager"]] = None
+    weight: Optional[float] = Field(None, description="Per-unit weight")
+    base_value: Optional[float] = Field(
+        None, description="Default monetary value per unit"
+    )
+    stack_size: Optional[int] = Field(
+        1, description="Max units per ItemInstance stack (1 = non-stackable)"
+    )
+    kind: Optional[str] = Field(
+        None,
+        description="weapon|armor|consumable|container|currency|misc (free-form)",
+    )
+    table_comment: ClassVar[str] = (
+        "Item template (catalog). ItemInstance is the per-instance row."
+    )
+
+    class Create(BaseModel, GameSystemModel.Reference.ID.Optional):
+        name: str = Field(...)
+        description: Optional[str] = None
+        weight: Optional[float] = None
+        base_value: Optional[float] = None
+        stack_size: Optional[int] = None
+        kind: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        weight: Optional[float] = None
+        base_value: Optional[float] = None
+        stack_size: Optional[int] = None
+        kind: Optional[str] = None
+
+    class Search(ApplicationModel.Search, GameSystemModel.Reference.ID.Search):
+        name: Optional[StringSearchModel] = None
+        kind: Optional[StringSearchModel] = None
+
+
+class ItemManager(AbstractBLLManager, RouterMixin):
+    _model = ItemModel
+
+
+ItemModel.Manager = ItemManager
+
+
+class ItemInstanceModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    ItemModel.Reference.Optional,
+    LocationModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["ItemInstanceManager"]] = None
+    # Two ownership axes, both nullable, no XOR constraint:
+    #   owner_faction_id = de jure / "in principle" (the Guild owns it)
+    #   owner_character_id = de facto / "in practice" (Bob is carrying it)
+    # Theft = the two disagree without an intervening TransactionLog.
+    owner_character_id: Optional[str] = Field(
+        None, description="De facto bearer / in-practice owner"
+    )
+    owner_faction_id: Optional[str] = Field(
+        None, description="De jure / in-principle owner"
+    )
+    quantity: Optional[int] = Field(1, description="Stack count (≥1)")
+    durability: Optional[float] = Field(None, description="System-defined HP/durability")
+    table_comment: ClassVar[str] = (
+        "Per-instance item row. location_id = current physical spot; "
+        "owner_* fields decoupled from location to capture theft / lend."
+    )
+
+    class Create(
+        BaseModel,
+        ItemModel.Reference.ID.Optional,
+        LocationModel.Reference.ID.Optional,
+    ):
+        owner_character_id: Optional[str] = None
+        owner_faction_id: Optional[str] = None
+        quantity: Optional[int] = None
+        durability: Optional[float] = None
+
+    class Update(BaseModel):
+        location_id: Optional[str] = None
+        owner_character_id: Optional[str] = None
+        owner_faction_id: Optional[str] = None
+        quantity: Optional[int] = None
+        durability: Optional[float] = None
+
+    class Search(
+        ApplicationModel.Search,
+        ItemModel.Reference.ID.Search,
+        LocationModel.Reference.ID.Search,
+    ):
+        owner_character_id: Optional[StringSearchModel] = None
+        owner_faction_id: Optional[StringSearchModel] = None
+
+
+class ItemInstanceManager(AbstractBLLManager, RouterMixin):
+    _model = ItemInstanceModel
+
+
+ItemInstanceModel.Manager = ItemInstanceManager
+
+
+# ---------------------------------------------------------------------------
+# 8. Quests, Objectives, and per-character/per-faction progress
+# ---------------------------------------------------------------------------
+
+
+class QuestModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    CampaignModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["QuestManager"]] = None
+    # Quest issuer; nullable so unattributed quests work. Manual to avoid
+    # collision with future Faction.Reference uses on this model.
+    giver_faction_id: Optional[str] = Field(
+        None, description="Faction that issued the quest"
+    )
+    table_comment: ClassVar[str] = "Quest template"
+
+    class Create(BaseModel, CampaignModel.Reference.ID.Optional):
+        name: str = Field(...)
+        description: Optional[str] = None
+        giver_faction_id: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        giver_faction_id: Optional[str] = None
+
+    class Search(ApplicationModel.Search, CampaignModel.Reference.ID.Search):
+        name: Optional[StringSearchModel] = None
+
+
+class QuestManager(AbstractBLLManager, RouterMixin):
+    _model = QuestModel
+
+
+QuestModel.Manager = QuestManager
+
+
+class ObjectiveModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    QuestModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["ObjectiveManager"]] = None
+    prerequisite_objective_id: Optional[str] = Field(
+        None,
+        description="Objective that must complete first (self-FK; chains/branches)",
+    )
+    order_index: Optional[int] = Field(
+        None, description="Display/precedence ordering within the quest"
+    )
+    table_comment: ClassVar[str] = (
+        "Objective template; chains via prerequisite_objective_id."
+    )
+
+    class Create(BaseModel, QuestModel.Reference.ID.Optional):
+        name: str = Field(...)
+        description: Optional[str] = None
+        prerequisite_objective_id: Optional[str] = None
+        order_index: Optional[int] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        prerequisite_objective_id: Optional[str] = None
+        order_index: Optional[int] = None
+
+    class Search(ApplicationModel.Search, QuestModel.Reference.ID.Search):
+        name: Optional[StringSearchModel] = None
+        prerequisite_objective_id: Optional[StringSearchModel] = None
+
+
+class ObjectiveManager(AbstractBLLManager, RouterMixin):
+    _model = ObjectiveModel
+
+
+ObjectiveModel.Manager = ObjectiveManager
+
+
+class CharacterQuestModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CharacterModel.Reference.Optional,
+    QuestModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CharacterQuestManager"]] = None
+    status: Optional[str] = Field(
+        None, description="available|active|completed|failed|abandoned"
+    )
+    accepted_at: Optional[datetime] = Field(None)
+    completed_at: Optional[datetime] = Field(None)
+    table_comment: ClassVar[str] = "Per-character quest progress instance"
+
+    class Create(
+        BaseModel,
+        CharacterModel.Reference.ID.Optional,
+        QuestModel.Reference.ID.Optional,
+    ):
+        status: Optional[str] = None
+        accepted_at: Optional[datetime] = None
+        completed_at: Optional[datetime] = None
+
+    class Update(BaseModel):
+        status: Optional[str] = None
+        accepted_at: Optional[datetime] = None
+        completed_at: Optional[datetime] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CharacterModel.Reference.ID.Search,
+        QuestModel.Reference.ID.Search,
+    ):
+        status: Optional[StringSearchModel] = None
+
+
+class CharacterQuestManager(AbstractBLLManager, RouterMixin):
+    _model = CharacterQuestModel
+
+
+CharacterQuestModel.Manager = CharacterQuestManager
+
+
+class FactionQuestModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    FactionModel.Reference.Optional,
+    QuestModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["FactionQuestManager"]] = None
+    status: Optional[str] = Field(None, description="See CharacterQuestModel.status")
+    accepted_at: Optional[datetime] = Field(None)
+    completed_at: Optional[datetime] = Field(None)
+    table_comment: ClassVar[str] = "Per-faction quest progress instance"
+
+    class Create(
+        BaseModel,
+        FactionModel.Reference.ID.Optional,
+        QuestModel.Reference.ID.Optional,
+    ):
+        status: Optional[str] = None
+        accepted_at: Optional[datetime] = None
+        completed_at: Optional[datetime] = None
+
+    class Update(BaseModel):
+        status: Optional[str] = None
+        accepted_at: Optional[datetime] = None
+        completed_at: Optional[datetime] = None
+
+    class Search(
+        ApplicationModel.Search,
+        FactionModel.Reference.ID.Search,
+        QuestModel.Reference.ID.Search,
+    ):
+        status: Optional[StringSearchModel] = None
+
+
+class FactionQuestManager(AbstractBLLManager, RouterMixin):
+    _model = FactionQuestModel
+
+
+FactionQuestModel.Manager = FactionQuestManager
+
+
+class CharacterObjectiveModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    CharacterModel.Reference.Optional,
+    ObjectiveModel.Reference.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["CharacterObjectiveManager"]] = None
+    status: Optional[str] = Field(None)
+    progress: Optional[float] = Field(
+        None, description="Numeric progress (e.g. 3 of 5 wolves slain)"
+    )
+    completed_at: Optional[datetime] = Field(None)
+    table_comment: ClassVar[str] = "Per-character objective progress instance"
+
+    class Create(
+        BaseModel,
+        CharacterModel.Reference.ID.Optional,
+        ObjectiveModel.Reference.ID.Optional,
+    ):
+        status: Optional[str] = None
+        progress: Optional[float] = None
+        completed_at: Optional[datetime] = None
+
+    class Update(BaseModel):
+        status: Optional[str] = None
+        progress: Optional[float] = None
+        completed_at: Optional[datetime] = None
+
+    class Search(
+        ApplicationModel.Search,
+        CharacterModel.Reference.ID.Search,
+        ObjectiveModel.Reference.ID.Search,
+    ):
+        status: Optional[StringSearchModel] = None
+
+
+class CharacterObjectiveManager(AbstractBLLManager, RouterMixin):
+    _model = CharacterObjectiveModel
+
+
+CharacterObjectiveModel.Manager = CharacterObjectiveManager
+
+
+# ---------------------------------------------------------------------------
+# Public roster
+# ---------------------------------------------------------------------------
+
+
+ALL_MODELS: List[type] = [
+    GameSystemModel,
+    CampaignModel,
+    TraitModel,
+    StatusEffectModel,
+    StatusEffectTraitModel,
+    CharacterModel,
+    CharacterTraitModel,
+    CharacterStatusEffectModel,
+    FactionModel,
+    CharacterFactionModel,
+    LocationModel,
+    ItemModel,
+    ItemInstanceModel,
+    QuestModel,
+    ObjectiveModel,
+    CharacterQuestModel,
+    FactionQuestModel,
+    CharacterObjectiveModel,
+]
+
+
+__all__ = [
+    "GameSystemModel",
+    "GameSystemManager",
+    "CampaignModel",
+    "CampaignManager",
+    "TraitModel",
+    "TraitManager",
+    "StatusEffectModel",
+    "StatusEffectManager",
+    "StatusEffectTraitModel",
+    "StatusEffectTraitManager",
+    "CharacterModel",
+    "CharacterManager",
+    "CharacterTraitModel",
+    "CharacterTraitManager",
+    "CharacterStatusEffectModel",
+    "CharacterStatusEffectManager",
+    "FactionModel",
+    "FactionManager",
+    "CharacterFactionModel",
+    "CharacterFactionManager",
+    "LocationModel",
+    "LocationManager",
+    "ItemModel",
+    "ItemManager",
+    "ItemInstanceModel",
+    "ItemInstanceManager",
+    "QuestModel",
+    "QuestManager",
+    "ObjectiveModel",
+    "ObjectiveManager",
+    "CharacterQuestModel",
+    "CharacterQuestManager",
+    "FactionQuestModel",
+    "FactionQuestManager",
+    "CharacterObjectiveModel",
+    "CharacterObjectiveManager",
+    "ALL_MODELS",
+]

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
@@ -1,0 +1,226 @@
+"""Structural tests for the rpg_state extension's BLL surface.
+
+These cover model wiring (Manager↔_model linkage), the unified-trait
+calculation contract, and the ItemInstance ownership semantics. They do
+not exercise the database; integration coverage will be added once the
+extension is wired into the test app fixture.
+"""
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "x" * 32)
+os.environ.setdefault("PYTEST_CURRENT_TEST", "rpg_state_test")
+
+from serverframework.extensions.rpg_state.BLL_RPGState import (
+    ALL_MODELS,
+    CampaignManager,
+    CampaignModel,
+    CharacterFactionManager,
+    CharacterFactionModel,
+    CharacterManager,
+    CharacterModel,
+    CharacterObjectiveManager,
+    CharacterObjectiveModel,
+    CharacterQuestManager,
+    CharacterQuestModel,
+    CharacterStatusEffectManager,
+    CharacterStatusEffectModel,
+    CharacterTraitManager,
+    CharacterTraitModel,
+    FactionManager,
+    FactionModel,
+    FactionQuestManager,
+    FactionQuestModel,
+    GameSystemManager,
+    GameSystemModel,
+    ItemInstanceManager,
+    ItemInstanceModel,
+    ItemManager,
+    ItemModel,
+    LocationManager,
+    LocationModel,
+    ObjectiveManager,
+    ObjectiveModel,
+    QuestManager,
+    QuestModel,
+    StatusEffectManager,
+    StatusEffectModel,
+    StatusEffectTraitManager,
+    StatusEffectTraitModel,
+    TraitManager,
+    TraitModel,
+)
+
+
+class TestModelManagerWiring:
+    """Every model must point to its Manager and vice versa."""
+
+    PAIRS = [
+        (GameSystemModel, GameSystemManager),
+        (CampaignModel, CampaignManager),
+        (TraitModel, TraitManager),
+        (StatusEffectModel, StatusEffectManager),
+        (StatusEffectTraitModel, StatusEffectTraitManager),
+        (CharacterModel, CharacterManager),
+        (CharacterTraitModel, CharacterTraitManager),
+        (CharacterStatusEffectModel, CharacterStatusEffectManager),
+        (FactionModel, FactionManager),
+        (CharacterFactionModel, CharacterFactionManager),
+        (LocationModel, LocationManager),
+        (ItemModel, ItemManager),
+        (ItemInstanceModel, ItemInstanceManager),
+        (QuestModel, QuestManager),
+        (ObjectiveModel, ObjectiveManager),
+        (CharacterQuestModel, CharacterQuestManager),
+        (FactionQuestModel, FactionQuestManager),
+        (CharacterObjectiveModel, CharacterObjectiveManager),
+    ]
+
+    def test_each_model_has_its_manager(self):
+        for model, manager in self.PAIRS:
+            assert model.Manager is manager, f"{model.__name__} → wrong Manager"
+            assert manager._model is model, f"{manager.__name__} → wrong _model"
+
+    def test_all_models_listed(self):
+        listed = set(ALL_MODELS)
+        expected = {model for model, _ in self.PAIRS}
+        assert listed == expected
+
+
+class TestCreateUpdateSearchPresent:
+    """Every model exposes Create / Update / Search nested classes."""
+
+    def test_nested_classes_exist(self):
+        for model in ALL_MODELS:
+            assert hasattr(model, "Create"), f"{model.__name__} missing Create"
+            assert hasattr(model, "Update"), f"{model.__name__} missing Update"
+            assert hasattr(model, "Search"), f"{model.__name__} missing Search"
+
+
+class TestUnifiedTraitContract:
+    """STR=16 lives on CharacterTrait.value. +2 from Bull's Strength lives
+    on StatusEffectTrait(operation='additive', value=2.0)."""
+
+    def test_character_trait_carries_value(self):
+        # Pydantic accepts the field; type is float-compatible.
+        ct = CharacterTraitModel.Create(value=16.0)
+        assert ct.value == 16.0
+
+    def test_status_effect_trait_carries_modifier(self):
+        set_row = StatusEffectTraitModel.Create(
+            operation="additive",
+            value=2.0,
+        )
+        assert set_row.operation == "additive"
+        assert set_row.value == 2.0
+
+    def test_character_status_effect_links_subject_to_template(self):
+        # The character's instance row references both the affected
+        # character and the StatusEffect template; modifiers come from
+        # StatusEffectTrait, not duplicated here.
+        cse = CharacterStatusEffectModel.Create(
+            character_id="char-1",
+            status_effect_id="effect-1",
+            source_character_id="char-2",  # caster
+        )
+        assert cse.character_id == "char-1"
+        assert cse.status_effect_id == "effect-1"
+        assert cse.source_character_id == "char-2"
+
+
+class TestItemOwnershipSemantics:
+    """De jure (faction) and de facto (character) ownership are
+    independent; both nullable, no XOR."""
+
+    def test_neither_owner_set(self):
+        # Wild loot: lying on a dungeon floor, no claim.
+        ii = ItemInstanceModel.Create(quantity=1)
+        assert ii.owner_character_id is None
+        assert ii.owner_faction_id is None
+
+    def test_both_owners_set(self):
+        # Legal: Guild owns it (faction), Bob carries it (character).
+        ii = ItemInstanceModel.Create(
+            owner_character_id="bob",
+            owner_faction_id="guild",
+            quantity=1,
+        )
+        assert ii.owner_character_id == "bob"
+        assert ii.owner_faction_id == "guild"
+
+    def test_character_only_set(self):
+        ii = ItemInstanceModel.Create(owner_character_id="bob", quantity=1)
+        assert ii.owner_faction_id is None
+
+    def test_faction_only_set(self):
+        ii = ItemInstanceModel.Create(owner_faction_id="guild", quantity=1)
+        assert ii.owner_character_id is None
+
+
+class TestCharacterPlayerLink:
+    """user_id on Character is the controlling player; null for NPCs."""
+
+    def test_pc_has_user_id(self):
+        c = CharacterModel.Create(name="Pip", kind="pc", user_id="user-1")
+        assert c.user_id == "user-1"
+
+    def test_npc_leaves_user_id_null(self):
+        c = CharacterModel.Create(name="Innkeeper", kind="npc")
+        assert c.user_id is None
+
+
+class TestSpatialContainers:
+    """Locations are recursive and can represent the inside of a
+    container item or a character's equipment slot."""
+
+    def test_nested_locations(self):
+        outer = LocationModel.Create(name="Tavern")
+        inner = LocationModel.Create(name="Tavern → Cellar", parent_id="outer-id")
+        assert inner.parent_id == "outer-id"
+        assert outer.parent_id is None
+
+    def test_container_item_instance(self):
+        # The interior of a satchel.
+        loc = LocationModel.Create(
+            name="Inside the Satchel",
+            container_item_instance_id="ii-satchel",
+            kind="container",
+        )
+        assert loc.container_item_instance_id == "ii-satchel"
+
+    def test_equipment_slot_bound_to_character(self):
+        loc = LocationModel.Create(
+            name="Bob's Left Hand",
+            associated_character_id="bob",
+            kind="equipment_slot",
+        )
+        assert loc.associated_character_id == "bob"
+
+
+class TestQuestObjectiveChaining:
+    def test_objective_prerequisite(self):
+        obj = ObjectiveModel.Create(
+            name="Slay the dragon",
+            quest_id="q1",
+            prerequisite_objective_id="o-find-dragon",
+            order_index=2,
+        )
+        assert obj.prerequisite_objective_id == "o-find-dragon"
+        assert obj.order_index == 2
+
+    def test_quest_dual_assignment(self):
+        cq = CharacterQuestModel.Create(
+            character_id="c1", quest_id="q1", status="active"
+        )
+        fq = FactionQuestModel.Create(
+            faction_id="f1", quest_id="q1", status="active"
+        )
+        assert cq.status == "active"
+        assert fq.status == "active"
+
+
+class TestFactionHierarchy:
+    def test_subfactions_via_parent_id(self):
+        # A party = sub-faction of a guild.
+        party = FactionModel.Create(name="Tavern Crew", parent_id="guild-id")
+        assert party.parent_id == "guild-id"

--- a/src/serverframework/extensions/rpg_state/EXT_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/EXT_RPGState.py
@@ -1,0 +1,26 @@
+"""rpg_state extension definition.
+
+Owns the present-state tables for an RPG campaign. No upstream extension
+dependencies; ``rpg_log`` depends on this for character / item / location
+references.
+"""
+
+from typing import ClassVar, List, Type
+
+from serverframework.extensions.AbstractExtensionProvider import (
+    AbstractStaticExtension,
+)
+
+
+class RPGStateExtension(AbstractStaticExtension):
+    name: ClassVar[str] = "rpg_state"
+    description: ClassVar[str] = (
+        "Present-state schema for RPG campaigns (system-agnostic)"
+    )
+    extension_dependencies: ClassVar[List[str]] = []
+
+    @classmethod
+    def models(cls) -> List[Type]:
+        from serverframework.extensions.rpg_state.BLL_RPGState import ALL_MODELS
+
+        return list(ALL_MODELS)

--- a/src/serverframework/extensions/rpg_state/EXT_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/EXT_RPGState_test.py
@@ -1,0 +1,24 @@
+"""Extension-level tests for rpg_state."""
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "x" * 32)
+os.environ.setdefault("PYTEST_CURRENT_TEST", "rpg_state_ext_test")
+
+from serverframework.extensions.rpg_state.BLL_RPGState import ALL_MODELS
+from serverframework.extensions.rpg_state.EXT_RPGState import RPGStateExtension
+
+
+class TestExtensionMetadata:
+    def test_name_and_description(self):
+        assert RPGStateExtension.name == "rpg_state"
+        assert "RPG" in RPGStateExtension.description
+
+    def test_no_extension_dependencies(self):
+        # rpg_state is foundational; rpg_log is the consumer.
+        assert RPGStateExtension.extension_dependencies == []
+
+    def test_models_returns_full_roster(self):
+        models = RPGStateExtension.models()
+        assert set(models) == set(ALL_MODELS)
+        assert len(models) == 18  # tracked count; bump when adding tables.

--- a/src/serverframework/extensions/rpg_state/__init__.py
+++ b/src/serverframework/extensions/rpg_state/__init__.py
@@ -1,0 +1,11 @@
+"""rpg_state extension.
+
+Owns the present-state schema for an RPG campaign: characters, factions,
+items, locations, quests, and the unified Trait / StatusEffect property
+model. Designed to be system-agnostic — DnD, Pathfinder, FFG, WH40K, and
+other tabletop / video-game / roleplay systems plug in via the
+``GameSystem`` reference table.
+
+State here is the "now". Historical events (combat actions, dialogue,
+transactions) live in the sibling ``rpg_log`` extension.
+"""

--- a/src/serverframework/extensions/rpg_state/manifest.toml
+++ b/src/serverframework/extensions/rpg_state/manifest.toml
@@ -1,0 +1,8 @@
+name = "rpg_state"
+version = "0.1.0"
+description = "Present-state schema for an RPG campaign — characters, factions, items, quests, locations, traits"
+
+# Foundational. No upstream extension dependencies.
+[[extension_dependencies]]
+
+[python_dependencies]

--- a/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
@@ -1,0 +1,473 @@
+"""Initial migration for rpg_state — owns the present-state tables.
+
+Schema is loose (no SQL FK constraints) to match existing extension
+migrations (acl_rbac, metadata, auth_invitations). Referential integrity
+is enforced at the ORM/manager layer via ``Reference.Optional`` mixins.
+
+Cyclic relationship resolved by the loose schema:
+- locations.container_item_instance_id → item_instances.id
+- item_instances.location_id           → locations.id
+"""
+
+from alembic import op
+
+
+revision = "001_rpg_state_initial"
+down_revision = None
+branch_labels = ("rpg_state",)
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS game_systems (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS campaigns (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            game_system_id VARCHAR(36),
+            user_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_campaigns_user ON campaigns(user_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS traits (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            kind VARCHAR(64),
+            game_system_id VARCHAR(36),
+            campaign_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_traits_kind ON traits(kind)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_traits_system ON traits(game_system_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS status_effects (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            default_duration_seconds INTEGER,
+            game_system_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS status_effect_traits (
+            id VARCHAR(36) PRIMARY KEY,
+            status_effect_id VARCHAR(36),
+            trait_id VARCHAR(36),
+            operation VARCHAR(32),
+            value REAL,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_set_effect ON status_effect_traits(status_effect_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_set_trait ON status_effect_traits(trait_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS characters (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            kind VARCHAR(64),
+            level INTEGER,
+            campaign_id VARCHAR(36),
+            user_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_characters_campaign ON characters(campaign_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_characters_user ON characters(user_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS character_traits (
+            id VARCHAR(36) PRIMARY KEY,
+            character_id VARCHAR(36),
+            trait_id VARCHAR(36),
+            value REAL,
+            rank INTEGER,
+            notes TEXT,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ct_character ON character_traits(character_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ct_trait ON character_traits(trait_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS character_status_effects (
+            id VARCHAR(36) PRIMARY KEY,
+            character_id VARCHAR(36),
+            status_effect_id VARCHAR(36),
+            started_at TIMESTAMP,
+            expires_at TIMESTAMP,
+            source_character_id VARCHAR(36),
+            source_item_instance_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cse_character "
+        "ON character_status_effects(character_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cse_active "
+        "ON character_status_effects(character_id, expires_at)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS factions (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            parent_id VARCHAR(36),
+            campaign_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_factions_campaign ON factions(campaign_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_factions_parent ON factions(parent_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS character_factions (
+            id VARCHAR(36) PRIMARY KEY,
+            character_id VARCHAR(36),
+            faction_id VARCHAR(36),
+            role VARCHAR(64),
+            reputation REAL,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cf_character ON character_factions(character_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cf_faction ON character_factions(faction_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS locations (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            parent_id VARCHAR(36),
+            campaign_id VARCHAR(36),
+            container_item_instance_id VARCHAR(36),
+            associated_character_id VARCHAR(36),
+            kind VARCHAR(64),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_locations_campaign ON locations(campaign_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_locations_parent ON locations(parent_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_locations_container "
+        "ON locations(container_item_instance_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_locations_character "
+        "ON locations(associated_character_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS items (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            game_system_id VARCHAR(36),
+            weight REAL,
+            base_value REAL,
+            stack_size INTEGER DEFAULT 1,
+            kind VARCHAR(64),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS item_instances (
+            id VARCHAR(36) PRIMARY KEY,
+            item_id VARCHAR(36),
+            location_id VARCHAR(36),
+            owner_character_id VARCHAR(36),
+            owner_faction_id VARCHAR(36),
+            quantity INTEGER DEFAULT 1,
+            durability REAL,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ii_location ON item_instances(location_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ii_owner_char "
+        "ON item_instances(owner_character_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ii_owner_faction "
+        "ON item_instances(owner_faction_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS quests (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            campaign_id VARCHAR(36),
+            giver_faction_id VARCHAR(36),
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_quests_campaign ON quests(campaign_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS objectives (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            quest_id VARCHAR(36),
+            prerequisite_objective_id VARCHAR(36),
+            order_index INTEGER,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_objectives_quest ON objectives(quest_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS character_quests (
+            id VARCHAR(36) PRIMARY KEY,
+            character_id VARCHAR(36),
+            quest_id VARCHAR(36),
+            status VARCHAR(32),
+            accepted_at TIMESTAMP,
+            completed_at TIMESTAMP,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cq_character ON character_quests(character_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_cq_status "
+        "ON character_quests(character_id, status)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS faction_quests (
+            id VARCHAR(36) PRIMARY KEY,
+            faction_id VARCHAR(36),
+            quest_id VARCHAR(36),
+            status VARCHAR(32),
+            accepted_at TIMESTAMP,
+            completed_at TIMESTAMP,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_fq_faction ON faction_quests(faction_id)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS character_objectives (
+            id VARCHAR(36) PRIMARY KEY,
+            character_id VARCHAR(36),
+            objective_id VARCHAR(36),
+            status VARCHAR(32),
+            progress REAL,
+            completed_at TIMESTAMP,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP,
+            deleted_at TIMESTAMP,
+            created_by_user_id VARCHAR(36),
+            updated_by_user_id VARCHAR(36),
+            deleted_by_user_id VARCHAR(36)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_co_character "
+        "ON character_objectives(character_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS character_objectives")
+    op.execute("DROP TABLE IF EXISTS faction_quests")
+    op.execute("DROP TABLE IF EXISTS character_quests")
+    op.execute("DROP TABLE IF EXISTS objectives")
+    op.execute("DROP TABLE IF EXISTS quests")
+    op.execute("DROP TABLE IF EXISTS item_instances")
+    op.execute("DROP TABLE IF EXISTS items")
+    op.execute("DROP TABLE IF EXISTS locations")
+    op.execute("DROP TABLE IF EXISTS character_factions")
+    op.execute("DROP TABLE IF EXISTS factions")
+    op.execute("DROP TABLE IF EXISTS character_status_effects")
+    op.execute("DROP TABLE IF EXISTS character_traits")
+    op.execute("DROP TABLE IF EXISTS characters")
+    op.execute("DROP TABLE IF EXISTS status_effect_traits")
+    op.execute("DROP TABLE IF EXISTS status_effects")
+    op.execute("DROP TABLE IF EXISTS traits")
+    op.execute("DROP TABLE IF EXISTS campaigns")
+    op.execute("DROP TABLE IF EXISTS game_systems")

--- a/src/serverframework/logic/AbstractLogicManager.py
+++ b/src/serverframework/logic/AbstractLogicManager.py
@@ -1076,10 +1076,17 @@ class ModelMeta(ModelMetaclass):
     @staticmethod
     def _create_reference_class(model_cls, model_name):
         """Creates Reference class with dynamically generated ID class"""
-        # Get the field name for the model (snake_case without 'Model' suffix)
-        field_name = model_name.lower()
-        if field_name.endswith("model"):
-            field_name = field_name[:-5]  # Remove 'model' suffix
+        # Strip the 'Model' suffix while preserving CamelCase boundaries so
+        # `snakecase` can insert the underscores. The previous form
+        # lowercased first, which destroyed the boundaries and produced
+        # field names like `iteminstance_id` for `ItemInstanceModel` while
+        # the table name generator emitted `item_instances` — leaving the
+        # FK column name out of sync with the parent table. Single-word
+        # models are unaffected (`UserModel` → `User` → `user`).
+        if model_name.endswith("Model"):
+            field_name = model_name[:-5]
+        else:
+            field_name = model_name
         field_name = stringcase.snakecase(field_name)
         id_field_name = f"{field_name}_id"
 


### PR DESCRIPTION
rpg_state owns the present-state schema for an RPG campaign — a
system-agnostic catalog (GameSystem) plus Campaign, Trait /
StatusEffect / StatusEffectTrait (unified-trait engine), Character (with
nullable user_id for player↔character), Faction (recursive), Location
(recursive containers + equipment-slot-as-location), Item / ItemInstance
(de-jure faction owner + de-facto character bearer, both nullable), and
Quest / Objective with separate per-character and per-faction progress
joins.

rpg_log owns the editable event log: Encounter (+ Participant join with
free-form sides), CombatAction, Dialogue (+ Participant), Interaction,
and Transaction. Logs are mutable per the standard UpdateMixinModel
audit fields so GMs can correct typos / retcon.

Drive-by: AbstractLogicManager._create_reference_class lowercased the
model name before snake_case, producing field names like
`iteminstance_id` while the table-name generator emitted
`item_instances`. Strip the `Model` suffix while preserving CamelCase so
`ItemInstanceModel` → `item_instance_id`. Single-word models are
unchanged.

37 unit tests cover model↔manager wiring, the unified-trait contract,
ItemInstance ownership semantics, recursive containers, and log
shapes. Existing acl_rbac, metadata, and auth_invitations tests still
pass.

https://claude.ai/code/session_01BgrrpxqoKxQQYPrjHGFM9p