### PR TITLE
rpg_state: codify item-ownership, membership, progression, ACL doctrine

### DIFF
--- a/src/serverframework/database/DB.Patterns.md
+++ b/src/serverframework/database/DB.Patterns.md
@@ -690,6 +690,113 @@ def test_manager_with_isolated_database():
 
 This Pydantic-first architecture with enterprise database management represents a modern approach to database patterns that maximizes developer productivity and operational reliability. The `DatabaseManager.py` implementation provides production-ready database management with thread-safe operations, multi-database support, and comprehensive session handling. The DatabaseMixin approach provides a single source of truth, while the sophisticated permission system and seeding infrastructure ensure security and maintainability at scale.
 
+## Schema Integrity Doctrine
+
+The codebase enforces integrity at the database layer wherever the
+invariant is non-negotiable. "Loose schema" — tables without foreign
+keys, nullable columns where a value is required, application-only
+enforcement of relational constraints — is **not** the codebase
+pattern and must not be claimed as one. Migration authors who skip
+DB-level constraints because "the manager enforces it" are wrong;
+manager-layer enforcement is a complement to DB-level integrity, not a
+substitute.
+
+### Required: foreign keys on every cross-table reference
+
+Every column whose value references the primary key of another table
+declares a `sa.ForeignKeyConstraint` (or the per-column `sa.ForeignKey`
+shorthand) in the migration. This includes:
+
+- Cross-extension references (e.g. an extension table's `user_id`
+  pointing at the core `users.id`).
+- Within-extension references (e.g. `objectives.quest_id` →
+  `quests.id`).
+- Self-references (e.g. `factions.parent_id` → `factions.id`,
+  `objectives.prerequisite_objective_id` → `objectives.id`).
+- Multi-FK columns referencing the same target (e.g.
+  `combat_action_logs.actor_person_id` and `target_person_id` both →
+  `persons.id` — declare each as its own `ForeignKeyConstraint`).
+
+Cyclic references (e.g. `locations.container_item_instance_id` ↔
+`item_instances.location_id`) are resolved by creating both tables
+without the cycle-closing FK, then adding the second FK via
+`op.batch_alter_table(...).create_foreign_key(...)` once both tables
+exist. This preserves DB-level enforcement at steady state.
+
+### Required: NOT NULL on required references
+
+If a row is meaningless without a particular reference, that column is
+`nullable=False`. Optional references are `nullable=True`. The Pydantic
+side mirrors this via `Reference` vs `Reference.Optional` mixins.
+
+### Required: CHECK constraints for non-relational invariants
+
+When an invariant cannot be expressed via FK + NOT NULL — the canonical
+case is **endpoint XOR** on a polymorphic edge table (exactly one of N
+mutually-exclusive endpoint columns is set per row) — the migration
+declares a `sa.CheckConstraint` (or
+`op.batch_alter_table(...).create_check_constraint(...)`). Examples:
+
+- `relationships(person_id, faction_id)` endpoint XOR per side. The
+  CHECK is added by the extension that injects the additional endpoint
+  columns (`rpg_state` widens `genealogy.relationships` and is
+  responsible for the CHECK that spans both extensions' columns).
+- Quantity ≥ 1 on stack rows: `CHECK (quantity >= 1)`.
+- State-machine transitions: `CHECK (status IN (...))` for closed
+  enums where the application would otherwise drift.
+
+Authors prefer portable CHECK syntax that works across SQLite,
+PostgreSQL, and MySQL — booleans-as-integers (e.g.
+`(person_id IS NOT NULL) + (faction_id IS NOT NULL) = 1`) is the
+portable XOR. Database-specific clauses are last-resort.
+
+### Required: migration ownership stamping
+
+Every `op.create_table` declares `info={"source_module": "...",
+"extension": "..."}` so `MigrationOwnership` and downstream tooling
+can route schema mutations correctly. When an extension widens
+another extension's table via `@extension_model` field injection, the
+injecting extension's migration owns the `op.add_column`,
+`op.alter_column`, and `op.create_check_constraint` calls; the
+`info` dict on those calls (or on the surrounding
+`batch_alter_table`) names the injecting extension as the owner of
+the new columns. The original-table-owner is unaffected.
+
+### Cross-extension column injection
+
+Extensions may widen another extension's table via the
+`@extension_model` decorator on the Pydantic side and matching
+`op.add_column` (and, if needed,
+`op.alter_column` to relax nullability, plus
+`op.create_check_constraint` for new invariants spanning the injected
+columns) on the migration side. The canonical example is the `payment`
+extension injecting `external_payment_id` onto `users`; `rpg_state`
+injects character columns onto `persons` and faction endpoints onto
+`relationships`. The injecting extension's migration is the one that
+must drop the columns on `downgrade`.
+
+### When manager-layer enforcement is appropriate
+
+Manager-layer validators are appropriate only for invariants the DB
+genuinely cannot express:
+
+- **Cycle prevention** in self-referential parent chains (a Location
+  whose ancestor chain contains itself; a quest that prerequisites
+  itself). Recursive walks need iteration caps; the manager rejects
+  edits that would close a cycle. (Depth caps are not appropriate —
+  they limit GMs / authors without correctness payoff.)
+- **Equipment-slot coherence** (a Location with `kind='equipment_slot'`
+  must have `associated_person_id` set). Could be a CHECK in
+  PostgreSQL but loses portability.
+- **Cross-row invariants** (no two `kind='leader'` member_of
+  relationships per faction at the same time). PostgreSQL exclusion
+  constraints handle some of these; portable solutions go to the
+  manager.
+
+When in doubt, push the constraint down to DDL. Application code is
+where invariants go to die; DB constraints survive bug fixes,
+refactors, and concurrent writers.
+
 ## Soft-Delete Enforcement
 
 Soft-delete is a `SoftDeleteMixin` on `AbstractDatabaseEntity` that adds the `deleted_at` column and registers a SQLAlchemy `before_compile` query event that auto-injects `deleted_at IS NULL` into every read against tables tagged with the mixin. A bypass parameter (`include_deleted=True`) is offered for admin queries that genuinely need tombstoned records; without it, deleted rows are invisible to the BLL.

--- a/src/serverframework/extensions/genealogy/BLL_Genealogy.py
+++ b/src/serverframework/extensions/genealogy/BLL_Genealogy.py
@@ -1,0 +1,218 @@
+"""genealogy — Person + Relationship graph.
+
+PersonModel owns the actor identity (name, birth/death, biography).
+RelationshipModel is a directed labelled edge whose default endpoints
+are both Persons. Downstream extensions may inject additional endpoint
+columns (e.g. ``faction_id`` / ``target_faction_id``) via
+``@extension_model``; manager-layer XOR enforces "exactly one endpoint
+per side" once those are injected.
+"""
+
+from datetime import datetime
+from typing import ClassVar, List, Optional, Type
+
+from pydantic import Field
+
+from serverframework.lib.Pydantic import BaseModel
+from serverframework.lib.Pydantic2FastAPI import RouterMixin
+from serverframework.logic.AbstractLogicManager import (
+    AbstractBLLManager,
+    ApplicationModel,
+    DateSearchModel,
+    DescriptionMixinModel,
+    ModelMeta,
+    NameMixinModel,
+    NumericalSearchModel,
+    StringSearchModel,
+    UpdateMixinModel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Person
+# ---------------------------------------------------------------------------
+
+
+class PersonModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    NameMixinModel.Optional,
+    DescriptionMixinModel.Optional,
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["PersonManager"]] = None
+    birth_date: Optional[datetime] = Field(None, description="Date of birth")
+    death_date: Optional[datetime] = Field(
+        None,
+        description="Date of death; NULL = living or unknown",
+    )
+    gender: Optional[str] = Field(
+        None,
+        description="Free-form gender label",
+    )
+    table_comment: ClassVar[str] = (
+        "An actor identity. Used standalone for genealogy and as the "
+        "humanoid subject of RPG Characters via Character.person_id. "
+        "death_date NULL means living or unknown — privacy heuristics "
+        "for living-person redaction live in the manager layer."
+    )
+
+    class Create(BaseModel):
+        name: str = Field(...)
+        description: Optional[str] = None
+        birth_date: Optional[datetime] = None
+        death_date: Optional[datetime] = None
+        gender: Optional[str] = None
+
+    class Update(BaseModel):
+        name: Optional[str] = None
+        description: Optional[str] = None
+        birth_date: Optional[datetime] = None
+        death_date: Optional[datetime] = None
+        gender: Optional[str] = None
+
+    class Search(ApplicationModel.Search):
+        name: Optional[StringSearchModel] = None
+        birth_date: Optional[DateSearchModel] = None
+        death_date: Optional[DateSearchModel] = None
+        gender: Optional[StringSearchModel] = None
+
+
+class PersonManager(AbstractBLLManager, RouterMixin):
+    _model = PersonModel
+
+
+PersonModel.Manager = PersonManager
+
+
+# ---------------------------------------------------------------------------
+# Relationship
+# ---------------------------------------------------------------------------
+
+
+class RelationshipModel(
+    ApplicationModel.Optional,
+    UpdateMixinModel.Optional,
+    PersonModel.Reference.Optional,  # → person_id (subject side default)
+    metaclass=ModelMeta,
+):
+    Manager: ClassVar[Type["RelationshipManager"]] = None
+
+    # Object-side default endpoint. Manual column to avoid Reference
+    # collision with the subject-side person_id (the metaclass keys
+    # field-name generation off the target model name).
+    target_person_id: Optional[str] = Field(
+        None,
+        description="Object-side Person endpoint (default).",
+    )
+
+    # The relationship label. Free-form so downstream extensions and
+    # standalone-genealogy users may introduce their own taxonomies.
+    # Conventional values:
+    #   ancestry|partnership|sibling_of           (genealogy core)
+    #   member_of|affiliated_with                  (rpg_state when injected)
+    #   social|obligation                          (rpg_state when injected)
+    kind: Optional[str] = Field(
+        None,
+        description=(
+            "Relationship kind. Genealogy core: ancestry|partnership|"
+            "sibling_of. Downstream extensions add their own labels."
+        ),
+    )
+    discriminator: Optional[str] = Field(
+        None,
+        description=(
+            "Subkind / refinement of the relationship: "
+            "biological|adopted|step|foster|legal_guardian for ancestry; "
+            "marriage|engagement|partnership|liaison for partnership; "
+            "leader|member|treasurer for member_of; etc."
+        ),
+    )
+    intensity: Optional[float] = Field(
+        None,
+        description=(
+            "Signed magnitude. -1.0 nemesis ↔ +1.0 closest; reused for "
+            "reputation, regard, partnership closeness, etc."
+        ),
+    )
+    qualifier: Optional[str] = Field(
+        None,
+        description=(
+            "Conditional context ('since the war', 'while she lived'). "
+            "Distinct from discriminator."
+        ),
+    )
+    valid_from: Optional[datetime] = Field(
+        None,
+        description="Edge start; NULL = from-the-dawn-of-time.",
+    )
+    valid_to: Optional[datetime] = Field(
+        None,
+        description="Edge end; NULL = still in effect.",
+    )
+    notes: Optional[str] = Field(None, description="Free-form notes")
+
+    table_comment: ClassVar[str] = (
+        "Directed labelled edge. Default endpoints are Persons "
+        "(person_id, target_person_id). Downstream extensions may "
+        "inject additional endpoint columns via @extension_model and "
+        "are responsible for ALTER TABLE in their migration plus a "
+        "CHECK constraint enforcing endpoint XOR (exactly one endpoint "
+        "per side). Symmetric semantics achieved by inserting two rows "
+        "or by query convention; no is_symmetric flag."
+    )
+
+    class Create(BaseModel, PersonModel.Reference.ID.Optional):
+        target_person_id: Optional[str] = None
+        kind: Optional[str] = None
+        discriminator: Optional[str] = None
+        intensity: Optional[float] = None
+        qualifier: Optional[str] = None
+        valid_from: Optional[datetime] = None
+        valid_to: Optional[datetime] = None
+        notes: Optional[str] = None
+
+    class Update(BaseModel):
+        kind: Optional[str] = None
+        discriminator: Optional[str] = None
+        intensity: Optional[float] = None
+        qualifier: Optional[str] = None
+        valid_from: Optional[datetime] = None
+        valid_to: Optional[datetime] = None
+        notes: Optional[str] = None
+
+    class Search(ApplicationModel.Search, PersonModel.Reference.ID.Search):
+        target_person_id: Optional[StringSearchModel] = None
+        kind: Optional[StringSearchModel] = None
+        discriminator: Optional[StringSearchModel] = None
+        intensity: Optional[NumericalSearchModel] = None
+        qualifier: Optional[StringSearchModel] = None
+        valid_from: Optional[DateSearchModel] = None
+        valid_to: Optional[DateSearchModel] = None
+
+
+class RelationshipManager(AbstractBLLManager, RouterMixin):
+    _model = RelationshipModel
+
+
+RelationshipModel.Manager = RelationshipManager
+
+
+# ---------------------------------------------------------------------------
+# Public roster
+# ---------------------------------------------------------------------------
+
+
+ALL_MODELS: List[type] = [
+    PersonModel,
+    RelationshipModel,
+]
+
+
+__all__ = [
+    "PersonModel",
+    "PersonManager",
+    "RelationshipModel",
+    "RelationshipManager",
+    "ALL_MODELS",
+]

--- a/src/serverframework/extensions/genealogy/BLL_Genealogy_test.py
+++ b/src/serverframework/extensions/genealogy/BLL_Genealogy_test.py
@@ -1,0 +1,102 @@
+"""Structural tests for the genealogy extension's BLL surface."""
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "x" * 32)
+os.environ.setdefault("PYTEST_CURRENT_TEST", "genealogy_test")
+
+from serverframework.extensions.genealogy.BLL_Genealogy import (
+    ALL_MODELS,
+    PersonManager,
+    PersonModel,
+    RelationshipManager,
+    RelationshipModel,
+)
+
+
+class TestModelManagerWiring:
+    PAIRS = [
+        (PersonModel, PersonManager),
+        (RelationshipModel, RelationshipManager),
+    ]
+
+    def test_each_model_has_its_manager(self):
+        for model, manager in self.PAIRS:
+            assert model.Manager is manager
+            assert manager._model is model
+
+    def test_all_models_listed(self):
+        assert set(ALL_MODELS) == {model for model, _ in self.PAIRS}
+
+
+class TestCreateUpdateSearchPresent:
+    def test_nested_classes_exist(self):
+        for model in ALL_MODELS:
+            assert hasattr(model, "Create"), f"{model.__name__} missing Create"
+            assert hasattr(model, "Update"), f"{model.__name__} missing Update"
+            assert hasattr(model, "Search"), f"{model.__name__} missing Search"
+
+
+class TestPersonShape:
+    def test_living_person_has_no_death_date(self):
+        p = PersonModel.Create(name="Bob", birth_date=None, death_date=None)
+        assert p.death_date is None
+
+    def test_full_person(self):
+        p = PersonModel.Create(
+            name="Alice",
+            description="Wizard",
+            gender="female",
+        )
+        assert p.name == "Alice"
+        assert p.gender == "female"
+
+
+class TestRelationshipShape:
+    def test_genealogy_default_is_person_to_person(self):
+        # Standalone genealogy edge: both endpoints are Persons.
+        r = RelationshipModel.Create(
+            person_id="alice",
+            target_person_id="bob",
+            kind="ancestry",
+            discriminator="biological",
+        )
+        assert r.person_id == "alice"
+        assert r.target_person_id == "bob"
+        assert r.kind == "ancestry"
+        assert r.discriminator == "biological"
+
+    def test_validity_window(self):
+        from datetime import datetime
+
+        r = RelationshipModel.Create(
+            person_id="alice",
+            target_person_id="bob",
+            kind="partnership",
+            discriminator="marriage",
+            valid_from=datetime(2020, 6, 1),
+            valid_to=datetime(2024, 12, 31),
+        )
+        assert r.valid_from.year == 2020
+        assert r.valid_to.year == 2024
+
+    def test_intensity_is_signed(self):
+        r = RelationshipModel.Create(
+            person_id="alice",
+            target_person_id="bob",
+            kind="social",
+            discriminator="rival",
+            intensity=-0.8,
+        )
+        assert r.intensity == -0.8
+
+    def test_qualifier_is_distinct_from_discriminator(self):
+        r = RelationshipModel.Create(
+            person_id="alice",
+            target_person_id="bob",
+            kind="social",
+            discriminator="ally",
+            qualifier="since the war",
+        )
+        assert r.discriminator == "ally"
+        assert r.qualifier == "since the war"

--- a/src/serverframework/extensions/genealogy/EXT_Genealogy.py
+++ b/src/serverframework/extensions/genealogy/EXT_Genealogy.py
@@ -1,0 +1,26 @@
+"""genealogy extension definition.
+
+Foundational. No upstream extension dependencies. Downstream extensions
+(notably ``rpg_state``) widen ``RelationshipModel`` via
+``@extension_model`` to add their own endpoint columns.
+"""
+
+from typing import ClassVar, List, Type
+
+from serverframework.extensions.AbstractExtensionProvider import (
+    AbstractStaticExtension,
+)
+
+
+class GenealogyExtension(AbstractStaticExtension):
+    name: ClassVar[str] = "genealogy"
+    description: ClassVar[str] = (
+        "Person and labelled-relationship graph; family-tree algorithms"
+    )
+    extension_dependencies: ClassVar[List[str]] = []
+
+    @classmethod
+    def models(cls) -> List[Type]:
+        from serverframework.extensions.genealogy.BLL_Genealogy import ALL_MODELS
+
+        return list(ALL_MODELS)

--- a/src/serverframework/extensions/genealogy/EXT_Genealogy_test.py
+++ b/src/serverframework/extensions/genealogy/EXT_Genealogy_test.py
@@ -1,0 +1,23 @@
+"""Extension-level tests for genealogy."""
+
+import os
+
+os.environ.setdefault("JWT_SECRET", "x" * 32)
+os.environ.setdefault("PYTEST_CURRENT_TEST", "genealogy_ext_test")
+
+from serverframework.extensions.genealogy.BLL_Genealogy import ALL_MODELS
+from serverframework.extensions.genealogy.EXT_Genealogy import GenealogyExtension
+
+
+class TestExtensionMetadata:
+    def test_name_and_description(self):
+        assert GenealogyExtension.name == "genealogy"
+        assert "person" in GenealogyExtension.description.lower()
+
+    def test_no_extension_dependencies(self):
+        assert GenealogyExtension.extension_dependencies == []
+
+    def test_models_returns_full_roster(self):
+        models = GenealogyExtension.models()
+        assert set(models) == set(ALL_MODELS)
+        assert len(models) == 2  # PersonModel, RelationshipModel

--- a/src/serverframework/extensions/genealogy/__init__.py
+++ b/src/serverframework/extensions/genealogy/__init__.py
@@ -1,0 +1,45 @@
+"""genealogy extension.
+
+Owns ``PersonModel`` and ``RelationshipModel`` — a directed labelled-edge
+graph between entities.
+
+Standalone genealogy
+--------------------
+On its own, the extension is a self-hosted-Ancestry-style tree:
+``Person`` records (name, birth/death, biography, gender) connected by
+``Relationship`` rows whose endpoints are both Persons. The ``kind``
+column carries the ancestry / partnership / sibling / social labels;
+``discriminator`` carries the subkind ("biological" vs "adopted",
+"marriage" vs "engagement"); ``valid_from`` / ``valid_to`` carry
+temporal validity. GEDCOM I/O and family-tree algorithms (ancestors_of,
+descendants_of, MRCA, kinship_degree) are layered on top.
+
+Cross-extension extension
+-------------------------
+``RelationshipModel`` is designed to be widened by downstream extensions
+via ``@extension_model`` (see ``payment`` for the canonical example). A
+downstream extension may inject additional endpoint columns (e.g.
+``faction_id`` / ``target_faction_id``) and is responsible for adding
+the corresponding ALTER TABLE in its own migration plus a CHECK
+constraint enforcing endpoint XOR (exactly one endpoint per side).
+
+Genealogy itself does not know about Factions, Organizations, or any
+other entity kind. It owns ``person_id`` (subject) and
+``target_person_id`` (object) and trusts downstream extensions to keep
+their injected endpoints consistent.
+
+Edge doctrine
+-------------
+- **Directed.** Every row is one directed edge. Symmetric semantics
+  (rivalry, partnership) are achieved by inserting two rows or by query
+  convention ("OR person_id=X OR target_person_id=X"); not by a
+  ``is_symmetric`` flag.
+- **Validity is nullable both ends.** ``valid_from = NULL`` means "from
+  the dawn of time"; ``valid_to = NULL`` means "still in effect".
+- **`kind` is free-form** so downstream extensions can introduce their
+  own labels without a schema change.
+- **`intensity` is signed**: -1.0 nemesis ↔ +1.0 closest. Reused for
+  reputation, regard, partnership closeness, etc.
+- **`qualifier` is conditional context** ("since the war", "while she
+  lived"). Distinct from ``discriminator`` (the subkind label).
+"""

--- a/src/serverframework/extensions/genealogy/manifest.toml
+++ b/src/serverframework/extensions/genealogy/manifest.toml
@@ -1,0 +1,8 @@
+name = "genealogy"
+version = "0.1.0"
+description = "Person and labelled-relationship graph; family-tree algorithms; GEDCOM-importable"
+
+# Foundational. No upstream extension dependencies.
+[[extension_dependencies]]
+
+[python_dependencies]

--- a/src/serverframework/extensions/genealogy/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/genealogy/migrations/versions/001_initial.py
@@ -1,0 +1,138 @@
+"""Initial migration for genealogy — owns ``persons`` and ``relationships``.
+
+FK enforcement is non-negotiable for the relationship graph:
+``person_id`` and ``target_person_id`` are FK-constrained to
+``persons.id``. Endpoint-existence (NOT NULL) is enforced for the
+standalone case; downstream extensions that widen the table with
+additional endpoint kinds are responsible for relaxing nullability and
+adding the corresponding CHECK constraint as part of their migration.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "001_genealogy_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("genealogy",)
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
+
+
+def upgrade() -> None:
+    if not _has_table("persons"):
+        op.create_table(
+            "persons",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("birth_date", sa.DateTime(), nullable=True),
+            sa.Column("death_date", sa.DateTime(), nullable=True),
+            sa.Column("gender", sa.String(64), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            comment=(
+                "An actor identity. Used standalone for genealogy and as the "
+                "humanoid subject of RPG Characters via Character.person_id."
+            ),
+            info={
+                "source_module": "serverframework.extensions.genealogy.BLL_Genealogy",
+                "extension": "genealogy",
+            },
+        )
+
+    persons_idx = _existing_index_names("persons")
+    if "ix_persons_name" not in persons_idx:
+        op.create_index("ix_persons_name", "persons", ["name"])
+    if "ix_persons_birth" not in persons_idx:
+        op.create_index("ix_persons_birth", "persons", ["birth_date"])
+
+    if not _has_table("relationships"):
+        op.create_table(
+            "relationships",
+            sa.Column("id", sa.String(36), nullable=False),
+            # Standalone-genealogy endpoints — both NOT NULL by default.
+            # Downstream extensions that widen the table relax these to
+            # nullable and replace the existence guarantee with a CHECK
+            # over the union of endpoint columns.
+            sa.Column("person_id", sa.String(36), nullable=False),
+            sa.Column("target_person_id", sa.String(36), nullable=False),
+            sa.Column("kind", sa.String(64), nullable=True),
+            sa.Column("discriminator", sa.String(64), nullable=True),
+            sa.Column("intensity", sa.Float(), nullable=True),
+            sa.Column("qualifier", sa.String(255), nullable=True),
+            sa.Column("valid_from", sa.DateTime(), nullable=True),
+            sa.Column("valid_to", sa.DateTime(), nullable=True),
+            sa.Column("notes", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["target_person_id"], ["persons.id"]),
+            comment=(
+                "Directed labelled edge. Default endpoints are Persons. "
+                "Downstream extensions may inject additional endpoint "
+                "columns and are responsible for the corresponding "
+                "ALTER TABLE plus endpoint-XOR CHECK constraint."
+            ),
+            info={
+                "source_module": "serverframework.extensions.genealogy.BLL_Genealogy",
+                "extension": "genealogy",
+            },
+        )
+
+    rel_idx = _existing_index_names("relationships")
+    if "ix_rel_subject_person" not in rel_idx:
+        op.create_index("ix_rel_subject_person", "relationships", ["person_id"])
+    if "ix_rel_target_person" not in rel_idx:
+        op.create_index(
+            "ix_rel_target_person", "relationships", ["target_person_id"]
+        )
+    if "ix_rel_kind" not in rel_idx:
+        op.create_index("ix_rel_kind", "relationships", ["kind"])
+    if "ix_rel_validity" not in rel_idx:
+        op.create_index(
+            "ix_rel_validity", "relationships", ["valid_from", "valid_to"]
+        )
+
+
+def downgrade() -> None:
+    rel_idx = _existing_index_names("relationships")
+    for name in (
+        "ix_rel_validity",
+        "ix_rel_kind",
+        "ix_rel_target_person",
+        "ix_rel_subject_person",
+    ):
+        if name in rel_idx:
+            op.drop_index(name, table_name="relationships")
+    if _has_table("relationships"):
+        op.drop_table("relationships")
+
+    persons_idx = _existing_index_names("persons")
+    for name in ("ix_persons_birth", "ix_persons_name"):
+        if name in persons_idx:
+            op.drop_index(name, table_name="persons")
+    if _has_table("persons"):
+        op.drop_table("persons")

--- a/src/serverframework/extensions/rpg_log/BLL_RPGLog.py
+++ b/src/serverframework/extensions/rpg_log/BLL_RPGLog.py
@@ -1,20 +1,34 @@
 """rpg_log — event log models and managers for RPG campaigns.
 
 Sibling to ``rpg_state``. Every log row carries:
-- ``campaign_id`` (Reference to rpg_state.CampaignModel)
+
+- ``campaign_id`` (Reference to ``rpg_state.CampaignModel``)
 - ``occurred_at`` — in-game time the event happened, distinct from the
   audit ``created_at`` (when the row was logged).
 - ``session_id`` — optional grouping by play session.
 
-Logs are editable (UpdateMixinModel) so GMs can fix typos and retcon;
-the standard ``updated_at`` / ``updated_by_user_id`` audit fields
-preserve the change trail.
+Logs are editable (``UpdateMixinModel``) so GMs can fix typos and
+retcon; the standard ``updated_at`` / ``updated_by_user_id`` audit
+fields preserve the change trail.
 
-Multiple FKs to the same target table (e.g. attacker / defender both
-referencing characters; from / to both referencing locations) are
-declared as plain ``Optional[str]`` columns rather than via the
-``Reference`` mixin, since the metaclass keys field-name generation off
-the target model name and would collide.
+Person endpoints
+----------------
+Actor / target / participant references all point at
+``genealogy.persons.id`` (via ``rpg_state``'s injection of character
+columns onto ``PersonModel``). The persons table is the character
+table for RPG users. Multiple FKs to the same target table (attacker /
+target both referencing persons; from / to both referencing locations
+or factions) are declared as plain ``Optional[str]`` columns rather
+than via the ``Reference`` mixin, since the metaclass keys field-name
+generation off the target model name and would collide.
+
+Schema integrity
+----------------
+Cross-extension foreign keys are real ``ForeignKeyConstraint``
+declarations. Required references use ``nullable=False``. Manager-layer
+validators handle the rest (encounter participation must reference a
+real encounter, dialogue participants must reference a real dialogue,
+etc.).
 """
 
 from datetime import datetime
@@ -22,9 +36,9 @@ from typing import ClassVar, List, Optional, Type
 
 from pydantic import Field
 
+from serverframework.extensions.genealogy.BLL_Genealogy import PersonModel
 from serverframework.extensions.rpg_state.BLL_RPGState import (
     CampaignModel,
-    CharacterModel,
     ItemInstanceModel,
     LocationModel,
     TraitModel,
@@ -110,26 +124,25 @@ class EncounterParticipantModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
     EncounterLogModel.Reference.Optional,
-    CharacterModel.Reference.Optional,
+    PersonModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["EncounterParticipantManager"]] = None
-    # Free-form side label so multi-side fights work
-    # (attackers / defenders / wildlife / bystanders / ...).
     side: Optional[str] = Field(None, description="Side / faction-of-convenience label")
-    # Faction at encounter time. Manual to avoid a Reference collision —
-    # the participant table doesn't need a back-resolved Faction object.
-    faction_id: Optional[str] = Field(None)
+    faction_id: Optional[str] = Field(
+        None,
+        description="Faction at encounter time (snapshot).",
+    )
     initiative: Optional[float] = Field(None)
     table_comment: ClassVar[str] = (
-        "Roster of an encounter. Faction inferable; explicit faction_id "
-        "captures the snapshot at encounter time."
+        "Roster of an encounter. faction_id captures the snapshot at "
+        "encounter time even if the person defects later."
     )
 
     class Create(
         BaseModel,
         EncounterLogModel.Reference.ID.Optional,
-        CharacterModel.Reference.ID.Optional,
+        PersonModel.Reference.ID.Optional,
     ):
         side: Optional[str] = None
         faction_id: Optional[str] = None
@@ -143,7 +156,7 @@ class EncounterParticipantModel(
     class Search(
         ApplicationModel.Search,
         EncounterLogModel.Reference.ID.Search,
-        CharacterModel.Reference.ID.Search,
+        PersonModel.Reference.ID.Search,
     ):
         side: Optional[StringSearchModel] = None
         faction_id: Optional[StringSearchModel] = None
@@ -171,10 +184,10 @@ class CombatActionLogModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["CombatActionLogManager"]] = None
-    # Two characters per action (actor + target); declared manually since
-    # CharacterModel.Reference would collide.
-    actor_character_id: Optional[str] = Field(None)
-    target_character_id: Optional[str] = Field(None)
+    # Two persons per action (actor + target); declared manually since
+    # PersonModel.Reference would collide.
+    actor_person_id: Optional[str] = Field(None)
+    target_person_id: Optional[str] = Field(None)
     action_type: Optional[str] = Field(
         None, description="attack|cast|defend|item_use|movement|other"
     )
@@ -186,8 +199,8 @@ class CombatActionLogModel(
     occurred_at: Optional[datetime] = Field(None)
     session_id: Optional[str] = Field(None)
     table_comment: ClassVar[str] = (
-        "One row per combat action. trait_id = spell/skill used (unified Trait); "
-        "item_instance_id = weapon/consumable used."
+        "One row per combat action. trait_id = spell/skill used (unified "
+        "Trait); item_instance_id = weapon/consumable used."
     )
 
     class Create(
@@ -197,8 +210,8 @@ class CombatActionLogModel(
         ItemInstanceModel.Reference.ID.Optional,
         TraitModel.Reference.ID.Optional,
     ):
-        actor_character_id: Optional[str] = None
-        target_character_id: Optional[str] = None
+        actor_person_id: Optional[str] = None
+        target_person_id: Optional[str] = None
         action_type: Optional[str] = None
         result: Optional[str] = None
         damage_amount: Optional[float] = None
@@ -217,8 +230,8 @@ class CombatActionLogModel(
         EncounterLogModel.Reference.ID.Search,
         CampaignModel.Reference.ID.Search,
     ):
-        actor_character_id: Optional[StringSearchModel] = None
-        target_character_id: Optional[StringSearchModel] = None
+        actor_person_id: Optional[StringSearchModel] = None
+        target_person_id: Optional[StringSearchModel] = None
         action_type: Optional[StringSearchModel] = None
         damage_amount: Optional[NumericalSearchModel] = None
         round_number: Optional[NumericalSearchModel] = None
@@ -245,8 +258,8 @@ class DialogueLogModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["DialogueLogManager"]] = None
-    actor_character_id: Optional[str] = Field(None, description="Speaker")
-    target_character_id: Optional[str] = Field(
+    actor_person_id: Optional[str] = Field(None, description="Speaker")
+    target_person_id: Optional[str] = Field(
         None, description="Primary addressee (null for group / monologue)"
     )
     text: Optional[str] = Field(None)
@@ -263,8 +276,8 @@ class DialogueLogModel(
         CampaignModel.Reference.ID.Optional,
         LocationModel.Reference.ID.Optional,
     ):
-        actor_character_id: Optional[str] = None
-        target_character_id: Optional[str] = None
+        actor_person_id: Optional[str] = None
+        target_person_id: Optional[str] = None
         text: Optional[str] = None
         tone: Optional[str] = None
         occurred_at: Optional[datetime] = None
@@ -279,8 +292,8 @@ class DialogueLogModel(
         CampaignModel.Reference.ID.Search,
         LocationModel.Reference.ID.Search,
     ):
-        actor_character_id: Optional[StringSearchModel] = None
-        target_character_id: Optional[StringSearchModel] = None
+        actor_person_id: Optional[StringSearchModel] = None
+        target_person_id: Optional[StringSearchModel] = None
         tone: Optional[StringSearchModel] = None
         occurred_at: Optional[DateSearchModel] = None
 
@@ -296,7 +309,7 @@ class DialogueParticipantModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
     DialogueLogModel.Reference.Optional,
-    CharacterModel.Reference.Optional,
+    PersonModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["DialogueParticipantManager"]] = None
@@ -310,7 +323,7 @@ class DialogueParticipantModel(
     class Create(
         BaseModel,
         DialogueLogModel.Reference.ID.Optional,
-        CharacterModel.Reference.ID.Optional,
+        PersonModel.Reference.ID.Optional,
     ):
         role: Optional[str] = None
 
@@ -320,7 +333,7 @@ class DialogueParticipantModel(
     class Search(
         ApplicationModel.Search,
         DialogueLogModel.Reference.ID.Search,
-        CharacterModel.Reference.ID.Search,
+        PersonModel.Reference.ID.Search,
     ):
         role: Optional[StringSearchModel] = None
 
@@ -346,7 +359,7 @@ class InteractionLogModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["InteractionLogManager"]] = None
-    actor_character_id: Optional[str] = Field(None)
+    actor_person_id: Optional[str] = Field(None)
     interaction_type: Optional[str] = Field(
         None,
         description="examine|use|open|pickup|drop|lock|unlock|read|...",
@@ -364,7 +377,7 @@ class InteractionLogModel(
         LocationModel.Reference.ID.Optional,
         ItemInstanceModel.Reference.ID.Optional,
     ):
-        actor_character_id: Optional[str] = None
+        actor_person_id: Optional[str] = None
         interaction_type: Optional[str] = None
         notes: Optional[str] = None
         occurred_at: Optional[datetime] = None
@@ -380,7 +393,7 @@ class InteractionLogModel(
         LocationModel.Reference.ID.Search,
         ItemInstanceModel.Reference.ID.Search,
     ):
-        actor_character_id: Optional[StringSearchModel] = None
+        actor_person_id: Optional[StringSearchModel] = None
         interaction_type: Optional[StringSearchModel] = None
         occurred_at: Optional[DateSearchModel] = None
 
@@ -409,8 +422,8 @@ class TransactionLogModel(
     # From / to. Manual columns since both reference the same target tables.
     from_location_id: Optional[str] = Field(None)
     to_location_id: Optional[str] = Field(None)
-    from_owner_character_id: Optional[str] = Field(None)
-    to_owner_character_id: Optional[str] = Field(None)
+    from_owner_person_id: Optional[str] = Field(None)
+    to_owner_person_id: Optional[str] = Field(None)
     from_owner_faction_id: Optional[str] = Field(None)
     to_owner_faction_id: Optional[str] = Field(None)
     price: Optional[float] = Field(None, description="Sale price (null = non-monetary)")
@@ -420,7 +433,8 @@ class TransactionLogModel(
     occurred_at: Optional[datetime] = Field(None)
     session_id: Optional[str] = Field(None)
     table_comment: ClassVar[str] = (
-        "One row per item movement. captures trade, theft, looting, and gifts."
+        "One row per item movement. Captures trade, theft, looting, and gifts. "
+        "owner_* fields are assignment / responsibility (not equipped)."
     )
 
     class Create(
@@ -431,8 +445,8 @@ class TransactionLogModel(
         quantity: Optional[int] = None
         from_location_id: Optional[str] = None
         to_location_id: Optional[str] = None
-        from_owner_character_id: Optional[str] = None
-        to_owner_character_id: Optional[str] = None
+        from_owner_person_id: Optional[str] = None
+        to_owner_person_id: Optional[str] = None
         from_owner_faction_id: Optional[str] = None
         to_owner_faction_id: Optional[str] = None
         price: Optional[float] = None
@@ -450,8 +464,8 @@ class TransactionLogModel(
         ItemInstanceModel.Reference.ID.Search,
     ):
         kind: Optional[StringSearchModel] = None
-        from_owner_character_id: Optional[StringSearchModel] = None
-        to_owner_character_id: Optional[StringSearchModel] = None
+        from_owner_person_id: Optional[StringSearchModel] = None
+        to_owner_person_id: Optional[StringSearchModel] = None
         from_owner_faction_id: Optional[StringSearchModel] = None
         to_owner_faction_id: Optional[StringSearchModel] = None
         occurred_at: Optional[DateSearchModel] = None

--- a/src/serverframework/extensions/rpg_log/BLL_RPGLog_test.py
+++ b/src/serverframework/extensions/rpg_log/BLL_RPGLog_test.py
@@ -58,14 +58,13 @@ class TestEncounterParticipation:
     EncounterLog."""
 
     def test_encounter_log_has_no_faction_field(self):
-        # The model deliberately omits a faction_id on EncounterLog itself.
         ep = EncounterLogModel.Create(name="Tavern brawl")
         assert not hasattr(ep, "faction_id")
 
     def test_participant_carries_side_and_faction(self):
         p = EncounterParticipantModel.Create(
             encounter_log_id="enc-1",
-            character_id="bob",
+            person_id="bob",
             faction_id="party",
             side="defenders",
             initiative=14.0,
@@ -75,21 +74,21 @@ class TestEncounterParticipation:
 
 
 class TestCombatActionShape:
-    """A combat action has actor + (optional) target characters and may
+    """A combat action has actor + (optional) target persons and may
     reference a weapon (item_instance) and/or a spell/skill (trait)."""
 
     def test_attack_with_weapon(self):
         a = CombatActionLogModel.Create(
             encounter_log_id="enc-1",
-            actor_character_id="bob",
-            target_character_id="orc-1",
+            actor_person_id="bob",
+            target_person_id="orc-1",
             item_instance_id="ii-sword",
             action_type="attack",
             result="hit",
             damage_amount=8.0,
             round_number=2,
         )
-        assert a.actor_character_id == "bob"
+        assert a.actor_person_id == "bob"
         assert a.item_instance_id == "ii-sword"
         assert a.damage_amount == 8.0
 
@@ -97,8 +96,8 @@ class TestCombatActionShape:
         # A spell IS a Trait (kind='spell') in the unified model.
         a = CombatActionLogModel.Create(
             encounter_log_id="enc-1",
-            actor_character_id="wizard",
-            target_character_id="orc-2",
+            actor_person_id="wizard",
+            target_person_id="orc-2",
             trait_id="spell-fireball",
             action_type="cast",
             result="hit",
@@ -110,19 +109,19 @@ class TestCombatActionShape:
 class TestDialogueGroupSupport:
     def test_dialogue_log_basic(self):
         d = DialogueLogModel.Create(
-            actor_character_id="bob",
-            target_character_id="innkeep",
+            actor_person_id="bob",
+            target_person_id="innkeep",
             text="One ale, please.",
             tone="friendly",
         )
-        assert d.actor_character_id == "bob"
+        assert d.actor_person_id == "bob"
         assert d.text == "One ale, please."
 
     def test_dialogue_participant_for_eavesdroppers(self):
         # A bard secretly listening from the next table.
         p = DialogueParticipantModel.Create(
             dialogue_log_id="dl-1",
-            character_id="bard",
+            person_id="bard",
             role="overhearer",
         )
         assert p.role == "overhearer"
@@ -135,15 +134,15 @@ class TestTransactionShape:
         t = TransactionLogModel.Create(
             item_instance_id="ii-sword",
             quantity=1,
-            from_owner_character_id="merchant",
-            to_owner_character_id="bob",
+            from_owner_person_id="merchant",
+            to_owner_person_id="bob",
             from_location_id="loc-shop",
             to_location_id="loc-bob-pack",
             price=50.0,
             kind="trade",
         )
-        assert t.from_owner_character_id == "merchant"
-        assert t.to_owner_character_id == "bob"
+        assert t.from_owner_person_id == "merchant"
+        assert t.to_owner_person_id == "bob"
         assert t.price == 50.0
         assert t.kind == "trade"
 
@@ -156,14 +155,13 @@ class TestTransactionShape:
             to_location_id="loc-thief-pack",
             kind="theft",
         )
-        assert t.from_owner_character_id is None
-        assert t.to_owner_character_id is None
+        assert t.from_owner_person_id is None
+        assert t.to_owner_person_id is None
         assert t.kind == "theft"
 
 
 class TestLogsAreEditable:
-    """Logs use UpdateMixinModel — the user opted for editable logs over
-    append-only. The Update class on each log model exposes mutable fields."""
+    """Logs use UpdateMixinModel — editable over append-only."""
 
     def test_combat_action_update_present(self):
         u = CombatActionLogModel.Update(damage_amount=10.0, result="crit")

--- a/src/serverframework/extensions/rpg_log/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_log/migrations/versions/001_initial.py
@@ -1,225 +1,330 @@
 """Initial migration for rpg_log — owns the event-log tables.
 
-Schema is loose (no SQL FK constraints) to match existing extension
-migrations. Referential integrity is enforced at the ORM/manager layer.
+Cross-extension foreign keys are real ``ForeignKeyConstraint``
+declarations. Manager-layer validators handle invariants that don't
+fit cleanly in DDL.
+
+Person endpoints reference ``persons.id`` (owned by ``genealogy``).
+Multi-FK columns (actor / target both → persons; from_owner / to_owner
+both → persons or factions) are declared as plain string columns with
+named ``ForeignKeyConstraint`` rows.
 """
 
+from typing import Sequence, Union
+
+import sqlalchemy as sa
 from alembic import op
 
 
-revision = "001_rpg_log_initial"
-down_revision = None
-branch_labels = ("rpg_log",)
-depends_on = None
+revision: str = "001_rpg_log_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("rpg_log",)
+depends_on: Union[str, Sequence[str], None] = None
+
+_INFO = {
+    "source_module": "serverframework.extensions.rpg_log.BLL_RPGLog",
+    "extension": "rpg_log",
+}
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS encounter_logs (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            campaign_id VARCHAR(36),
-            location_id VARCHAR(36),
-            occurred_at TIMESTAMP,
-            session_id VARCHAR(36),
-            started_at TIMESTAMP,
-            ended_at TIMESTAMP,
-            outcome VARCHAR(255),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("encounter_logs"):
+        op.create_table(
+            "encounter_logs",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("location_id", sa.String(36), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(), nullable=True),
+            sa.Column("session_id", sa.String(36), nullable=True),
+            sa.Column("started_at", sa.DateTime(), nullable=True),
+            sa.Column("ended_at", sa.DateTime(), nullable=True),
+            sa.Column("outcome", sa.String(255), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            sa.ForeignKeyConstraint(["location_id"], ["locations.id"]),
+            comment="Top-level encounter log (combat or otherwise)",
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_enc_campaign ON encounter_logs(campaign_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_enc_session ON encounter_logs(session_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS encounter_participants (
-            id VARCHAR(36) PRIMARY KEY,
-            encounter_log_id VARCHAR(36),
-            character_id VARCHAR(36),
-            faction_id VARCHAR(36),
-            side VARCHAR(64),
-            initiative REAL,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
-        )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_ep_encounter "
-        "ON encounter_participants(encounter_log_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_ep_character "
-        "ON encounter_participants(character_id)"
-    )
+    enc_idx = _existing_index_names("encounter_logs")
+    if "ix_enc_campaign" not in enc_idx:
+        op.create_index("ix_enc_campaign", "encounter_logs", ["campaign_id"])
+    if "ix_enc_session" not in enc_idx:
+        op.create_index("ix_enc_session", "encounter_logs", ["session_id"])
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS combat_action_logs (
-            id VARCHAR(36) PRIMARY KEY,
-            encounter_log_id VARCHAR(36),
-            campaign_id VARCHAR(36),
-            actor_character_id VARCHAR(36),
-            target_character_id VARCHAR(36),
-            item_instance_id VARCHAR(36),
-            trait_id VARCHAR(36),
-            action_type VARCHAR(64),
-            result VARCHAR(64),
-            damage_amount REAL,
-            round_number INTEGER,
-            occurred_at TIMESTAMP,
-            session_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("encounter_participants"):
+        op.create_table(
+            "encounter_participants",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("encounter_log_id", sa.String(36), nullable=True),
+            sa.Column("person_id", sa.String(36), nullable=True),
+            sa.Column("faction_id", sa.String(36), nullable=True),
+            sa.Column("side", sa.String(64), nullable=True),
+            sa.Column("initiative", sa.Float(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["encounter_log_id"], ["encounter_logs.id"]
+            ),
+            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["faction_id"], ["factions.id"]),
+            comment=(
+                "Roster of an encounter. faction_id is the snapshot at "
+                "encounter time even if the person defects later."
+            ),
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cal_encounter "
-        "ON combat_action_logs(encounter_log_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cal_actor "
-        "ON combat_action_logs(actor_character_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cal_target "
-        "ON combat_action_logs(target_character_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS dialogue_logs (
-            id VARCHAR(36) PRIMARY KEY,
-            campaign_id VARCHAR(36),
-            location_id VARCHAR(36),
-            actor_character_id VARCHAR(36),
-            target_character_id VARCHAR(36),
-            text TEXT,
-            tone VARCHAR(64),
-            occurred_at TIMESTAMP,
-            session_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    ep_idx = _existing_index_names("encounter_participants")
+    if "ix_ep_encounter" not in ep_idx:
+        op.create_index(
+            "ix_ep_encounter", "encounter_participants", ["encounter_log_id"]
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_dl_actor "
-        "ON dialogue_logs(actor_character_id)"
-    )
+    if "ix_ep_person" not in ep_idx:
+        op.create_index(
+            "ix_ep_person", "encounter_participants", ["person_id"]
+        )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS dialogue_participants (
-            id VARCHAR(36) PRIMARY KEY,
-            dialogue_log_id VARCHAR(36),
-            character_id VARCHAR(36),
-            role VARCHAR(64),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("combat_action_logs"):
+        op.create_table(
+            "combat_action_logs",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("encounter_log_id", sa.String(36), nullable=True),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("actor_person_id", sa.String(36), nullable=True),
+            sa.Column("target_person_id", sa.String(36), nullable=True),
+            sa.Column("item_instance_id", sa.String(36), nullable=True),
+            sa.Column("trait_id", sa.String(36), nullable=True),
+            sa.Column("action_type", sa.String(64), nullable=True),
+            sa.Column("result", sa.String(64), nullable=True),
+            sa.Column("damage_amount", sa.Float(), nullable=True),
+            sa.Column("round_number", sa.Integer(), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(), nullable=True),
+            sa.Column("session_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["encounter_log_id"], ["encounter_logs.id"]
+            ),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            sa.ForeignKeyConstraint(["actor_person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["target_person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(
+                ["item_instance_id"], ["item_instances.id"]
+            ),
+            sa.ForeignKeyConstraint(["trait_id"], ["traits.id"]),
+            comment=(
+                "One row per combat action. trait_id = spell/skill used; "
+                "item_instance_id = weapon/consumable used."
+            ),
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_dp_dialogue "
-        "ON dialogue_participants(dialogue_log_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS interaction_logs (
-            id VARCHAR(36) PRIMARY KEY,
-            campaign_id VARCHAR(36),
-            location_id VARCHAR(36),
-            item_instance_id VARCHAR(36),
-            actor_character_id VARCHAR(36),
-            interaction_type VARCHAR(64),
-            notes TEXT,
-            occurred_at TIMESTAMP,
-            session_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    cal_idx = _existing_index_names("combat_action_logs")
+    if "ix_cal_encounter" not in cal_idx:
+        op.create_index(
+            "ix_cal_encounter", "combat_action_logs", ["encounter_log_id"]
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_il_actor "
-        "ON interaction_logs(actor_character_id)"
-    )
+    if "ix_cal_actor" not in cal_idx:
+        op.create_index(
+            "ix_cal_actor", "combat_action_logs", ["actor_person_id"]
+        )
+    if "ix_cal_target" not in cal_idx:
+        op.create_index(
+            "ix_cal_target", "combat_action_logs", ["target_person_id"]
+        )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS transaction_logs (
-            id VARCHAR(36) PRIMARY KEY,
-            campaign_id VARCHAR(36),
-            item_instance_id VARCHAR(36),
-            quantity INTEGER DEFAULT 1,
-            from_location_id VARCHAR(36),
-            to_location_id VARCHAR(36),
-            from_owner_character_id VARCHAR(36),
-            to_owner_character_id VARCHAR(36),
-            from_owner_faction_id VARCHAR(36),
-            to_owner_faction_id VARCHAR(36),
-            price REAL,
-            kind VARCHAR(64),
-            occurred_at TIMESTAMP,
-            session_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("dialogue_logs"):
+        op.create_table(
+            "dialogue_logs",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("location_id", sa.String(36), nullable=True),
+            sa.Column("actor_person_id", sa.String(36), nullable=True),
+            sa.Column("target_person_id", sa.String(36), nullable=True),
+            sa.Column("text", sa.Text(), nullable=True),
+            sa.Column("tone", sa.String(64), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(), nullable=True),
+            sa.Column("session_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            sa.ForeignKeyConstraint(["location_id"], ["locations.id"]),
+            sa.ForeignKeyConstraint(["actor_person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["target_person_id"], ["persons.id"]),
+            comment="One uttered line.",
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_tl_item ON transaction_logs(item_instance_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_tl_kind ON transaction_logs(kind)"
-    )
+
+    if "ix_dl_actor" not in _existing_index_names("dialogue_logs"):
+        op.create_index(
+            "ix_dl_actor", "dialogue_logs", ["actor_person_id"]
+        )
+
+    if not _has_table("dialogue_participants"):
+        op.create_table(
+            "dialogue_participants",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("dialogue_log_id", sa.String(36), nullable=True),
+            sa.Column("person_id", sa.String(36), nullable=True),
+            sa.Column("role", sa.String(64), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["dialogue_log_id"], ["dialogue_logs.id"]
+            ),
+            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
+            comment="Audience join for DialogueLog.",
+            info=_INFO,
+        )
+
+    if "ix_dp_dialogue" not in _existing_index_names("dialogue_participants"):
+        op.create_index(
+            "ix_dp_dialogue", "dialogue_participants", ["dialogue_log_id"]
+        )
+
+    if not _has_table("interaction_logs"):
+        op.create_table(
+            "interaction_logs",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("location_id", sa.String(36), nullable=True),
+            sa.Column("item_instance_id", sa.String(36), nullable=True),
+            sa.Column("actor_person_id", sa.String(36), nullable=True),
+            sa.Column("interaction_type", sa.String(64), nullable=True),
+            sa.Column("notes", sa.Text(), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(), nullable=True),
+            sa.Column("session_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            sa.ForeignKeyConstraint(["location_id"], ["locations.id"]),
+            sa.ForeignKeyConstraint(
+                ["item_instance_id"], ["item_instances.id"]
+            ),
+            sa.ForeignKeyConstraint(["actor_person_id"], ["persons.id"]),
+            comment="Non-combat / non-dialogue interactions.",
+            info=_INFO,
+        )
+
+    if "ix_il_actor" not in _existing_index_names("interaction_logs"):
+        op.create_index(
+            "ix_il_actor", "interaction_logs", ["actor_person_id"]
+        )
+
+    if not _has_table("transaction_logs"):
+        op.create_table(
+            "transaction_logs",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("item_instance_id", sa.String(36), nullable=True),
+            sa.Column(
+                "quantity", sa.Integer(), nullable=True, server_default="1"
+            ),
+            sa.Column("from_location_id", sa.String(36), nullable=True),
+            sa.Column("to_location_id", sa.String(36), nullable=True),
+            sa.Column("from_owner_person_id", sa.String(36), nullable=True),
+            sa.Column("to_owner_person_id", sa.String(36), nullable=True),
+            sa.Column("from_owner_faction_id", sa.String(36), nullable=True),
+            sa.Column("to_owner_faction_id", sa.String(36), nullable=True),
+            sa.Column("price", sa.Float(), nullable=True),
+            sa.Column("kind", sa.String(64), nullable=True),
+            sa.Column("occurred_at", sa.DateTime(), nullable=True),
+            sa.Column("session_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            sa.ForeignKeyConstraint(
+                ["item_instance_id"], ["item_instances.id"]
+            ),
+            sa.ForeignKeyConstraint(["from_location_id"], ["locations.id"]),
+            sa.ForeignKeyConstraint(["to_location_id"], ["locations.id"]),
+            sa.ForeignKeyConstraint(
+                ["from_owner_person_id"], ["persons.id"]
+            ),
+            sa.ForeignKeyConstraint(
+                ["to_owner_person_id"], ["persons.id"]
+            ),
+            sa.ForeignKeyConstraint(
+                ["from_owner_faction_id"], ["factions.id"]
+            ),
+            sa.ForeignKeyConstraint(
+                ["to_owner_faction_id"], ["factions.id"]
+            ),
+            comment=(
+                "One row per item movement (trade, theft, looting, gifts). "
+                "owner_* columns = assignment / responsibility (not equipped)."
+            ),
+            info=_INFO,
+        )
+
+    tl_idx = _existing_index_names("transaction_logs")
+    if "ix_tl_item" not in tl_idx:
+        op.create_index(
+            "ix_tl_item", "transaction_logs", ["item_instance_id"]
+        )
+    if "ix_tl_kind" not in tl_idx:
+        op.create_index("ix_tl_kind", "transaction_logs", ["kind"])
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE IF EXISTS transaction_logs")
-    op.execute("DROP TABLE IF EXISTS interaction_logs")
-    op.execute("DROP TABLE IF EXISTS dialogue_participants")
-    op.execute("DROP TABLE IF EXISTS dialogue_logs")
-    op.execute("DROP TABLE IF EXISTS combat_action_logs")
-    op.execute("DROP TABLE IF EXISTS encounter_participants")
-    op.execute("DROP TABLE IF EXISTS encounter_logs")
+    for tbl in (
+        "transaction_logs",
+        "interaction_logs",
+        "dialogue_participants",
+        "dialogue_logs",
+        "combat_action_logs",
+        "encounter_participants",
+        "encounter_logs",
+    ):
+        if _has_table(tbl):
+            op.drop_table(tbl)

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState.py
@@ -30,10 +30,18 @@ Model groups (declared in dependency order so ``.Reference`` mixins resolve):
 Ownership semantics on ``ItemInstanceModel``:
 - ``owner_faction_id`` = de jure / "in principle" owner (the Guild owns
   this sword).
-- ``owner_character_id`` = de facto / "in practice" bearer (Bob carries
-  it). Either, both, or neither may be set; theft is the natural state of
-  having ``owner_character_id`` differ from the legal owner without an
-  intermediate ``TransactionLog``.
+- ``owner_character_id`` = de facto / assigned-to / responsible-party.
+  This is **not** "is currently equipped". Owner answers "who would
+  notice this is missing?" — the character to whom the item is assigned,
+  loaned, or attributed by the faction's books. Equipping is a spatial
+  concern handled by ``LocationModel`` (an equipment slot is a Location
+  bound to a character via ``associated_character_id``); the bearer of a
+  sword may differ from its owner the same way an employee may use, but
+  not own, a company laptop.
+- Either, both, or neither owner field may be set. Theft is the natural
+  state of having ``owner_character_id`` differ from the bearer (the
+  current ``location_id`` chain) without an intermediate
+  ``TransactionLog``.
 """
 
 from datetime import datetime
@@ -162,9 +170,27 @@ class TraitModel(
         description="attribute|skill|spell|talent|feat|language|ability|...",
     )
     # campaign_id null = global template; set = campaign-specific override.
+    #
+    # Conventional `kind` values (free-form so systems may extend):
+    #   attribute  — STR, DEX, CHA, ...
+    #   skill      — Stealth, Persuasion, Athletics, ...
+    #   spell      — Fireball, Bull's Strength (a spell IS a Trait so
+    #                CombatActionLog.trait_id reaches it directly).
+    #   talent / feat / ability / language — durable learnings.
+    #   resource   — HP, mana, spell_slot_1, stress, wounds, dice pools;
+    #                CharacterTrait.value carries current value.
+    #   progression — level, experience, spent_experience, milestones,
+    #                 advancement_points. By convention: name='level',
+    #                 'experience', 'spent_experience'. Each system picks
+    #                 the dimensions it cares about. CharacterModel has
+    #                 NO `level` column on purpose.
     table_comment: ClassVar[str] = (
-        "Unified property catalog: stats, skills, spells, talents, feats. "
-        "campaign_id=NULL means a globally-shared template."
+        "Unified property catalog: stats, skills, spells, talents, feats, "
+        "resources, progression dimensions. campaign_id=NULL means a "
+        "globally-shared template; set = campaign-scoped override. "
+        "Conventional kinds: attribute|skill|spell|talent|feat|ability|"
+        "language|resource|progression. By convention progression Traits "
+        "are named 'level', 'experience', 'spent_experience', etc."
     )
 
     class Create(
@@ -303,9 +329,17 @@ class CharacterModel(
     Manager: ClassVar[Type["CharacterManager"]] = None
     # pc|npc|monster|creature|vehicle|construct — free-form for system flex.
     kind: Optional[str] = Field(None, description="pc|npc|monster|creature|...")
-    level: Optional[int] = Field(None, description="System-defined level/tier")
+    # Progression (level, experience, spent_experience, milestones, etc.)
+    # is *not* a column on Character. It lives in the unified Trait
+    # catalog as Traits with kind='resource' or kind='progression', joined
+    # via CharacterTrait. This keeps level-vs-XP-vs-milestone systems
+    # equally first-class. See TraitModel.table_comment for conventions.
     table_comment: ClassVar[str] = (
-        "Any in-game actor. user_id = controlling player (PC); null = NPC."
+        "Any in-game actor (PC, NPC, monster, creature, vehicle, ...). "
+        "user_id = controlling player when one exists; NULL = unattached "
+        "NPC. Progression dimensions (level / XP / spent XP / milestones) "
+        "are Traits joined via CharacterTrait, not columns here, so "
+        "level-based and XP-based and milestone-based systems all work."
     )
 
     class Create(
@@ -316,13 +350,11 @@ class CharacterModel(
         name: str = Field(...)
         description: Optional[str] = None
         kind: Optional[str] = None
-        level: Optional[int] = None
 
     class Update(BaseModel):
         name: Optional[str] = None
         description: Optional[str] = None
         kind: Optional[str] = None
-        level: Optional[int] = None
 
     class Search(
         ApplicationModel.Search,
@@ -434,7 +466,12 @@ class CharacterStatusEffectModel(
         source_item_instance_id: Optional[str] = None
 
     class Update(BaseModel):
+        # Fully editable so GMs can retcon any aspect of an applied
+        # effect — start time, expiry, source caster, source consumable.
+        started_at: Optional[datetime] = None
         expires_at: Optional[datetime] = None
+        source_character_id: Optional[str] = None
+        source_item_instance_id: Optional[str] = None
 
     class Search(
         ApplicationModel.Search,
@@ -665,21 +702,35 @@ class ItemInstanceModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["ItemInstanceManager"]] = None
-    # Two ownership axes, both nullable, no XOR constraint:
-    #   owner_faction_id = de jure / "in principle" (the Guild owns it)
-    #   owner_character_id = de facto / "in practice" (Bob is carrying it)
-    # Theft = the two disagree without an intervening TransactionLog.
+    # Two ownership axes, both nullable, no XOR constraint. Ownership is
+    # *assignment / responsibility*, NOT equipped-state:
+    #   owner_faction_id   = de jure (the Guild owns it on paper).
+    #   owner_character_id = assigned-to / who-would-notice-it-missing.
+    # Equipped-state is spatial (location_id pointing at an equipment-slot
+    # Location bound to a character), not an ownership concern.
+    # Theft = the bearer (location chain) differs from owner_* without an
+    # intervening consensual TransactionLog.
     owner_character_id: Optional[str] = Field(
-        None, description="De facto bearer / in-practice owner"
+        None,
+        description=(
+            "Assigned-to / responsible character — 'who would notice it "
+            "missing'. Not the equipped-by character (that's spatial)."
+        ),
     )
     owner_faction_id: Optional[str] = Field(
-        None, description="De jure / in-principle owner"
+        None,
+        description="De jure / on-the-books owner faction.",
     )
     quantity: Optional[int] = Field(1, description="Stack count (≥1)")
     durability: Optional[float] = Field(None, description="System-defined HP/durability")
     table_comment: ClassVar[str] = (
-        "Per-instance item row. location_id = current physical spot; "
-        "owner_* fields decoupled from location to capture theft / lend."
+        "Per-instance item row. location_id = current physical spot "
+        "(equipment-slot Locations bound to a character represent the "
+        "*equipped* relationship). owner_character_id = assignment / "
+        "responsibility / who-would-notice-missing — distinct from the "
+        "equipping character. owner_faction_id = de jure owner. Theft is "
+        "the location chain disagreeing with owner_* without a "
+        "TransactionLog."
     )
 
     class Create(

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState.py
@@ -25,10 +25,14 @@ Slowed are all Traits. Templates and applied instances share one model:
   feats, abilities, languages, resources, progression dimensions, and
   status effects).
 - ``DerivativeTraitModel`` (replaces ``StatusEffectTrait``) is the
-  edge: how one Trait contributes to another. Bull's Strength → STR
-  (op='additive', value=2.0). Initiative ← DEX (op='additive',
-  value=1.0) plus a constant (op='additive', value=5.0,
-  source_trait_id=NULL).
+  edge: how a Trait *or an Item* contributes to a target Trait.
+  Bull's Strength → STR (op='additive', value=2.0). Initiative ← DEX
+  (op='additive', value=1.0) plus a constant (op='additive',
+  value=5.0, source_trait_id=NULL, source_item_id=NULL). Ring of
+  Protection (Item) → AC (op='additive', value=1.0,
+  source_item_id=ring) — applied while the person wears an
+  ItemInstance of the Item. ``source_trait_id`` and ``source_item_id``
+  are mutually exclusive at the row level.
 - ``PersonTraitModel`` is the join: this person carries this trait,
   with the magnitude on ``value`` (and, for transient applications,
   ``started_at`` / ``expires_at`` / ``source_*``). Multiple rows per
@@ -48,7 +52,12 @@ sharing a non-NULL group keep only the max-abs contribution; rows with
 
 Contribution magnitude:
 - ``source_trait_id`` set → ``effective = value × (source PersonTrait.value or 1.0)``.
-- ``source_trait_id`` NULL → ``effective = value`` (a constant).
+- ``source_item_id`` set → ``effective = value`` while the person carries
+  an ItemInstance of this Item in an active configuration (equipped /
+  held / in an equipment-slot Location associated with the person);
+  contribution drops to 0 otherwise. The active-configuration check
+  is runtime-resolved against ItemInstance.location_id.
+- both NULL → ``effective = value`` (a constant).
 
 ``qualifier`` is conditional context ("vs orcs", "while prone"). NULL =
 always applies; non-NULL = the UI surfaces it as a toggle and the
@@ -358,15 +367,27 @@ class DerivativeTraitModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["DerivativeTraitManager"]] = None
-    # Both endpoints reference traits.id; manual columns since
-    # TraitModel.Reference would generate one trait_id and collide on
-    # the second.
+    # Source endpoints. Two flavours, mutually exclusive at the row
+    # level (enforced by ck_derivative_traits_source_xor in DDL): a
+    # row's contribution comes from either a Trait OR an Item, never
+    # both. Both NULL = constant contribution (the row's `value` is
+    # added unconditionally).
     source_trait_id: Optional[str] = Field(
         None,
         description=(
             "FK → traits.id. When set, contribution scales with the "
-            "source's PersonTrait.value (or 1.0 if null). When NULL, "
-            "the row contributes a constant equal to `value`."
+            "source's PersonTrait.value (or 1.0 if null). Mutually "
+            "exclusive with source_item_id."
+        ),
+    )
+    source_item_id: Optional[str] = Field(
+        None,
+        description=(
+            "FK → items.id. When set, contribution applies while the "
+            "person carries an ItemInstance of this Item in an active "
+            "configuration (equipped / held / in an equipment slot "
+            "associated with the person — runtime-resolved, not part "
+            "of this row). Mutually exclusive with source_trait_id."
         ),
     )
     target_trait_id: Optional[str] = Field(
@@ -413,16 +434,21 @@ class DerivativeTraitModel(
     )
     table_comment: ClassVar[str] = (
         "Edges defining how one Trait contributes to another. Replaces "
-        "the prior StatusEffectTrait; subsumes both arithmetic "
-        "derivations (Initiative ← DEX + 5) and applied-effect "
-        "modifiers (Bull's Strength → STR +2). Resolution pipeline: "
-        "override → additive → multiplicative → clamp; order_index "
-        "sequences within phase; stacking_group de-duplicates by "
-        "max-abs. source_trait_id NULL = constant contribution."
+        "the prior StatusEffectTrait; subsumes arithmetic derivations "
+        "(Initiative ← DEX + 5), applied-effect modifiers (Bull's "
+        "Strength → STR +2), and item effects (Ring of Protection → AC "
+        "+1 while worn). Resolution pipeline: override → additive → "
+        "multiplicative → clamp; order_index sequences within phase; "
+        "stacking_group de-duplicates by max-abs. Source mutual "
+        "exclusion: source_trait_id XOR source_item_id (at most one); "
+        "both NULL = constant contribution. Activation for source_item "
+        "rows is runtime-resolved against the person's worn / held "
+        "ItemInstances."
     )
 
     class Create(BaseModel):
         source_trait_id: Optional[str] = None
+        source_item_id: Optional[str] = None
         target_trait_id: Optional[str] = None
         operation: Optional[DerivativeOperation] = None
         value: Optional[float] = None
@@ -439,6 +465,7 @@ class DerivativeTraitModel(
 
     class Search(ApplicationModel.Search):
         source_trait_id: Optional[StringSearchModel] = None
+        source_item_id: Optional[StringSearchModel] = None
         target_trait_id: Optional[StringSearchModel] = None
         operation: Optional[StringSearchModel] = None
         value: Optional[NumericalSearchModel] = None
@@ -1148,32 +1175,11 @@ class RPG_RelationshipModel(BaseModel):
 # Manager-layer integrity for invariants the DB cannot express. These
 # hooks reject mutations that would close a cycle in a self-referential
 # parent chain (Faction, Location) or in the Hook DAG.
-
-
-def _payload_value(context: HookContext, key: str) -> Optional[str]:
-    """Pull ``key`` off the most likely create/update payload arg.
-
-    Hooks see the manager's call args by position or kwarg; the payload
-    is conventionally the first positional or a ``data`` / ``payload``
-    kwarg. We try the common shapes and return None if nothing
-    matches.
-    """
-    for kwarg in ("data", "payload", "create_data", "update_data"):
-        candidate = context.kwarg(kwarg, default=None)
-        if candidate is not None and hasattr(candidate, key):
-            return getattr(candidate, key, None)
-    arg0 = context.arg(0, default=None)
-    if arg0 is not None and hasattr(arg0, key):
-        return getattr(arg0, key, None)
-    return None
-
-
-def _record_id(context: HookContext) -> Optional[str]:
-    """Pull the record id off an update call (kwarg ``id`` or second arg)."""
-    rid = context.kwarg("id", default=None)
-    if rid is not None:
-        return rid
-    return context.arg(1, default=None)
+#
+# AbstractBLLManager.create / update / list pass payload fields as flat
+# kwargs: ``manager.create(parent_id="x", ...)``,
+# ``manager.update(id, parent_id="z")``, ``manager.list(child_hook_id="y")``.
+# We read straight from ``context.kwarg(...)``.
 
 
 def _faction_parent_lookup(manager: AbstractBLLManager):
@@ -1219,13 +1225,14 @@ def _hook_parents_lookup(manager: AbstractBLLManager):
 def _faction_no_cycle(context: HookContext) -> None:
     if context.method_name not in ("update", "create"):
         return
-    candidate = _payload_value(context, "parent_id")
+    candidate = context.kwarg("parent_id", default=None)
     if not candidate:
         return
     if context.method_name == "create":
-        # New row has no descendants; only self-parent could be a cycle.
+        # New row has no descendants yet; only direct self-parent is a
+        # cycle (caught by would_create_tree_cycle when we know our id).
         return
-    rid = _record_id(context)
+    rid = context.kwarg("id", default=None) or context.arg(0, default=None)
     if not rid:
         return
     if would_create_tree_cycle(
@@ -1240,12 +1247,12 @@ def _faction_no_cycle(context: HookContext) -> None:
 def _location_no_cycle(context: HookContext) -> None:
     if context.method_name not in ("update", "create"):
         return
-    candidate = _payload_value(context, "parent_id")
+    candidate = context.kwarg("parent_id", default=None)
     if not candidate:
         return
     if context.method_name == "create":
         return
-    rid = _record_id(context)
+    rid = context.kwarg("id", default=None) or context.arg(0, default=None)
     if not rid:
         return
     if would_create_tree_cycle(
@@ -1260,8 +1267,8 @@ def _location_no_cycle(context: HookContext) -> None:
 def _hook_dependency_no_cycle(context: HookContext) -> None:
     if context.method_name not in ("create", "update"):
         return
-    parent_id = _payload_value(context, "parent_hook_id")
-    child_id = _payload_value(context, "child_hook_id")
+    parent_id = context.kwarg("parent_hook_id", default=None)
+    child_id = context.kwarg("child_hook_id", default=None)
     if not parent_id or not child_id:
         return
     if would_create_dag_cycle(

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState.py
@@ -1,47 +1,84 @@
 """rpg_state — present-state models and managers for RPG campaigns.
 
-Model groups (declared in dependency order so ``.Reference`` mixins resolve):
+Hard-depends on ``genealogy``. RPG **does not** define a separate
+``Character`` table. Instead, ``rpg_state`` widens
+``genealogy.PersonModel`` via ``@extension_model`` to add the
+character-specific fields (``kind``, ``campaign_id``, ``user_id``); the
+``persons`` table is the character table for RPG users. Per-character
+joins (traits, status effects, quest progress) reference
+``persons.id`` and live in the ``person_*`` join tables defined here.
 
-1. ``GameSystemModel`` — reference catalog ("DnD 5e", "Pathfinder 2e", ...).
+``rpg_state`` also widens ``genealogy.RelationshipModel`` with Faction
+endpoints (``faction_id`` and ``target_faction_id``) so that a single
+relationship table holds Person↔Person, Person↔Faction, and
+Faction↔Faction edges. The migration adds a CHECK constraint enforcing
+endpoint XOR (exactly one endpoint per side: a Person or a Faction, not
+both, not neither).
+
+Model groups (declared in dependency order so ``.Reference`` mixins
+resolve):
+
+1. ``GameSystemModel`` — reference catalog ("DnD 5e", "Pathfinder 2e").
 2. ``CampaignModel`` — root of campaign-scoped data; ``user_id`` is the GM.
-3. Trait / StatusEffect templates — system-agnostic property catalog. The
-   unified ``TraitModel`` carries a ``kind`` discriminator
-   (attribute / skill / spell / talent / feat / language / ability) so the
-   same calculation surface handles permanent learnings and transient buffs.
-4. ``CharacterModel`` — PCs, NPCs, monsters; ``user_id`` is the controlling
-   player when one exists (NPCs leave it null).
-5. Per-character joins (``CharacterTraitModel``,
-   ``CharacterStatusEffectModel``). Magnitude lives on the join: a
-   character's STR=16 is a row on ``CharacterTraitModel.value``; the
-   "+2 STR" granted by Bull's Strength is a ``StatusEffectTraitModel``
-   row with operation='additive', value=2.
+3. Trait / StatusEffect templates — system-agnostic property catalog.
+   The unified ``TraitModel`` carries a ``kind`` discriminator so the
+   same calculation surface handles attributes, skills, spells, talents,
+   feats, languages, abilities, resources (HP/mana/spell slots), and
+   progression dimensions (level, experience, spent_experience).
+4. RPG injection onto ``PersonModel`` — the persons table grows
+   ``kind``, ``campaign_id``, ``user_id`` to serve as the RPG character
+   table.
+5. Per-character joins (``PersonTraitModel``,
+   ``PersonStatusEffectModel``). Magnitude lives on the join: STR=16 is
+   ``PersonTraitModel.value``; "+2 STR" granted by Bull's Strength is a
+   ``StatusEffectTraitModel`` row with operation='additive', value=2.
 6. Faction hierarchy. ``FactionModel`` uses ``parent_id`` (from
    ``ParentMixinModel``) to model squads-within-platoons / parties-as-
-   sub-guilds without a separate Party entity.
-7. Spatial model. ``LocationModel`` is recursive (``parent_id``) and may
-   itself be the inside of a container item via
+   sub-guilds without a separate Party entity. Faction membership is
+   **not** modelled here — it's a ``RelationshipModel`` row with
+   ``kind='member_of'`` and Person↔Faction endpoints.
+7. Spatial model. ``LocationModel`` is recursive (``parent_id``) and
+   may itself be the inside of a container item via
    ``container_item_instance_id``. Equipment is modelled as a Location
-   bound to a character (``associated_character_id``); equipping is a
+   bound to a person via ``associated_person_id``; equipping is a
    spatial move, no IsEquipped flag.
 8. Quest / Objective templates separated from per-character /
    per-faction instances. Objectives carry an optional
    ``prerequisite_objective_id`` for branching / linear chains.
+9. RPG injection onto ``RelationshipModel`` — adds ``faction_id`` and
+   ``target_faction_id``; the migration adds the endpoint-XOR CHECK.
 
 Ownership semantics on ``ItemInstanceModel``:
 - ``owner_faction_id`` = de jure / "in principle" owner (the Guild owns
-  this sword).
-- ``owner_character_id`` = de facto / assigned-to / responsible-party.
-  This is **not** "is currently equipped". Owner answers "who would
-  notice this is missing?" — the character to whom the item is assigned,
-  loaned, or attributed by the faction's books. Equipping is a spatial
-  concern handled by ``LocationModel`` (an equipment slot is a Location
-  bound to a character via ``associated_character_id``); the bearer of a
-  sword may differ from its owner the same way an employee may use, but
-  not own, a company laptop.
+  this sword on the books).
+- ``owner_person_id`` = assigned-to / responsible-party / who-would-
+  notice-it-missing. **Not** "is currently equipped". Equipping is a
+  spatial concern (an equipment-slot Location bound to a person via
+  ``associated_person_id``); the bearer of a sword may differ from its
+  owner the same way an employee may use, but not own, a company laptop.
 - Either, both, or neither owner field may be set. Theft is the natural
-  state of having ``owner_character_id`` differ from the bearer (the
+  state of having ``owner_person_id`` differ from the bearer (the
   current ``location_id`` chain) without an intermediate
   ``TransactionLog``.
+
+Membership & visibility
+-----------------------
+Membership is inferred:
+
+- Campaign owner = ``CampaignModel.user_id`` (GM).
+- A user is a player in a campaign iff they own at least one Person
+  (with ``user_id`` set) carrying that ``campaign_id``.
+
+Granular visibility (GM-secret NPCs, hidden quests, shared handouts) is
+delegated to the optional ``acl_rbac`` extension. ``rpg_state`` does
+**not** carry visibility columns.
+
+Progression
+-----------
+Progression dimensions (level, experience, spent_experience,
+milestones, dice pools) live in the unified Trait catalog as
+``TraitModel(kind='progression')`` rows joined via ``PersonTraitModel``.
+There is no ``level`` column on the persons table.
 """
 
 from datetime import datetime
@@ -49,8 +86,13 @@ from typing import ClassVar, List, Optional, Type
 
 from pydantic import Field
 
+from serverframework.extensions.genealogy.BLL_Genealogy import (
+    PersonModel,
+    RelationshipModel,
+)
 from serverframework.lib.Pydantic import BaseModel
 from serverframework.lib.Pydantic2FastAPI import RouterMixin
+from serverframework.lib.Pydantic2SQLAlchemy import extension_model
 from serverframework.logic.AbstractLogicManager import (
     AbstractBLLManager,
     ApplicationModel,
@@ -163,34 +205,32 @@ class TraitModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["TraitManager"]] = None
-    # Unified discriminator: attribute|skill|spell|talent|feat|language|ability.
-    # Free string so downstream systems can extend without a schema change.
-    kind: Optional[str] = Field(
-        None,
-        description="attribute|skill|spell|talent|feat|language|ability|...",
-    )
-    # campaign_id null = global template; set = campaign-specific override.
-    #
     # Conventional `kind` values (free-form so systems may extend):
     #   attribute  — STR, DEX, CHA, ...
     #   skill      — Stealth, Persuasion, Athletics, ...
-    #   spell      — Fireball, Bull's Strength (a spell IS a Trait so
-    #                CombatActionLog.trait_id reaches it directly).
+    #   spell      — Fireball (a spell IS a Trait so CombatActionLog.trait_id
+    #                reaches it directly).
     #   talent / feat / ability / language — durable learnings.
     #   resource   — HP, mana, spell_slot_1, stress, wounds, dice pools;
-    #                CharacterTrait.value carries current value.
+    #                PersonTrait.value carries current value.
     #   progression — level, experience, spent_experience, milestones,
-    #                 advancement_points. By convention: name='level',
-    #                 'experience', 'spent_experience'. Each system picks
-    #                 the dimensions it cares about. CharacterModel has
-    #                 NO `level` column on purpose.
+    #                 advancement_points. By convention named 'level',
+    #                 'experience', 'spent_experience'. The persons table
+    #                 has NO `level` column on purpose.
+    kind: Optional[str] = Field(
+        None,
+        description=(
+            "attribute|skill|spell|talent|feat|ability|language|resource|"
+            "progression|... (free-form)"
+        ),
+    )
     table_comment: ClassVar[str] = (
         "Unified property catalog: stats, skills, spells, talents, feats, "
         "resources, progression dimensions. campaign_id=NULL means a "
         "globally-shared template; set = campaign-scoped override. "
         "Conventional kinds: attribute|skill|spell|talent|feat|ability|"
-        "language|resource|progression. By convention progression Traits "
-        "are named 'level', 'experience', 'spent_experience', etc."
+        "language|resource|progression. Progression Traits are by "
+        "convention named 'level', 'experience', 'spent_experience', etc."
     )
 
     class Create(
@@ -237,8 +277,13 @@ class StatusEffectModel(
         description="Default lifetime when applied; null = until removed",
     )
     table_comment: ClassVar[str] = (
-        "Status effect templates (buffs, debuffs, conditions). "
-        "Per-trait modifiers live on StatusEffectTrait."
+        "Status effect templates (buffs, debuffs, conditions, damage). "
+        "Per-trait modifiers live on StatusEffectTrait. By convention, "
+        "HealthDamage and ManaExpenditure are StatusEffects whose "
+        "StatusEffectTrait edges point at the relevant resource Trait "
+        "with a negative additive value — so 'Bob takes 8 damage' = "
+        "applying a Wound StatusEffect with StatusEffectTrait(value=-8) "
+        "against the HealthMax Trait."
     )
 
     class Create(BaseModel, GameSystemModel.Reference.ID.Optional):
@@ -276,12 +321,24 @@ class StatusEffectTraitModel(
     )
     value: Optional[float] = Field(
         None,
-        description="Modifier magnitude (e.g. +2 for additive, x1.5 for multiplicative)",
+        description=(
+            "Modifier magnitude; signed (e.g. +2 for buff, -8 for damage, "
+            "x1.5 for multiplicative)."
+        ),
+    )
+    qualifier: Optional[str] = Field(
+        None,
+        description=(
+            "Conditional context. NULL = always applies; non-NULL = "
+            "conditional, e.g. 'vs orcs', 'while prone', 'in moonlight'. "
+            "UI surfaces non-NULL qualifiers as toggles."
+        ),
     )
     table_comment: ClassVar[str] = (
         "Per-trait modifiers contributed by a StatusEffect template. "
         "Bull's Strength → (status_effect=BullsStrength, trait=STR, "
-        "operation='additive', value=2.0)."
+        "operation='additive', value=2.0). Damage uses negative values "
+        "against resource Traits. qualifier carries conditional context."
     )
 
     class Create(
@@ -291,10 +348,12 @@ class StatusEffectTraitModel(
     ):
         operation: Optional[str] = None
         value: Optional[float] = None
+        qualifier: Optional[str] = None
 
     class Update(BaseModel):
         operation: Optional[str] = None
         value: Optional[float] = None
+        qualifier: Optional[str] = None
 
     class Search(
         ApplicationModel.Search,
@@ -303,6 +362,7 @@ class StatusEffectTraitModel(
     ):
         operation: Optional[StringSearchModel] = None
         value: Optional[NumericalSearchModel] = None
+        qualifier: Optional[StringSearchModel] = None
 
 
 class StatusEffectTraitManager(AbstractBLLManager, RouterMixin):
@@ -313,81 +373,75 @@ StatusEffectTraitModel.Manager = StatusEffectTraitManager
 
 
 # ---------------------------------------------------------------------------
-# 4. Character
+# 4. Inject character fields onto genealogy.PersonModel
 # ---------------------------------------------------------------------------
+#
+# rpg_state does not own its own Character table. The persons table
+# (owned by genealogy) is the character table for RPG users; this
+# extension class adds the character-specific columns. Migration adds
+# the matching ALTER TABLE on `persons`.
 
 
-class CharacterModel(
-    ApplicationModel.Optional,
-    UpdateMixinModel.Optional,
-    NameMixinModel.Optional,
-    DescriptionMixinModel.Optional,
-    CampaignModel.Reference.Optional,
-    UserModel.Reference.Optional,
-    metaclass=ModelMeta,
-):
-    Manager: ClassVar[Type["CharacterManager"]] = None
-    # pc|npc|monster|creature|vehicle|construct — free-form for system flex.
-    kind: Optional[str] = Field(None, description="pc|npc|monster|creature|...")
-    # Progression (level, experience, spent_experience, milestones, etc.)
-    # is *not* a column on Character. It lives in the unified Trait
-    # catalog as Traits with kind='resource' or kind='progression', joined
-    # via CharacterTrait. This keeps level-vs-XP-vs-milestone systems
-    # equally first-class. See TraitModel.table_comment for conventions.
-    table_comment: ClassVar[str] = (
-        "Any in-game actor (PC, NPC, monster, creature, vehicle, ...). "
-        "user_id = controlling player when one exists; NULL = unattached "
-        "NPC. Progression dimensions (level / XP / spent XP / milestones) "
-        "are Traits joined via CharacterTrait, not columns here, so "
-        "level-based and XP-based and milestone-based systems all work."
+@extension_model(PersonModel)
+class RPG_PersonModel(BaseModel):
+    """RPG character-specific fields injected onto ``genealogy.PersonModel``.
+
+    The persons table becomes the character table for RPG users. Adds:
+
+    - ``kind``: pc|npc|monster|creature|vehicle|construct|... — free-form
+      so each system can extend.
+    - ``campaign_id``: FK to ``campaigns.id``; the campaign this actor
+      belongs to. NULL = unattached / cross-campaign template.
+    - ``user_id``: FK to ``users.id``; the controlling player when one
+      exists. NULL = NPC.
+    """
+
+    kind: Optional[str] = Field(
+        None, description="pc|npc|monster|creature|vehicle|construct|... (free-form)"
+    )
+    campaign_id: Optional[str] = Field(
+        None, description="FK → campaigns.id; NULL = cross-campaign / template"
+    )
+    user_id: Optional[str] = Field(
+        None,
+        description="FK → users.id; controlling player. NULL = NPC.",
     )
 
-    class Create(
-        BaseModel,
-        CampaignModel.Reference.ID.Optional,
-        UserModel.Reference.ID.Optional,
-    ):
-        name: str = Field(...)
-        description: Optional[str] = None
+    class Create(BaseModel):
         kind: Optional[str] = None
+        campaign_id: Optional[str] = None
+        user_id: Optional[str] = None
 
     class Update(BaseModel):
-        name: Optional[str] = None
-        description: Optional[str] = None
         kind: Optional[str] = None
+        campaign_id: Optional[str] = None
+        user_id: Optional[str] = None
 
-    class Search(
-        ApplicationModel.Search,
-        CampaignModel.Reference.ID.Search,
-        UserModel.Reference.ID.Search,
-    ):
-        name: Optional[StringSearchModel] = None
+    class Search(BaseModel):
         kind: Optional[StringSearchModel] = None
-
-
-class CharacterManager(AbstractBLLManager, RouterMixin):
-    _model = CharacterModel
-
-
-CharacterModel.Manager = CharacterManager
+        campaign_id: Optional[StringSearchModel] = None
+        user_id: Optional[StringSearchModel] = None
 
 
 # ---------------------------------------------------------------------------
-# 5. Per-character joins
+# 5. Per-person joins (RPG-domain join tables; references persons.id)
 # ---------------------------------------------------------------------------
 
 
-class CharacterTraitModel(
+class PersonTraitModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
-    CharacterModel.Reference.Optional,
+    PersonModel.Reference.Optional,
     TraitModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["CharacterTraitManager"]] = None
+    Manager: ClassVar[Type["PersonTraitManager"]] = None
     value: Optional[float] = Field(
         None,
-        description="Base magnitude (e.g. STR=16). Active modifiers stack on top.",
+        description=(
+            "Base magnitude (e.g. STR=16; current HP for resource Traits). "
+            "Active modifiers stack on top via PersonStatusEffect."
+        ),
     )
     rank: Optional[int] = Field(
         None,
@@ -395,13 +449,14 @@ class CharacterTraitModel(
     )
     notes: Optional[str] = Field(None)
     table_comment: ClassVar[str] = (
-        "Per-character base trait values. Effective value = this.value + "
-        "Σ active StatusEffectTrait modifiers via CharacterStatusEffect."
+        "Per-person base trait values. Effective value = this.value + "
+        "Σ active StatusEffectTrait modifiers via PersonStatusEffect "
+        "(filtered by qualifier conditions when relevant)."
     )
 
     class Create(
         BaseModel,
-        CharacterModel.Reference.ID.Optional,
+        PersonModel.Reference.ID.Optional,
         TraitModel.Reference.ID.Optional,
     ):
         value: Optional[float] = None
@@ -415,82 +470,88 @@ class CharacterTraitModel(
 
     class Search(
         ApplicationModel.Search,
-        CharacterModel.Reference.ID.Search,
+        PersonModel.Reference.ID.Search,
         TraitModel.Reference.ID.Search,
     ):
         value: Optional[NumericalSearchModel] = None
         rank: Optional[NumericalSearchModel] = None
 
 
-class CharacterTraitManager(AbstractBLLManager, RouterMixin):
-    _model = CharacterTraitModel
+class PersonTraitManager(AbstractBLLManager, RouterMixin):
+    _model = PersonTraitModel
 
 
-CharacterTraitModel.Manager = CharacterTraitManager
+PersonTraitModel.Manager = PersonTraitManager
 
 
-class CharacterStatusEffectModel(
+class PersonStatusEffectModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
-    CharacterModel.Reference.Optional,
+    PersonModel.Reference.Optional,
     StatusEffectModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["CharacterStatusEffectManager"]] = None
+    Manager: ClassVar[Type["PersonStatusEffectManager"]] = None
     started_at: Optional[datetime] = Field(None)
     expires_at: Optional[datetime] = Field(
         None,
         description="Effect end; null = persists until manually removed",
     )
-    # Caster / source. Manual columns (Character already used for the
-    # affected character; ItemInstance.Reference would create a cycle).
-    source_character_id: Optional[str] = Field(
+    # Source attribution; manual columns to avoid Reference collisions
+    # (PersonModel.Reference is already used for the affected person;
+    # ItemInstance.Reference would create a cycle).
+    source_person_id: Optional[str] = Field(
         None, description="The caster / applier"
     )
     source_item_instance_id: Optional[str] = Field(
         None, description="Item consumed to apply the effect"
     )
     table_comment: ClassVar[str] = (
-        "Active StatusEffect attachments per character. "
-        "The effect's per-trait modifiers come from StatusEffectTrait."
+        "Active StatusEffect attachments per person. The effect's "
+        "per-trait modifiers come from StatusEffectTrait. Multiple "
+        "stacked effects (e.g. damage ticks) are multiple rows; the "
+        "manager may consolidate expired rows on session close."
     )
 
     class Create(
         BaseModel,
-        CharacterModel.Reference.ID.Optional,
+        PersonModel.Reference.ID.Optional,
         StatusEffectModel.Reference.ID.Optional,
     ):
         started_at: Optional[datetime] = None
         expires_at: Optional[datetime] = None
-        source_character_id: Optional[str] = None
+        source_person_id: Optional[str] = None
         source_item_instance_id: Optional[str] = None
 
     class Update(BaseModel):
-        # Fully editable so GMs can retcon any aspect of an applied
-        # effect — start time, expiry, source caster, source consumable.
+        # Fully editable — GMs can retcon any aspect of an applied effect.
         started_at: Optional[datetime] = None
         expires_at: Optional[datetime] = None
-        source_character_id: Optional[str] = None
+        source_person_id: Optional[str] = None
         source_item_instance_id: Optional[str] = None
 
     class Search(
         ApplicationModel.Search,
-        CharacterModel.Reference.ID.Search,
+        PersonModel.Reference.ID.Search,
         StatusEffectModel.Reference.ID.Search,
     ):
         expires_at: Optional[DateSearchModel] = None
 
 
-class CharacterStatusEffectManager(AbstractBLLManager, RouterMixin):
-    _model = CharacterStatusEffectModel
+class PersonStatusEffectManager(AbstractBLLManager, RouterMixin):
+    _model = PersonStatusEffectModel
 
 
-CharacterStatusEffectModel.Manager = CharacterStatusEffectManager
+PersonStatusEffectModel.Manager = PersonStatusEffectManager
 
 
 # ---------------------------------------------------------------------------
 # 6. Faction hierarchy
 # ---------------------------------------------------------------------------
+#
+# Faction membership is **not** a join table — it's a Relationship row
+# with kind='member_of', subject = person, target = faction (via the
+# faction_id endpoint columns injected onto RelationshipModel below).
 
 
 class FactionModel(
@@ -504,8 +565,13 @@ class FactionModel(
 ):
     Manager: ClassVar[Type["FactionManager"]] = None
     table_comment: ClassVar[str] = (
-        "Hierarchical faction (parent_id self-FK). A 'party' is a "
-        "Faction with a Guild parent or no parent."
+        "Hierarchical faction (parent_id self-FK fast-path for the "
+        "primary tree — squads-within-platoons / parties-as-sub-guilds). "
+        "Non-tree faction edges (allied, at-war, vassal) live in "
+        "RelationshipModel(kind='affiliated_with', ...). Membership of "
+        "persons in factions also lives in RelationshipModel "
+        "(kind='member_of'); this extension does not own a "
+        "person_factions table."
     )
 
     class Create(BaseModel, CampaignModel.Reference.ID.Optional):
@@ -533,49 +599,6 @@ class FactionManager(AbstractBLLManager, RouterMixin):
 FactionModel.Manager = FactionManager
 
 
-class CharacterFactionModel(
-    ApplicationModel.Optional,
-    UpdateMixinModel.Optional,
-    CharacterModel.Reference.Optional,
-    FactionModel.Reference.Optional,
-    metaclass=ModelMeta,
-):
-    Manager: ClassVar[Type["CharacterFactionManager"]] = None
-    role: Optional[str] = Field(
-        None, description="member|leader|enemy|ally|... (free-form)"
-    )
-    reputation: Optional[float] = Field(
-        None, description="Standing within the faction"
-    )
-    table_comment: ClassVar[str] = "Character↔Faction membership join"
-
-    class Create(
-        BaseModel,
-        CharacterModel.Reference.ID.Optional,
-        FactionModel.Reference.ID.Optional,
-    ):
-        role: Optional[str] = None
-        reputation: Optional[float] = None
-
-    class Update(BaseModel):
-        role: Optional[str] = None
-        reputation: Optional[float] = None
-
-    class Search(
-        ApplicationModel.Search,
-        CharacterModel.Reference.ID.Search,
-        FactionModel.Reference.ID.Search,
-    ):
-        role: Optional[StringSearchModel] = None
-
-
-class CharacterFactionManager(AbstractBLLManager, RouterMixin):
-    _model = CharacterFactionModel
-
-
-CharacterFactionModel.Manager = CharacterFactionManager
-
-
 # ---------------------------------------------------------------------------
 # 7. Spatial: Location / Item / ItemInstance
 # ---------------------------------------------------------------------------
@@ -591,17 +614,17 @@ class LocationModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["LocationManager"]] = None
-    # When this Location IS the inside of a container item (a satchel's
-    # interior is a Location whose container_item_instance_id points to
-    # the satchel ItemInstance). Manual column to avoid the cyclic
-    # ItemInstance ↔ Location reference at class-definition time.
+    # Cycle-resolved manually: a satchel's interior is a Location whose
+    # container_item_instance_id points to the satchel ItemInstance, and
+    # ItemInstance.location_id points back at containing Locations. The
+    # ALTER TABLE that adds the FK lands after both tables exist.
     container_item_instance_id: Optional[str] = Field(
         None,
         description="Set when this Location represents the inside of a container item",
     )
-    associated_character_id: Optional[str] = Field(
+    associated_person_id: Optional[str] = Field(
         None,
-        description="Set when this Location is an equipment slot bound to a character",
+        description="Set when this Location is an equipment slot bound to a person",
     )
     kind: Optional[str] = Field(
         None,
@@ -609,8 +632,9 @@ class LocationModel(
     )
     table_comment: ClassVar[str] = (
         "Recursive spatial node. parent_id = parent location; "
-        "container_item_instance_id = container that this is the inside of; "
-        "associated_character_id = equipment-slot owner. Equipping is a move."
+        "container_item_instance_id = container that this is the inside "
+        "of; associated_person_id = equipment-slot owner. Equipping is "
+        "a spatial move."
     )
 
     class Create(BaseModel, CampaignModel.Reference.ID.Optional):
@@ -618,7 +642,7 @@ class LocationModel(
         description: Optional[str] = None
         parent_id: Optional[str] = None
         container_item_instance_id: Optional[str] = None
-        associated_character_id: Optional[str] = None
+        associated_person_id: Optional[str] = None
         kind: Optional[str] = None
 
     class Update(BaseModel):
@@ -626,7 +650,7 @@ class LocationModel(
         description: Optional[str] = None
         parent_id: Optional[str] = None
         container_item_instance_id: Optional[str] = None
-        associated_character_id: Optional[str] = None
+        associated_person_id: Optional[str] = None
         kind: Optional[str] = None
 
     class Search(ApplicationModel.Search, CampaignModel.Reference.ID.Search):
@@ -702,19 +726,18 @@ class ItemInstanceModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["ItemInstanceManager"]] = None
-    # Two ownership axes, both nullable, no XOR constraint. Ownership is
-    # *assignment / responsibility*, NOT equipped-state:
-    #   owner_faction_id   = de jure (the Guild owns it on paper).
-    #   owner_character_id = assigned-to / who-would-notice-it-missing.
-    # Equipped-state is spatial (location_id pointing at an equipment-slot
-    # Location bound to a character), not an ownership concern.
-    # Theft = the bearer (location chain) differs from owner_* without an
-    # intervening consensual TransactionLog.
-    owner_character_id: Optional[str] = Field(
+    # Two ownership axes, both nullable. Ownership is *assignment /
+    # responsibility*, NOT equipped-state. owner_faction_id = de jure
+    # (the Guild owns it on paper); owner_person_id = assigned-to /
+    # who-would-notice-it-missing. Equipping is spatial (location_id
+    # pointing at an equipment-slot Location bound to a person), not an
+    # ownership concern. Theft = location chain disagrees with owner_*
+    # without an intervening consensual TransactionLog.
+    owner_person_id: Optional[str] = Field(
         None,
         description=(
-            "Assigned-to / responsible character — 'who would notice it "
-            "missing'. Not the equipped-by character (that's spatial)."
+            "Assigned-to / responsible person — 'who would notice it "
+            "missing'. Not the equipping person (that's spatial)."
         ),
     )
     owner_faction_id: Optional[str] = Field(
@@ -725,10 +748,10 @@ class ItemInstanceModel(
     durability: Optional[float] = Field(None, description="System-defined HP/durability")
     table_comment: ClassVar[str] = (
         "Per-instance item row. location_id = current physical spot "
-        "(equipment-slot Locations bound to a character represent the "
-        "*equipped* relationship). owner_character_id = assignment / "
+        "(equipment-slot Locations bound to a person represent the "
+        "*equipped* relationship). owner_person_id = assignment / "
         "responsibility / who-would-notice-missing — distinct from the "
-        "equipping character. owner_faction_id = de jure owner. Theft is "
+        "equipping person. owner_faction_id = de jure owner. Theft is "
         "the location chain disagreeing with owner_* without a "
         "TransactionLog."
     )
@@ -738,14 +761,14 @@ class ItemInstanceModel(
         ItemModel.Reference.ID.Optional,
         LocationModel.Reference.ID.Optional,
     ):
-        owner_character_id: Optional[str] = None
+        owner_person_id: Optional[str] = None
         owner_faction_id: Optional[str] = None
         quantity: Optional[int] = None
         durability: Optional[float] = None
 
     class Update(BaseModel):
         location_id: Optional[str] = None
-        owner_character_id: Optional[str] = None
+        owner_person_id: Optional[str] = None
         owner_faction_id: Optional[str] = None
         quantity: Optional[int] = None
         durability: Optional[float] = None
@@ -755,7 +778,7 @@ class ItemInstanceModel(
         ItemModel.Reference.ID.Search,
         LocationModel.Reference.ID.Search,
     ):
-        owner_character_id: Optional[StringSearchModel] = None
+        owner_person_id: Optional[StringSearchModel] = None
         owner_faction_id: Optional[StringSearchModel] = None
 
 
@@ -767,7 +790,7 @@ ItemInstanceModel.Manager = ItemInstanceManager
 
 
 # ---------------------------------------------------------------------------
-# 8. Quests, Objectives, and per-character/per-faction progress
+# 8. Quests, Objectives, and per-person/per-faction progress
 # ---------------------------------------------------------------------------
 
 
@@ -780,8 +803,6 @@ class QuestModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["QuestManager"]] = None
-    # Quest issuer; nullable so unattributed quests work. Manual to avoid
-    # collision with future Faction.Reference uses on this model.
     giver_faction_id: Optional[str] = Field(
         None, description="Faction that issued the quest"
     )
@@ -852,24 +873,24 @@ class ObjectiveManager(AbstractBLLManager, RouterMixin):
 ObjectiveModel.Manager = ObjectiveManager
 
 
-class CharacterQuestModel(
+class PersonQuestModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
-    CharacterModel.Reference.Optional,
+    PersonModel.Reference.Optional,
     QuestModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["CharacterQuestManager"]] = None
+    Manager: ClassVar[Type["PersonQuestManager"]] = None
     status: Optional[str] = Field(
         None, description="available|active|completed|failed|abandoned"
     )
     accepted_at: Optional[datetime] = Field(None)
     completed_at: Optional[datetime] = Field(None)
-    table_comment: ClassVar[str] = "Per-character quest progress instance"
+    table_comment: ClassVar[str] = "Per-person quest progress instance"
 
     class Create(
         BaseModel,
-        CharacterModel.Reference.ID.Optional,
+        PersonModel.Reference.ID.Optional,
         QuestModel.Reference.ID.Optional,
     ):
         status: Optional[str] = None
@@ -883,17 +904,17 @@ class CharacterQuestModel(
 
     class Search(
         ApplicationModel.Search,
-        CharacterModel.Reference.ID.Search,
+        PersonModel.Reference.ID.Search,
         QuestModel.Reference.ID.Search,
     ):
         status: Optional[StringSearchModel] = None
 
 
-class CharacterQuestManager(AbstractBLLManager, RouterMixin):
-    _model = CharacterQuestModel
+class PersonQuestManager(AbstractBLLManager, RouterMixin):
+    _model = PersonQuestModel
 
 
-CharacterQuestModel.Manager = CharacterQuestManager
+PersonQuestModel.Manager = PersonQuestManager
 
 
 class FactionQuestModel(
@@ -904,7 +925,7 @@ class FactionQuestModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["FactionQuestManager"]] = None
-    status: Optional[str] = Field(None, description="See CharacterQuestModel.status")
+    status: Optional[str] = Field(None, description="See PersonQuestModel.status")
     accepted_at: Optional[datetime] = Field(None)
     completed_at: Optional[datetime] = Field(None)
     table_comment: ClassVar[str] = "Per-faction quest progress instance"
@@ -938,24 +959,24 @@ class FactionQuestManager(AbstractBLLManager, RouterMixin):
 FactionQuestModel.Manager = FactionQuestManager
 
 
-class CharacterObjectiveModel(
+class PersonObjectiveModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
-    CharacterModel.Reference.Optional,
+    PersonModel.Reference.Optional,
     ObjectiveModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["CharacterObjectiveManager"]] = None
+    Manager: ClassVar[Type["PersonObjectiveManager"]] = None
     status: Optional[str] = Field(None)
     progress: Optional[float] = Field(
         None, description="Numeric progress (e.g. 3 of 5 wolves slain)"
     )
     completed_at: Optional[datetime] = Field(None)
-    table_comment: ClassVar[str] = "Per-character objective progress instance"
+    table_comment: ClassVar[str] = "Per-person objective progress instance"
 
     class Create(
         BaseModel,
-        CharacterModel.Reference.ID.Optional,
+        PersonModel.Reference.ID.Optional,
         ObjectiveModel.Reference.ID.Optional,
     ):
         status: Optional[str] = None
@@ -969,17 +990,66 @@ class CharacterObjectiveModel(
 
     class Search(
         ApplicationModel.Search,
-        CharacterModel.Reference.ID.Search,
+        PersonModel.Reference.ID.Search,
         ObjectiveModel.Reference.ID.Search,
     ):
         status: Optional[StringSearchModel] = None
 
 
-class CharacterObjectiveManager(AbstractBLLManager, RouterMixin):
-    _model = CharacterObjectiveModel
+class PersonObjectiveManager(AbstractBLLManager, RouterMixin):
+    _model = PersonObjectiveModel
 
 
-CharacterObjectiveModel.Manager = CharacterObjectiveManager
+PersonObjectiveModel.Manager = PersonObjectiveManager
+
+
+# ---------------------------------------------------------------------------
+# 9. Inject Faction endpoints onto genealogy.RelationshipModel
+# ---------------------------------------------------------------------------
+
+
+@extension_model(RelationshipModel)
+class RPG_RelationshipModel(BaseModel):
+    """RPG Faction endpoints injected onto ``genealogy.RelationshipModel``.
+
+    Genealogy ships ``person_id`` (subject) and ``target_person_id``
+    (object). RPG widens the table with ``faction_id`` (subject) and
+    ``target_faction_id`` (object). The migration adds the endpoint-XOR
+    CHECK: exactly one of (``person_id``, ``faction_id``) per row, same
+    for the target side.
+
+    Examples (kind, discriminator) → endpoints:
+        ('member_of', 'leader')      → person → faction
+        ('affiliated_with', 'allied') → faction → faction
+        ('social', 'rival')          → person → person (unchanged)
+    """
+
+    faction_id: Optional[str] = Field(
+        None,
+        description=(
+            "Subject-side Faction endpoint. XOR with person_id "
+            "(enforced by migration CHECK)."
+        ),
+    )
+    target_faction_id: Optional[str] = Field(
+        None,
+        description=(
+            "Object-side Faction endpoint. XOR with target_person_id "
+            "(enforced by migration CHECK)."
+        ),
+    )
+
+    class Create(BaseModel):
+        faction_id: Optional[str] = None
+        target_faction_id: Optional[str] = None
+
+    class Update(BaseModel):
+        faction_id: Optional[str] = None
+        target_faction_id: Optional[str] = None
+
+    class Search(BaseModel):
+        faction_id: Optional[StringSearchModel] = None
+        target_faction_id: Optional[StringSearchModel] = None
 
 
 # ---------------------------------------------------------------------------
@@ -993,19 +1063,17 @@ ALL_MODELS: List[type] = [
     TraitModel,
     StatusEffectModel,
     StatusEffectTraitModel,
-    CharacterModel,
-    CharacterTraitModel,
-    CharacterStatusEffectModel,
+    PersonTraitModel,
+    PersonStatusEffectModel,
     FactionModel,
-    CharacterFactionModel,
     LocationModel,
     ItemModel,
     ItemInstanceModel,
     QuestModel,
     ObjectiveModel,
-    CharacterQuestModel,
+    PersonQuestModel,
     FactionQuestModel,
-    CharacterObjectiveModel,
+    PersonObjectiveModel,
 ]
 
 
@@ -1020,16 +1088,13 @@ __all__ = [
     "StatusEffectManager",
     "StatusEffectTraitModel",
     "StatusEffectTraitManager",
-    "CharacterModel",
-    "CharacterManager",
-    "CharacterTraitModel",
-    "CharacterTraitManager",
-    "CharacterStatusEffectModel",
-    "CharacterStatusEffectManager",
+    "RPG_PersonModel",
+    "PersonTraitModel",
+    "PersonTraitManager",
+    "PersonStatusEffectModel",
+    "PersonStatusEffectManager",
     "FactionModel",
     "FactionManager",
-    "CharacterFactionModel",
-    "CharacterFactionManager",
     "LocationModel",
     "LocationManager",
     "ItemModel",
@@ -1040,11 +1105,12 @@ __all__ = [
     "QuestManager",
     "ObjectiveModel",
     "ObjectiveManager",
-    "CharacterQuestModel",
-    "CharacterQuestManager",
+    "PersonQuestModel",
+    "PersonQuestManager",
     "FactionQuestModel",
     "FactionQuestManager",
-    "CharacterObjectiveModel",
-    "CharacterObjectiveManager",
+    "PersonObjectiveModel",
+    "PersonObjectiveManager",
+    "RPG_RelationshipModel",
     "ALL_MODELS",
 ]

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState.py
@@ -122,13 +122,18 @@ There is no ``level`` column on the persons table.
 """
 
 from datetime import datetime
-from typing import ClassVar, List, Optional, Type
+from typing import ClassVar, List, Literal, Optional, Type
 
 from pydantic import Field
 
 from serverframework.extensions.genealogy.BLL_Genealogy import (
     PersonModel,
     RelationshipModel,
+)
+from serverframework.lib.CycleGuard import (
+    CycleGuardError,
+    would_create_dag_cycle,
+    would_create_tree_cycle,
 )
 from serverframework.lib.Pydantic import BaseModel
 from serverframework.lib.Pydantic2FastAPI import RouterMixin
@@ -138,14 +143,43 @@ from serverframework.logic.AbstractLogicManager import (
     ApplicationModel,
     DateSearchModel,
     DescriptionMixinModel,
+    HookContext,
+    HookTiming,
     ModelMeta,
     NameMixinModel,
     NumericalSearchModel,
     ParentMixinModel,
     StringSearchModel,
     UpdateMixinModel,
+    hook_bll,
 )
 from serverframework.logic.BLL_Auth import UserModel
+
+
+# ---------------------------------------------------------------------------
+# Closed enums
+# ---------------------------------------------------------------------------
+
+DerivativeOperation = Literal["override", "additive", "multiplicative", "clamp"]
+"""Closed set of derivation operations for ``DerivativeTraitModel``.
+
+Doubles as the resolution-pipeline phase: override → additive →
+multiplicative → clamp. Within each phase, ``order_index`` orders ties.
+"""
+
+HookKind = Literal[
+    "major_quest",
+    "side_quest",
+    "objective",
+    "plot_thread",
+    "mystery",
+    "rumor",
+    "obligation",
+    "foreshadowing",
+    "hint",
+    "background",
+]
+"""Closed set of Hook narrative kinds for ``HookModel``."""
 
 
 # ---------------------------------------------------------------------------
@@ -339,12 +373,14 @@ class DerivativeTraitModel(
         None,
         description="FK → traits.id. The trait being modified.",
     )
-    operation: Optional[str] = Field(
+    operation: Optional[DerivativeOperation] = Field(
         None,
         description=(
-            "override|additive|multiplicative|clamp. Also identifies "
-            "the resolution phase: override → additive → multiplicative "
-            "→ clamp. Within each phase, order_index sequences ties."
+            "Closed enum: override|additive|multiplicative|clamp. Also "
+            "identifies the resolution phase: override → additive → "
+            "multiplicative → clamp. Within each phase, order_index "
+            "sequences ties. Validated by Pydantic Literal and enforced "
+            "in DDL by a CHECK constraint in the migration."
         ),
     )
     value: Optional[float] = Field(
@@ -388,14 +424,14 @@ class DerivativeTraitModel(
     class Create(BaseModel):
         source_trait_id: Optional[str] = None
         target_trait_id: Optional[str] = None
-        operation: Optional[str] = None
+        operation: Optional[DerivativeOperation] = None
         value: Optional[float] = None
         order_index: Optional[int] = None
         stacking_group: Optional[str] = None
         qualifier: Optional[str] = None
 
     class Update(BaseModel):
-        operation: Optional[str] = None
+        operation: Optional[DerivativeOperation] = None
         value: Optional[float] = None
         order_index: Optional[int] = None
         stacking_group: Optional[str] = None
@@ -431,6 +467,10 @@ class RPG_PersonModel(BaseModel):
     - ``kind``: pc|npc|monster|creature|vehicle|construct|... — free-form.
     - ``campaign_id``: FK to ``campaigns.id``; NULL = unattached / template.
     - ``user_id``: FK to ``users.id``; NULL = NPC.
+    - ``location_id``: FK to ``locations.id``; the person's current
+      scene/region location. Distinct from any *body-part*
+      sub-Locations associated with the person (see ``LocationModel``
+      for the body-parts-as-locations convention).
     """
 
     kind: Optional[str] = Field(
@@ -443,21 +483,32 @@ class RPG_PersonModel(BaseModel):
         None,
         description="FK → users.id; controlling player. NULL = NPC.",
     )
+    location_id: Optional[str] = Field(
+        None,
+        description=(
+            "FK → locations.id. Current scene/region location. "
+            "Distinct from body-part sub-Locations (those are owned via "
+            "Location.associated_person_id, not Person.location_id)."
+        ),
+    )
 
     class Create(BaseModel):
         kind: Optional[str] = None
         campaign_id: Optional[str] = None
         user_id: Optional[str] = None
+        location_id: Optional[str] = None
 
     class Update(BaseModel):
         kind: Optional[str] = None
         campaign_id: Optional[str] = None
         user_id: Optional[str] = None
+        location_id: Optional[str] = None
 
     class Search(BaseModel):
         kind: Optional[StringSearchModel] = None
         campaign_id: Optional[StringSearchModel] = None
         user_id: Optional[StringSearchModel] = None
+        location_id: Optional[StringSearchModel] = None
 
 
 # ---------------------------------------------------------------------------
@@ -513,11 +564,25 @@ class PersonTraitModel(
         None,
         description="Item consumed to apply the effect (FK → item_instances.id)",
     )
+    # Target localisation: where on the person (or, more generally,
+    # which Location) does this trait/effect apply? Wounds use this to
+    # target a body part sub-Location ("Bob's left arm"); buffs that
+    # are full-body leave it NULL.
+    target_location_id: Optional[str] = Field(
+        None,
+        description=(
+            "FK → locations.id. Where this trait/effect is localised. "
+            "For Wounds and similar damage applications: a body-part "
+            "sub-Location. NULL = whole-body / location-agnostic."
+        ),
+    )
     notes: Optional[str] = Field(None)
     table_comment: ClassVar[str] = (
         "Per-person trait instances. Multiple rows per (person, trait) "
-        "are allowed (e.g. several Wound stacks). Durable traits leave "
-        "started_at/expires_at NULL; transient applications fill them. "
+        "are allowed (e.g. several Wound stacks at different body "
+        "parts). Durable traits leave started_at/expires_at NULL; "
+        "transient applications fill them. target_location_id "
+        "localises the application (e.g. damage to a specific limb). "
         "The full effective value of a derived target trait is computed "
         "by walking DerivativeTrait edges into it from active source "
         "Traits the person carries."
@@ -534,6 +599,7 @@ class PersonTraitModel(
         expires_at: Optional[datetime] = None
         source_person_id: Optional[str] = None
         source_item_instance_id: Optional[str] = None
+        target_location_id: Optional[str] = None
         notes: Optional[str] = None
 
     class Update(BaseModel):
@@ -544,6 +610,7 @@ class PersonTraitModel(
         expires_at: Optional[datetime] = None
         source_person_id: Optional[str] = None
         source_item_instance_id: Optional[str] = None
+        target_location_id: Optional[str] = None
         notes: Optional[str] = None
 
     class Search(
@@ -555,6 +622,7 @@ class PersonTraitModel(
         rank: Optional[NumericalSearchModel] = None
         started_at: Optional[DateSearchModel] = None
         expires_at: Optional[DateSearchModel] = None
+        target_location_id: Optional[StringSearchModel] = None
 
 
 class PersonTraitManager(AbstractBLLManager, RouterMixin):
@@ -639,13 +707,22 @@ class LocationModel(
     )
     kind: Optional[str] = Field(
         None,
-        description="region|room|container|equipment_slot|inventory|... (free-form)",
+        description=(
+            "region|room|container|equipment_slot|inventory|body|"
+            "body_part|organ|... (free-form)"
+        ),
     )
     table_comment: ClassVar[str] = (
         "Recursive spatial node. parent_id = parent location; "
         "container_item_instance_id = container that this is the inside "
-        "of; associated_person_id = equipment-slot owner. Equipping is "
-        "a spatial move."
+        "of; associated_person_id = the person this Location is bound "
+        "to. Equipping is a spatial move (item moves into an "
+        "equipment-slot Location whose associated_person_id is the "
+        "wearer). Body parts are also Locations: a person's anatomy "
+        "lives as a tree of Locations (kind='body'/'body_part'/'organ') "
+        "rooted at a body Location with associated_person_id=person. "
+        "PersonTrait.target_location_id points at body-part Locations "
+        "to localise damage / effect application."
     )
 
     class Create(BaseModel, CampaignModel.Reference.ID.Optional):
@@ -807,14 +884,13 @@ class HookModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["HookManager"]] = None
-    # Free-form discriminator. Conventional values: major_quest |
-    # side_quest | objective | plot_thread | mystery | rumor |
-    # obligation | foreshadowing | background | hint | ...
-    kind: Optional[str] = Field(
+    kind: Optional[HookKind] = Field(
         None,
         description=(
-            "major_quest|side_quest|objective|plot_thread|mystery|"
-            "rumor|obligation|foreshadowing|... (free-form)"
+            "Closed enum: major_quest|side_quest|objective|plot_thread|"
+            "mystery|rumor|obligation|foreshadowing|hint|background. "
+            "Validated by Pydantic Literal and enforced in DDL by a "
+            "CHECK constraint in the migration."
         ),
     )
     giver_faction_id: Optional[str] = Field(
@@ -831,13 +907,13 @@ class HookModel(
     class Create(BaseModel, CampaignModel.Reference.ID.Optional):
         name: str = Field(...)
         description: Optional[str] = None
-        kind: Optional[str] = None
+        kind: Optional[HookKind] = None
         giver_faction_id: Optional[str] = None
 
     class Update(BaseModel):
         name: Optional[str] = None
         description: Optional[str] = None
-        kind: Optional[str] = None
+        kind: Optional[HookKind] = None
         giver_faction_id: Optional[str] = None
 
     class Search(ApplicationModel.Search, CampaignModel.Reference.ID.Search):
@@ -1063,6 +1139,137 @@ class RPG_RelationshipModel(BaseModel):
     class Search(BaseModel):
         faction_id: Optional[StringSearchModel] = None
         target_faction_id: Optional[StringSearchModel] = None
+
+
+# ---------------------------------------------------------------------------
+# Cycle guards — Faction.parent_id, Location.parent_id, HookDependency
+# ---------------------------------------------------------------------------
+#
+# Manager-layer integrity for invariants the DB cannot express. These
+# hooks reject mutations that would close a cycle in a self-referential
+# parent chain (Faction, Location) or in the Hook DAG.
+
+
+def _payload_value(context: HookContext, key: str) -> Optional[str]:
+    """Pull ``key`` off the most likely create/update payload arg.
+
+    Hooks see the manager's call args by position or kwarg; the payload
+    is conventionally the first positional or a ``data`` / ``payload``
+    kwarg. We try the common shapes and return None if nothing
+    matches.
+    """
+    for kwarg in ("data", "payload", "create_data", "update_data"):
+        candidate = context.kwarg(kwarg, default=None)
+        if candidate is not None and hasattr(candidate, key):
+            return getattr(candidate, key, None)
+    arg0 = context.arg(0, default=None)
+    if arg0 is not None and hasattr(arg0, key):
+        return getattr(arg0, key, None)
+    return None
+
+
+def _record_id(context: HookContext) -> Optional[str]:
+    """Pull the record id off an update call (kwarg ``id`` or second arg)."""
+    rid = context.kwarg("id", default=None)
+    if rid is not None:
+        return rid
+    return context.arg(1, default=None)
+
+
+def _faction_parent_lookup(manager: AbstractBLLManager):
+    def _get(faction_id: str) -> Optional[str]:
+        try:
+            row = manager.get(id=faction_id)
+        except Exception:
+            return None
+        return getattr(row, "parent_id", None) if row else None
+
+    return _get
+
+
+def _location_parent_lookup(manager: AbstractBLLManager):
+    def _get(location_id: str) -> Optional[str]:
+        try:
+            row = manager.get(id=location_id)
+        except Exception:
+            return None
+        return getattr(row, "parent_id", None) if row else None
+
+    return _get
+
+
+def _hook_parents_lookup(manager: AbstractBLLManager):
+    """Return a function that yields the parent_hook_ids of a given child."""
+
+    def _get(child_hook_id: str):
+        try:
+            edges = manager.list(child_hook_id=child_hook_id) or []
+        except Exception:
+            return ()
+        return [
+            getattr(edge, "parent_hook_id", None)
+            for edge in edges
+            if getattr(edge, "parent_hook_id", None)
+        ]
+
+    return _get
+
+
+@hook_bll(FactionManager, timing=HookTiming.BEFORE, priority=10)
+def _faction_no_cycle(context: HookContext) -> None:
+    if context.method_name not in ("update", "create"):
+        return
+    candidate = _payload_value(context, "parent_id")
+    if not candidate:
+        return
+    if context.method_name == "create":
+        # New row has no descendants; only self-parent could be a cycle.
+        return
+    rid = _record_id(context)
+    if not rid:
+        return
+    if would_create_tree_cycle(
+        rid, candidate, _faction_parent_lookup(context.manager)
+    ):
+        raise CycleGuardError(
+            f"Setting Faction({rid}).parent_id={candidate} would close a cycle."
+        )
+
+
+@hook_bll(LocationManager, timing=HookTiming.BEFORE, priority=10)
+def _location_no_cycle(context: HookContext) -> None:
+    if context.method_name not in ("update", "create"):
+        return
+    candidate = _payload_value(context, "parent_id")
+    if not candidate:
+        return
+    if context.method_name == "create":
+        return
+    rid = _record_id(context)
+    if not rid:
+        return
+    if would_create_tree_cycle(
+        rid, candidate, _location_parent_lookup(context.manager)
+    ):
+        raise CycleGuardError(
+            f"Setting Location({rid}).parent_id={candidate} would close a cycle."
+        )
+
+
+@hook_bll(HookDependencyManager, timing=HookTiming.BEFORE, priority=10)
+def _hook_dependency_no_cycle(context: HookContext) -> None:
+    if context.method_name not in ("create", "update"):
+        return
+    parent_id = _payload_value(context, "parent_hook_id")
+    child_id = _payload_value(context, "child_hook_id")
+    if not parent_id or not child_id:
+        return
+    if would_create_dag_cycle(
+        parent_id, child_id, _hook_parents_lookup(context.manager)
+    ):
+        raise CycleGuardError(
+            f"HookDependency parent={parent_id} → child={child_id} would close a cycle."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState.py
@@ -5,7 +5,7 @@ Hard-depends on ``genealogy``. RPG **does not** define a separate
 ``genealogy.PersonModel`` via ``@extension_model`` to add the
 character-specific fields (``kind``, ``campaign_id``, ``user_id``); the
 ``persons`` table is the character table for RPG users. Per-character
-joins (traits, status effects, quest progress) reference
+joins (traits, status-effect applications, hook progress) reference
 ``persons.id`` and live in the ``person_*`` join tables defined here.
 
 ``rpg_state`` also widens ``genealogy.RelationshipModel`` with Faction
@@ -15,38 +15,78 @@ Faction↔Faction edges. The migration adds a CHECK constraint enforcing
 endpoint XOR (exactly one endpoint per side: a Person or a Faction, not
 both, not neither).
 
+Unified Trait model
+-------------------
+There is **no** separate StatusEffect table. A status effect is a Trait
+with ``kind='status_effect'``. Bull's Strength, Wound, Bleed, Marked,
+Slowed are all Traits. Templates and applied instances share one model:
+
+- ``TraitModel`` is the catalog (attributes, skills, spells, talents,
+  feats, abilities, languages, resources, progression dimensions, and
+  status effects).
+- ``DerivativeTraitModel`` (replaces ``StatusEffectTrait``) is the
+  edge: how one Trait contributes to another. Bull's Strength → STR
+  (op='additive', value=2.0). Initiative ← DEX (op='additive',
+  value=1.0) plus a constant (op='additive', value=5.0,
+  source_trait_id=NULL).
+- ``PersonTraitModel`` is the join: this person carries this trait,
+  with the magnitude on ``value`` (and, for transient applications,
+  ``started_at`` / ``expires_at`` / ``source_*``). Multiple rows per
+  ``(person, trait)`` are allowed (e.g. several stacks of Wound).
+
+Resolution pipeline (deterministic, indexable):
+
+1. ``override`` — last write wins by ``order_index``.
+2. ``additive`` — sum the contributions, in ``order_index`` order.
+3. ``multiplicative`` — apply each multiplier, in ``order_index`` order.
+4. ``clamp`` — apply min/max bounds (sign of ``value`` selects min vs
+   max).
+
+Within each phase, ``stacking_group`` controls de-duplication: rows
+sharing a non-NULL group keep only the max-abs contribution; rows with
+``stacking_group=NULL`` always sum.
+
+Contribution magnitude:
+- ``source_trait_id`` set → ``effective = value × (source PersonTrait.value or 1.0)``.
+- ``source_trait_id`` NULL → ``effective = value`` (a constant).
+
+``qualifier`` is conditional context ("vs orcs", "while prone"). NULL =
+always applies; non-NULL = the UI surfaces it as a toggle and the
+calculation only includes the row when the condition is on.
+
+Hook DAG (replaces Quest+Objective)
+-----------------------------------
+There is **no** separate Quest / Objective hierarchy. Both fold into
+``HookModel``: a campaign-scoped narrative element with a free-form
+``kind`` discriminator (major_quest|side_quest|objective|plot_thread|
+mystery|rumor|obligation|foreshadowing|background|...).
+
+Dependencies between Hooks live in ``HookDependencyModel(parent_hook_id,
+child_hook_id, reason)``. The presence of a row IS the dependency; the
+``reason`` string explains why ("requires the dragon to be slain
+first", "alternative path via diplomacy", "blocked while the curse is
+active"). No dependency-kind enum.
+
+Per-actor progress lives in ``PersonHookModel`` and ``FactionHookModel``
+with status / accepted_at / completed_at / progress (numeric for
+incremental hooks; NULL for atomic).
+
 Model groups (declared in dependency order so ``.Reference`` mixins
 resolve):
 
 1. ``GameSystemModel`` — reference catalog ("DnD 5e", "Pathfinder 2e").
 2. ``CampaignModel`` — root of campaign-scoped data; ``user_id`` is the GM.
-3. Trait / StatusEffect templates — system-agnostic property catalog.
-   The unified ``TraitModel`` carries a ``kind`` discriminator so the
-   same calculation surface handles attributes, skills, spells, talents,
-   feats, languages, abilities, resources (HP/mana/spell slots), and
-   progression dimensions (level, experience, spent_experience).
-4. RPG injection onto ``PersonModel`` — the persons table grows
-   ``kind``, ``campaign_id``, ``user_id`` to serve as the RPG character
-   table.
-5. Per-character joins (``PersonTraitModel``,
-   ``PersonStatusEffectModel``). Magnitude lives on the join: STR=16 is
-   ``PersonTraitModel.value``; "+2 STR" granted by Bull's Strength is a
-   ``StatusEffectTraitModel`` row with operation='additive', value=2.
-6. Faction hierarchy. ``FactionModel`` uses ``parent_id`` (from
-   ``ParentMixinModel``) to model squads-within-platoons / parties-as-
-   sub-guilds without a separate Party entity. Faction membership is
-   **not** modelled here — it's a ``RelationshipModel`` row with
-   ``kind='member_of'`` and Person↔Faction endpoints.
-7. Spatial model. ``LocationModel`` is recursive (``parent_id``) and
-   may itself be the inside of a container item via
-   ``container_item_instance_id``. Equipment is modelled as a Location
-   bound to a person via ``associated_person_id``; equipping is a
-   spatial move, no IsEquipped flag.
-8. Quest / Objective templates separated from per-character /
-   per-faction instances. Objectives carry an optional
-   ``prerequisite_objective_id`` for branching / linear chains.
-9. RPG injection onto ``RelationshipModel`` — adds ``faction_id`` and
-   ``target_faction_id``; the migration adds the endpoint-XOR CHECK.
+3. ``TraitModel`` — unified property catalog including status effects.
+4. ``DerivativeTraitModel`` — edges defining how Traits derive from each other.
+5. RPG injection onto ``PersonModel`` (kind, campaign_id, user_id).
+6. ``PersonTraitModel`` — per-person trait values and applied effects.
+7. ``FactionModel`` — hierarchical faction (parent_id self-FK).
+8. ``LocationModel`` / ``ItemModel`` / ``ItemInstanceModel`` —
+   spatial / inventory.
+9. ``HookModel`` / ``HookDependencyModel`` /
+   ``PersonHookModel`` / ``FactionHookModel`` — narrative DAG.
+10. RPG injection onto ``RelationshipModel`` (faction_id,
+    target_faction_id; endpoint-XOR CHECK in the migration).
 
 Ownership semantics on ``ItemInstanceModel``:
 - ``owner_faction_id`` = de jure / "in principle" owner (the Guild owns
@@ -191,7 +231,7 @@ CampaignModel.Manager = CampaignManager
 
 
 # ---------------------------------------------------------------------------
-# 3. Trait, StatusEffect, StatusEffectTrait — property catalog
+# 3. Trait — unified property catalog (incl. status effects)
 # ---------------------------------------------------------------------------
 
 
@@ -215,22 +255,30 @@ class TraitModel(
     #                PersonTrait.value carries current value.
     #   progression — level, experience, spent_experience, milestones,
     #                 advancement_points. By convention named 'level',
-    #                 'experience', 'spent_experience'. The persons table
-    #                 has NO `level` column on purpose.
+    #                 'experience', 'spent_experience'.
+    #   status_effect — Bull's Strength, Wound, Bleed, Marked, Slowed.
+    #                   Applied to a person via PersonTrait with timing
+    #                   (started_at / expires_at) and source attribution.
     kind: Optional[str] = Field(
         None,
         description=(
             "attribute|skill|spell|talent|feat|ability|language|resource|"
-            "progression|... (free-form)"
+            "progression|status_effect|... (free-form)"
+        ),
+    )
+    default_duration_seconds: Optional[int] = Field(
+        None,
+        description=(
+            "Default lifetime when applied. Only meaningful when "
+            "kind='status_effect'; NULL = persists until manually removed."
         ),
     )
     table_comment: ClassVar[str] = (
         "Unified property catalog: stats, skills, spells, talents, feats, "
-        "resources, progression dimensions. campaign_id=NULL means a "
-        "globally-shared template; set = campaign-scoped override. "
-        "Conventional kinds: attribute|skill|spell|talent|feat|ability|"
-        "language|resource|progression. Progression Traits are by "
-        "convention named 'level', 'experience', 'spent_experience', etc."
+        "abilities, languages, resources, progression, and status effects. "
+        "campaign_id=NULL = globally-shared template; set = "
+        "campaign-scoped override. default_duration_seconds is meaningful "
+        "only for kind='status_effect'."
     )
 
     class Create(
@@ -241,11 +289,13 @@ class TraitModel(
         name: str = Field(...)
         description: Optional[str] = None
         kind: Optional[str] = None
+        default_duration_seconds: Optional[int] = None
 
     class Update(BaseModel):
         name: Optional[str] = None
         description: Optional[str] = None
         kind: Optional[str] = None
+        default_duration_seconds: Optional[int] = None
 
     class Search(
         ApplicationModel.Search,
@@ -263,123 +313,113 @@ class TraitManager(AbstractBLLManager, RouterMixin):
 TraitModel.Manager = TraitManager
 
 
-class StatusEffectModel(
+# ---------------------------------------------------------------------------
+# 4. DerivativeTrait — edges defining how Traits derive from each other
+# ---------------------------------------------------------------------------
+
+
+class DerivativeTraitModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
-    NameMixinModel.Optional,
-    DescriptionMixinModel.Optional,
-    GameSystemModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["StatusEffectManager"]] = None
-    default_duration_seconds: Optional[int] = Field(
+    Manager: ClassVar[Type["DerivativeTraitManager"]] = None
+    # Both endpoints reference traits.id; manual columns since
+    # TraitModel.Reference would generate one trait_id and collide on
+    # the second.
+    source_trait_id: Optional[str] = Field(
         None,
-        description="Default lifetime when applied; null = until removed",
+        description=(
+            "FK → traits.id. When set, contribution scales with the "
+            "source's PersonTrait.value (or 1.0 if null). When NULL, "
+            "the row contributes a constant equal to `value`."
+        ),
     )
-    table_comment: ClassVar[str] = (
-        "Status effect templates (buffs, debuffs, conditions, damage). "
-        "Per-trait modifiers live on StatusEffectTrait. By convention, "
-        "HealthDamage and ManaExpenditure are StatusEffects whose "
-        "StatusEffectTrait edges point at the relevant resource Trait "
-        "with a negative additive value — so 'Bob takes 8 damage' = "
-        "applying a Wound StatusEffect with StatusEffectTrait(value=-8) "
-        "against the HealthMax Trait."
+    target_trait_id: Optional[str] = Field(
+        None,
+        description="FK → traits.id. The trait being modified.",
     )
-
-    class Create(BaseModel, GameSystemModel.Reference.ID.Optional):
-        name: str = Field(...)
-        description: Optional[str] = None
-        default_duration_seconds: Optional[int] = None
-
-    class Update(BaseModel):
-        name: Optional[str] = None
-        description: Optional[str] = None
-        default_duration_seconds: Optional[int] = None
-
-    class Search(ApplicationModel.Search, GameSystemModel.Reference.ID.Search):
-        name: Optional[StringSearchModel] = None
-
-
-class StatusEffectManager(AbstractBLLManager, RouterMixin):
-    _model = StatusEffectModel
-
-
-StatusEffectModel.Manager = StatusEffectManager
-
-
-class StatusEffectTraitModel(
-    ApplicationModel.Optional,
-    UpdateMixinModel.Optional,
-    StatusEffectModel.Reference.Optional,
-    TraitModel.Reference.Optional,
-    metaclass=ModelMeta,
-):
-    Manager: ClassVar[Type["StatusEffectTraitManager"]] = None
     operation: Optional[str] = Field(
         None,
-        description="additive|multiplicative|set",
+        description=(
+            "override|additive|multiplicative|clamp. Also identifies "
+            "the resolution phase: override → additive → multiplicative "
+            "→ clamp. Within each phase, order_index sequences ties."
+        ),
     )
     value: Optional[float] = Field(
         None,
         description=(
-            "Modifier magnitude; signed (e.g. +2 for buff, -8 for damage, "
-            "x1.5 for multiplicative)."
+            "Magnitude. Signed. For additive: the contribution; for "
+            "multiplicative: the multiplier; for override: the new value; "
+            "for clamp: positive = upper bound, negative = lower bound."
+        ),
+    )
+    order_index: Optional[int] = Field(
+        None,
+        description="Tie-breaker within phase (lower runs first; default 0).",
+    )
+    stacking_group: Optional[str] = Field(
+        None,
+        description=(
+            "NULL = always stacks (sum). Non-NULL = within group, only "
+            "the max-abs contribution wins. Used to model 'doesn't stack "
+            "with itself' / typed-bonus stacking rules."
         ),
     )
     qualifier: Optional[str] = Field(
         None,
         description=(
             "Conditional context. NULL = always applies; non-NULL = "
-            "conditional, e.g. 'vs orcs', 'while prone', 'in moonlight'. "
-            "UI surfaces non-NULL qualifiers as toggles."
+            "conditional ('vs orcs', 'while prone', 'in moonlight'). UI "
+            "surfaces non-NULL qualifiers as toggles."
         ),
     )
     table_comment: ClassVar[str] = (
-        "Per-trait modifiers contributed by a StatusEffect template. "
-        "Bull's Strength → (status_effect=BullsStrength, trait=STR, "
-        "operation='additive', value=2.0). Damage uses negative values "
-        "against resource Traits. qualifier carries conditional context."
+        "Edges defining how one Trait contributes to another. Replaces "
+        "the prior StatusEffectTrait; subsumes both arithmetic "
+        "derivations (Initiative ← DEX + 5) and applied-effect "
+        "modifiers (Bull's Strength → STR +2). Resolution pipeline: "
+        "override → additive → multiplicative → clamp; order_index "
+        "sequences within phase; stacking_group de-duplicates by "
+        "max-abs. source_trait_id NULL = constant contribution."
     )
 
-    class Create(
-        BaseModel,
-        StatusEffectModel.Reference.ID.Optional,
-        TraitModel.Reference.ID.Optional,
-    ):
+    class Create(BaseModel):
+        source_trait_id: Optional[str] = None
+        target_trait_id: Optional[str] = None
         operation: Optional[str] = None
         value: Optional[float] = None
+        order_index: Optional[int] = None
+        stacking_group: Optional[str] = None
         qualifier: Optional[str] = None
 
     class Update(BaseModel):
         operation: Optional[str] = None
         value: Optional[float] = None
+        order_index: Optional[int] = None
+        stacking_group: Optional[str] = None
         qualifier: Optional[str] = None
 
-    class Search(
-        ApplicationModel.Search,
-        StatusEffectModel.Reference.ID.Search,
-        TraitModel.Reference.ID.Search,
-    ):
+    class Search(ApplicationModel.Search):
+        source_trait_id: Optional[StringSearchModel] = None
+        target_trait_id: Optional[StringSearchModel] = None
         operation: Optional[StringSearchModel] = None
         value: Optional[NumericalSearchModel] = None
+        stacking_group: Optional[StringSearchModel] = None
         qualifier: Optional[StringSearchModel] = None
 
 
-class StatusEffectTraitManager(AbstractBLLManager, RouterMixin):
-    _model = StatusEffectTraitModel
+class DerivativeTraitManager(AbstractBLLManager, RouterMixin):
+    _model = DerivativeTraitModel
 
 
-StatusEffectTraitModel.Manager = StatusEffectTraitManager
+DerivativeTraitModel.Manager = DerivativeTraitManager
 
 
 # ---------------------------------------------------------------------------
-# 4. Inject character fields onto genealogy.PersonModel
+# 5. Inject character fields onto genealogy.PersonModel
 # ---------------------------------------------------------------------------
-#
-# rpg_state does not own its own Character table. The persons table
-# (owned by genealogy) is the character table for RPG users; this
-# extension class adds the character-specific columns. Migration adds
-# the matching ALTER TABLE on `persons`.
 
 
 @extension_model(PersonModel)
@@ -388,12 +428,9 @@ class RPG_PersonModel(BaseModel):
 
     The persons table becomes the character table for RPG users. Adds:
 
-    - ``kind``: pc|npc|monster|creature|vehicle|construct|... — free-form
-      so each system can extend.
-    - ``campaign_id``: FK to ``campaigns.id``; the campaign this actor
-      belongs to. NULL = unattached / cross-campaign template.
-    - ``user_id``: FK to ``users.id``; the controlling player when one
-      exists. NULL = NPC.
+    - ``kind``: pc|npc|monster|creature|vehicle|construct|... — free-form.
+    - ``campaign_id``: FK to ``campaigns.id``; NULL = unattached / template.
+    - ``user_id``: FK to ``users.id``; NULL = NPC.
     """
 
     kind: Optional[str] = Field(
@@ -424,7 +461,7 @@ class RPG_PersonModel(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# 5. Per-person joins (RPG-domain join tables; references persons.id)
+# 6. PersonTrait — per-person trait values + applied-effect attachments
 # ---------------------------------------------------------------------------
 
 
@@ -439,19 +476,51 @@ class PersonTraitModel(
     value: Optional[float] = Field(
         None,
         description=(
-            "Base magnitude (e.g. STR=16; current HP for resource Traits). "
-            "Active modifiers stack on top via PersonStatusEffect."
+            "Per-instance magnitude. For attribute traits: STR=16. For "
+            "resource traits: current HP. For status-effect applications: "
+            "the magnitude carried by this stack (e.g. -8 for a Wound). "
+            "Effective contribution to derived traits = "
+            "DerivativeTrait.value × (this value or 1.0)."
         ),
     )
     rank: Optional[int] = Field(
         None,
         description="Optional discrete rank (e.g. proficiency tier)",
     )
+    started_at: Optional[datetime] = Field(
+        None,
+        description=(
+            "Application start. NULL = persistent (durable trait). "
+            "Set for transient applications (status effects, buffs, "
+            "wounds)."
+        ),
+    )
+    expires_at: Optional[datetime] = Field(
+        None,
+        description=(
+            "Application end. NULL = persists until manually removed. "
+            "For active filtering, use ``expires_at IS NULL OR "
+            "expires_at > now()``."
+        ),
+    )
+    # Source attribution for applied effects. Manual columns since
+    # PersonModel.Reference is already used for the affected person and
+    # ItemInstance.Reference would create a cycle.
+    source_person_id: Optional[str] = Field(
+        None, description="The caster / applier (FK → persons.id)"
+    )
+    source_item_instance_id: Optional[str] = Field(
+        None,
+        description="Item consumed to apply the effect (FK → item_instances.id)",
+    )
     notes: Optional[str] = Field(None)
     table_comment: ClassVar[str] = (
-        "Per-person base trait values. Effective value = this.value + "
-        "Σ active StatusEffectTrait modifiers via PersonStatusEffect "
-        "(filtered by qualifier conditions when relevant)."
+        "Per-person trait instances. Multiple rows per (person, trait) "
+        "are allowed (e.g. several Wound stacks). Durable traits leave "
+        "started_at/expires_at NULL; transient applications fill them. "
+        "The full effective value of a derived target trait is computed "
+        "by walking DerivativeTrait edges into it from active source "
+        "Traits the person carries."
     )
 
     class Create(
@@ -461,11 +530,20 @@ class PersonTraitModel(
     ):
         value: Optional[float] = None
         rank: Optional[int] = None
+        started_at: Optional[datetime] = None
+        expires_at: Optional[datetime] = None
+        source_person_id: Optional[str] = None
+        source_item_instance_id: Optional[str] = None
         notes: Optional[str] = None
 
     class Update(BaseModel):
+        # Fully editable so GMs can retcon any aspect.
         value: Optional[float] = None
         rank: Optional[int] = None
+        started_at: Optional[datetime] = None
+        expires_at: Optional[datetime] = None
+        source_person_id: Optional[str] = None
+        source_item_instance_id: Optional[str] = None
         notes: Optional[str] = None
 
     class Search(
@@ -475,6 +553,8 @@ class PersonTraitModel(
     ):
         value: Optional[NumericalSearchModel] = None
         rank: Optional[NumericalSearchModel] = None
+        started_at: Optional[DateSearchModel] = None
+        expires_at: Optional[DateSearchModel] = None
 
 
 class PersonTraitManager(AbstractBLLManager, RouterMixin):
@@ -484,74 +564,9 @@ class PersonTraitManager(AbstractBLLManager, RouterMixin):
 PersonTraitModel.Manager = PersonTraitManager
 
 
-class PersonStatusEffectModel(
-    ApplicationModel.Optional,
-    UpdateMixinModel.Optional,
-    PersonModel.Reference.Optional,
-    StatusEffectModel.Reference.Optional,
-    metaclass=ModelMeta,
-):
-    Manager: ClassVar[Type["PersonStatusEffectManager"]] = None
-    started_at: Optional[datetime] = Field(None)
-    expires_at: Optional[datetime] = Field(
-        None,
-        description="Effect end; null = persists until manually removed",
-    )
-    # Source attribution; manual columns to avoid Reference collisions
-    # (PersonModel.Reference is already used for the affected person;
-    # ItemInstance.Reference would create a cycle).
-    source_person_id: Optional[str] = Field(
-        None, description="The caster / applier"
-    )
-    source_item_instance_id: Optional[str] = Field(
-        None, description="Item consumed to apply the effect"
-    )
-    table_comment: ClassVar[str] = (
-        "Active StatusEffect attachments per person. The effect's "
-        "per-trait modifiers come from StatusEffectTrait. Multiple "
-        "stacked effects (e.g. damage ticks) are multiple rows; the "
-        "manager may consolidate expired rows on session close."
-    )
-
-    class Create(
-        BaseModel,
-        PersonModel.Reference.ID.Optional,
-        StatusEffectModel.Reference.ID.Optional,
-    ):
-        started_at: Optional[datetime] = None
-        expires_at: Optional[datetime] = None
-        source_person_id: Optional[str] = None
-        source_item_instance_id: Optional[str] = None
-
-    class Update(BaseModel):
-        # Fully editable — GMs can retcon any aspect of an applied effect.
-        started_at: Optional[datetime] = None
-        expires_at: Optional[datetime] = None
-        source_person_id: Optional[str] = None
-        source_item_instance_id: Optional[str] = None
-
-    class Search(
-        ApplicationModel.Search,
-        PersonModel.Reference.ID.Search,
-        StatusEffectModel.Reference.ID.Search,
-    ):
-        expires_at: Optional[DateSearchModel] = None
-
-
-class PersonStatusEffectManager(AbstractBLLManager, RouterMixin):
-    _model = PersonStatusEffectModel
-
-
-PersonStatusEffectModel.Manager = PersonStatusEffectManager
-
-
 # ---------------------------------------------------------------------------
-# 6. Faction hierarchy
+# 7. Faction hierarchy
 # ---------------------------------------------------------------------------
-#
-# Faction membership is **not** a join table — it's a Relationship row
-# with kind='member_of', subject = person, target = faction (via the
-# faction_id endpoint columns injected onto RelationshipModel below).
 
 
 class FactionModel(
@@ -600,7 +615,7 @@ FactionModel.Manager = FactionManager
 
 
 # ---------------------------------------------------------------------------
-# 7. Spatial: Location / Item / ItemInstance
+# 8. Spatial: Location / Item / ItemInstance
 # ---------------------------------------------------------------------------
 
 
@@ -614,10 +629,6 @@ class LocationModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["LocationManager"]] = None
-    # Cycle-resolved manually: a satchel's interior is a Location whose
-    # container_item_instance_id points to the satchel ItemInstance, and
-    # ItemInstance.location_id points back at containing Locations. The
-    # ALTER TABLE that adds the FK lands after both tables exist.
     container_item_instance_id: Optional[str] = Field(
         None,
         description="Set when this Location represents the inside of a container item",
@@ -726,13 +737,6 @@ class ItemInstanceModel(
     metaclass=ModelMeta,
 ):
     Manager: ClassVar[Type["ItemInstanceManager"]] = None
-    # Two ownership axes, both nullable. Ownership is *assignment /
-    # responsibility*, NOT equipped-state. owner_faction_id = de jure
-    # (the Guild owns it on paper); owner_person_id = assigned-to /
-    # who-would-notice-it-missing. Equipping is spatial (location_id
-    # pointing at an equipment-slot Location bound to a person), not an
-    # ownership concern. Theft = location chain disagrees with owner_*
-    # without an intervening consensual TransactionLog.
     owner_person_id: Optional[str] = Field(
         None,
         description=(
@@ -790,11 +794,11 @@ ItemInstanceModel.Manager = ItemInstanceManager
 
 
 # ---------------------------------------------------------------------------
-# 8. Quests, Objectives, and per-person/per-faction progress
+# 9. Hooks — narrative DAG (replaces Quest+Objective)
 # ---------------------------------------------------------------------------
 
 
-class QuestModel(
+class HookModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
     NameMixinModel.Optional,
@@ -802,209 +806,218 @@ class QuestModel(
     CampaignModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["QuestManager"]] = None
-    giver_faction_id: Optional[str] = Field(
-        None, description="Faction that issued the quest"
+    Manager: ClassVar[Type["HookManager"]] = None
+    # Free-form discriminator. Conventional values: major_quest |
+    # side_quest | objective | plot_thread | mystery | rumor |
+    # obligation | foreshadowing | background | hint | ...
+    kind: Optional[str] = Field(
+        None,
+        description=(
+            "major_quest|side_quest|objective|plot_thread|mystery|"
+            "rumor|obligation|foreshadowing|... (free-form)"
+        ),
     )
-    table_comment: ClassVar[str] = "Quest template"
+    giver_faction_id: Optional[str] = Field(
+        None,
+        description="Faction that issued the hook (FK → factions.id).",
+    )
+    table_comment: ClassVar[str] = (
+        "Narrative element. Replaces Quest+Objective with a single "
+        "table; hierarchy and prerequisite relationships move to "
+        "HookDependency. Per-actor progress lives in PersonHook / "
+        "FactionHook."
+    )
 
     class Create(BaseModel, CampaignModel.Reference.ID.Optional):
         name: str = Field(...)
         description: Optional[str] = None
+        kind: Optional[str] = None
         giver_faction_id: Optional[str] = None
 
     class Update(BaseModel):
         name: Optional[str] = None
         description: Optional[str] = None
+        kind: Optional[str] = None
         giver_faction_id: Optional[str] = None
 
     class Search(ApplicationModel.Search, CampaignModel.Reference.ID.Search):
         name: Optional[StringSearchModel] = None
+        kind: Optional[StringSearchModel] = None
 
 
-class QuestManager(AbstractBLLManager, RouterMixin):
-    _model = QuestModel
+class HookManager(AbstractBLLManager, RouterMixin):
+    _model = HookModel
 
 
-QuestModel.Manager = QuestManager
+HookModel.Manager = HookManager
 
 
-class ObjectiveModel(
+class HookDependencyModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
-    NameMixinModel.Optional,
-    DescriptionMixinModel.Optional,
-    QuestModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["ObjectiveManager"]] = None
-    prerequisite_objective_id: Optional[str] = Field(
+    Manager: ClassVar[Type["HookDependencyManager"]] = None
+    # Both endpoints reference hooks.id; manual columns since
+    # HookModel.Reference would generate one hook_id and collide on the
+    # second.
+    parent_hook_id: Optional[str] = Field(
         None,
-        description="Objective that must complete first (self-FK; chains/branches)",
+        description="The prerequisite Hook (FK → hooks.id).",
     )
-    order_index: Optional[int] = Field(
-        None, description="Display/precedence ordering within the quest"
+    child_hook_id: Optional[str] = Field(
+        None,
+        description="The dependent Hook (FK → hooks.id).",
+    )
+    reason: Optional[str] = Field(
+        None,
+        description=(
+            "Free-form explanation of why the dependency exists "
+            "('requires the dragon to be slain first', "
+            "'alternative path via diplomacy', "
+            "'blocked while the curse is active'). The presence of the "
+            "row IS the dependency; reason explains it."
+        ),
     )
     table_comment: ClassVar[str] = (
-        "Objective template; chains via prerequisite_objective_id."
+        "DAG edge between two Hooks. Presence of a row IS the "
+        "dependency; the reason string explains it. No dependency-kind "
+        "enum: complete/fail/unlock/block/alternative-path semantics "
+        "are described in the reason text. Manager-layer cycle guard "
+        "rejects edits that would close a cycle."
     )
 
-    class Create(BaseModel, QuestModel.Reference.ID.Optional):
-        name: str = Field(...)
-        description: Optional[str] = None
-        prerequisite_objective_id: Optional[str] = None
-        order_index: Optional[int] = None
+    class Create(BaseModel):
+        parent_hook_id: Optional[str] = None
+        child_hook_id: Optional[str] = None
+        reason: Optional[str] = None
 
     class Update(BaseModel):
-        name: Optional[str] = None
-        description: Optional[str] = None
-        prerequisite_objective_id: Optional[str] = None
-        order_index: Optional[int] = None
+        reason: Optional[str] = None
 
-    class Search(ApplicationModel.Search, QuestModel.Reference.ID.Search):
-        name: Optional[StringSearchModel] = None
-        prerequisite_objective_id: Optional[StringSearchModel] = None
+    class Search(ApplicationModel.Search):
+        parent_hook_id: Optional[StringSearchModel] = None
+        child_hook_id: Optional[StringSearchModel] = None
+        reason: Optional[StringSearchModel] = None
 
 
-class ObjectiveManager(AbstractBLLManager, RouterMixin):
-    _model = ObjectiveModel
+class HookDependencyManager(AbstractBLLManager, RouterMixin):
+    _model = HookDependencyModel
 
 
-ObjectiveModel.Manager = ObjectiveManager
+HookDependencyModel.Manager = HookDependencyManager
 
 
-class PersonQuestModel(
+class PersonHookModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
     PersonModel.Reference.Optional,
-    QuestModel.Reference.Optional,
+    HookModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["PersonQuestManager"]] = None
+    Manager: ClassVar[Type["PersonHookManager"]] = None
     status: Optional[str] = Field(
-        None, description="available|active|completed|failed|abandoned"
+        None,
+        description=(
+            "available|active|completed|failed|abandoned|superseded|... "
+            "(free-form; non-quest Hooks may use 'unresolved' / "
+            "'resolved' instead)"
+        ),
     )
     accepted_at: Optional[datetime] = Field(None)
     completed_at: Optional[datetime] = Field(None)
-    table_comment: ClassVar[str] = "Per-person quest progress instance"
+    progress: Optional[float] = Field(
+        None,
+        description=(
+            "Numeric progress for incremental hooks (3 of 5 wolves "
+            "slain). NULL for atomic hooks."
+        ),
+    )
+    table_comment: ClassVar[str] = (
+        "Per-person hook progress. Replaces both PersonQuest and "
+        "PersonObjective."
+    )
 
     class Create(
         BaseModel,
         PersonModel.Reference.ID.Optional,
-        QuestModel.Reference.ID.Optional,
+        HookModel.Reference.ID.Optional,
     ):
         status: Optional[str] = None
         accepted_at: Optional[datetime] = None
         completed_at: Optional[datetime] = None
+        progress: Optional[float] = None
 
     class Update(BaseModel):
         status: Optional[str] = None
         accepted_at: Optional[datetime] = None
         completed_at: Optional[datetime] = None
+        progress: Optional[float] = None
 
     class Search(
         ApplicationModel.Search,
         PersonModel.Reference.ID.Search,
-        QuestModel.Reference.ID.Search,
+        HookModel.Reference.ID.Search,
     ):
         status: Optional[StringSearchModel] = None
+        progress: Optional[NumericalSearchModel] = None
 
 
-class PersonQuestManager(AbstractBLLManager, RouterMixin):
-    _model = PersonQuestModel
+class PersonHookManager(AbstractBLLManager, RouterMixin):
+    _model = PersonHookModel
 
 
-PersonQuestModel.Manager = PersonQuestManager
+PersonHookModel.Manager = PersonHookManager
 
 
-class FactionQuestModel(
+class FactionHookModel(
     ApplicationModel.Optional,
     UpdateMixinModel.Optional,
     FactionModel.Reference.Optional,
-    QuestModel.Reference.Optional,
+    HookModel.Reference.Optional,
     metaclass=ModelMeta,
 ):
-    Manager: ClassVar[Type["FactionQuestManager"]] = None
-    status: Optional[str] = Field(None, description="See PersonQuestModel.status")
+    Manager: ClassVar[Type["FactionHookManager"]] = None
+    status: Optional[str] = Field(None, description="See PersonHookModel.status")
     accepted_at: Optional[datetime] = Field(None)
     completed_at: Optional[datetime] = Field(None)
-    table_comment: ClassVar[str] = "Per-faction quest progress instance"
+    progress: Optional[float] = Field(None)
+    table_comment: ClassVar[str] = "Per-faction hook progress."
 
     class Create(
         BaseModel,
         FactionModel.Reference.ID.Optional,
-        QuestModel.Reference.ID.Optional,
+        HookModel.Reference.ID.Optional,
     ):
         status: Optional[str] = None
         accepted_at: Optional[datetime] = None
         completed_at: Optional[datetime] = None
+        progress: Optional[float] = None
 
     class Update(BaseModel):
         status: Optional[str] = None
         accepted_at: Optional[datetime] = None
         completed_at: Optional[datetime] = None
+        progress: Optional[float] = None
 
     class Search(
         ApplicationModel.Search,
         FactionModel.Reference.ID.Search,
-        QuestModel.Reference.ID.Search,
+        HookModel.Reference.ID.Search,
     ):
         status: Optional[StringSearchModel] = None
+        progress: Optional[NumericalSearchModel] = None
 
 
-class FactionQuestManager(AbstractBLLManager, RouterMixin):
-    _model = FactionQuestModel
+class FactionHookManager(AbstractBLLManager, RouterMixin):
+    _model = FactionHookModel
 
 
-FactionQuestModel.Manager = FactionQuestManager
-
-
-class PersonObjectiveModel(
-    ApplicationModel.Optional,
-    UpdateMixinModel.Optional,
-    PersonModel.Reference.Optional,
-    ObjectiveModel.Reference.Optional,
-    metaclass=ModelMeta,
-):
-    Manager: ClassVar[Type["PersonObjectiveManager"]] = None
-    status: Optional[str] = Field(None)
-    progress: Optional[float] = Field(
-        None, description="Numeric progress (e.g. 3 of 5 wolves slain)"
-    )
-    completed_at: Optional[datetime] = Field(None)
-    table_comment: ClassVar[str] = "Per-person objective progress instance"
-
-    class Create(
-        BaseModel,
-        PersonModel.Reference.ID.Optional,
-        ObjectiveModel.Reference.ID.Optional,
-    ):
-        status: Optional[str] = None
-        progress: Optional[float] = None
-        completed_at: Optional[datetime] = None
-
-    class Update(BaseModel):
-        status: Optional[str] = None
-        progress: Optional[float] = None
-        completed_at: Optional[datetime] = None
-
-    class Search(
-        ApplicationModel.Search,
-        PersonModel.Reference.ID.Search,
-        ObjectiveModel.Reference.ID.Search,
-    ):
-        status: Optional[StringSearchModel] = None
-
-
-class PersonObjectiveManager(AbstractBLLManager, RouterMixin):
-    _model = PersonObjectiveModel
-
-
-PersonObjectiveModel.Manager = PersonObjectiveManager
+FactionHookModel.Manager = FactionHookManager
 
 
 # ---------------------------------------------------------------------------
-# 9. Inject Faction endpoints onto genealogy.RelationshipModel
+# 10. Inject Faction endpoints onto genealogy.RelationshipModel
 # ---------------------------------------------------------------------------
 
 
@@ -1061,19 +1074,16 @@ ALL_MODELS: List[type] = [
     GameSystemModel,
     CampaignModel,
     TraitModel,
-    StatusEffectModel,
-    StatusEffectTraitModel,
+    DerivativeTraitModel,
     PersonTraitModel,
-    PersonStatusEffectModel,
     FactionModel,
     LocationModel,
     ItemModel,
     ItemInstanceModel,
-    QuestModel,
-    ObjectiveModel,
-    PersonQuestModel,
-    FactionQuestModel,
-    PersonObjectiveModel,
+    HookModel,
+    HookDependencyModel,
+    PersonHookModel,
+    FactionHookModel,
 ]
 
 
@@ -1084,15 +1094,11 @@ __all__ = [
     "CampaignManager",
     "TraitModel",
     "TraitManager",
-    "StatusEffectModel",
-    "StatusEffectManager",
-    "StatusEffectTraitModel",
-    "StatusEffectTraitManager",
+    "DerivativeTraitModel",
+    "DerivativeTraitManager",
     "RPG_PersonModel",
     "PersonTraitModel",
     "PersonTraitManager",
-    "PersonStatusEffectModel",
-    "PersonStatusEffectManager",
     "FactionModel",
     "FactionManager",
     "LocationModel",
@@ -1101,16 +1107,14 @@ __all__ = [
     "ItemManager",
     "ItemInstanceModel",
     "ItemInstanceManager",
-    "QuestModel",
-    "QuestManager",
-    "ObjectiveModel",
-    "ObjectiveManager",
-    "PersonQuestModel",
-    "PersonQuestManager",
-    "FactionQuestModel",
-    "FactionQuestManager",
-    "PersonObjectiveModel",
-    "PersonObjectiveManager",
+    "HookModel",
+    "HookManager",
+    "HookDependencyModel",
+    "HookDependencyManager",
+    "PersonHookModel",
+    "PersonHookManager",
+    "FactionHookModel",
+    "FactionHookManager",
     "RPG_RelationshipModel",
     "ALL_MODELS",
 ]

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
@@ -1,8 +1,10 @@
 """Structural tests for the rpg_state extension's BLL surface.
 
-Cover model wiring (Manager↔_model linkage), the unified-trait
-calculation contract, ItemInstance ownership semantics, and the
-genealogy injection points (RPG_PersonModel, RPG_RelationshipModel).
+Covers the unified Trait model (StatusEffect folded into Trait;
+DerivativeTrait edges replace StatusEffectTrait), the Hook DAG
+(Quest+Objective folded into Hook; HookDependency carries the edges),
+ItemInstance ownership semantics, and the genealogy injection points
+(RPG_PersonModel, RPG_RelationshipModel).
 """
 
 import os
@@ -14,36 +16,30 @@ from serverframework.extensions.rpg_state.BLL_RPGState import (
     ALL_MODELS,
     CampaignManager,
     CampaignModel,
+    DerivativeTraitManager,
+    DerivativeTraitModel,
+    FactionHookManager,
+    FactionHookModel,
     FactionManager,
     FactionModel,
-    FactionQuestManager,
-    FactionQuestModel,
     GameSystemManager,
     GameSystemModel,
+    HookDependencyManager,
+    HookDependencyModel,
+    HookManager,
+    HookModel,
     ItemInstanceManager,
     ItemInstanceModel,
     ItemManager,
     ItemModel,
     LocationManager,
     LocationModel,
-    ObjectiveManager,
-    ObjectiveModel,
-    PersonObjectiveManager,
-    PersonObjectiveModel,
-    PersonQuestManager,
-    PersonQuestModel,
-    PersonStatusEffectManager,
-    PersonStatusEffectModel,
+    PersonHookManager,
+    PersonHookModel,
     PersonTraitManager,
     PersonTraitModel,
-    QuestManager,
-    QuestModel,
     RPG_PersonModel,
     RPG_RelationshipModel,
-    StatusEffectManager,
-    StatusEffectModel,
-    StatusEffectTraitManager,
-    StatusEffectTraitModel,
     TraitManager,
     TraitModel,
 )
@@ -56,19 +52,16 @@ class TestModelManagerWiring:
         (GameSystemModel, GameSystemManager),
         (CampaignModel, CampaignManager),
         (TraitModel, TraitManager),
-        (StatusEffectModel, StatusEffectManager),
-        (StatusEffectTraitModel, StatusEffectTraitManager),
+        (DerivativeTraitModel, DerivativeTraitManager),
         (PersonTraitModel, PersonTraitManager),
-        (PersonStatusEffectModel, PersonStatusEffectManager),
         (FactionModel, FactionManager),
         (LocationModel, LocationManager),
         (ItemModel, ItemManager),
         (ItemInstanceModel, ItemInstanceManager),
-        (QuestModel, QuestManager),
-        (ObjectiveModel, ObjectiveManager),
-        (PersonQuestModel, PersonQuestManager),
-        (FactionQuestModel, FactionQuestManager),
-        (PersonObjectiveModel, PersonObjectiveManager),
+        (HookModel, HookManager),
+        (HookDependencyModel, HookDependencyManager),
+        (PersonHookModel, PersonHookManager),
+        (FactionHookModel, FactionHookManager),
     ]
 
     def test_each_model_has_its_manager(self):
@@ -83,8 +76,6 @@ class TestModelManagerWiring:
 
 
 class TestCreateUpdateSearchPresent:
-    """Every model exposes Create / Update / Search nested classes."""
-
     def test_nested_classes_exist(self):
         for model in ALL_MODELS:
             assert hasattr(model, "Create"), f"{model.__name__} missing Create"
@@ -93,14 +84,9 @@ class TestCreateUpdateSearchPresent:
 
 
 class TestPersonInjectionContract:
-    """RPG_PersonModel injects character-specific fields onto
-    genealogy.PersonModel. No CharacterModel exists in rpg_state."""
-
     def test_rpg_person_carries_character_fields(self):
         rp = RPG_PersonModel(
-            kind="pc",
-            campaign_id="c1",
-            user_id="user-1",
+            kind="pc", campaign_id="c1", user_id="user-1"
         )
         assert rp.kind == "pc"
         assert rp.campaign_id == "c1"
@@ -119,10 +105,6 @@ class TestPersonInjectionContract:
 
 
 class TestRelationshipFactionInjection:
-    """RPG_RelationshipModel adds faction_id and target_faction_id
-    so the relationships table holds Person↔Faction and Faction↔Faction
-    edges. The endpoint-XOR CHECK is enforced by the migration."""
-
     def test_subject_faction_endpoint(self):
         rr = RPG_RelationshipModel(faction_id="f-guild")
         assert rr.faction_id == "f-guild"
@@ -134,87 +116,177 @@ class TestRelationshipFactionInjection:
 
     def test_both_faction_endpoints(self):
         rr = RPG_RelationshipModel(
-            faction_id="f-guild",
-            target_faction_id="f-thieves",
+            faction_id="f-guild", target_faction_id="f-thieves"
         )
         assert rr.faction_id == "f-guild"
         assert rr.target_faction_id == "f-thieves"
 
 
 class TestUnifiedTraitContract:
-    """STR=16 lives on PersonTrait.value. +2 from Bull's Strength lives
-    on StatusEffectTrait(operation='additive', value=2.0). Damage uses
-    negative values (HealthDamage = StatusEffectTrait(value=-8) against
-    a HealthMax resource Trait)."""
+    """StatusEffect is folded into Trait via kind='status_effect'.
+    No separate StatusEffectModel exists."""
 
-    def test_person_trait_carries_value(self):
-        pt = PersonTraitModel.Create(value=16.0)
-        assert pt.value == 16.0
+    def test_no_status_effect_model(self):
+        from serverframework.extensions.rpg_state import BLL_RPGState
 
-    def test_status_effect_trait_carries_modifier(self):
-        set_row = StatusEffectTraitModel.Create(
+        assert not hasattr(BLL_RPGState, "StatusEffectModel")
+        assert not hasattr(BLL_RPGState, "StatusEffectTraitModel")
+        assert not hasattr(BLL_RPGState, "PersonStatusEffectModel")
+
+    def test_status_effect_is_a_trait_kind(self):
+        bs = TraitModel.Create(
+            name="Bull's Strength",
+            kind="status_effect",
+            default_duration_seconds=600,
+        )
+        assert bs.kind == "status_effect"
+        assert bs.default_duration_seconds == 600
+
+    def test_attribute_trait_has_no_duration(self):
+        # default_duration_seconds is meaningful only for status_effect.
+        str_attr = TraitModel.Create(name="STR", kind="attribute")
+        assert str_attr.default_duration_seconds is None
+
+
+class TestDerivativeTraitContract:
+    """DerivativeTrait carries operation, value, order_index,
+    stacking_group, qualifier. source_trait_id NULL = constant."""
+
+    def test_static_buff_via_derivative(self):
+        # Bull's Strength → STR, +2 always.
+        d = DerivativeTraitModel.Create(
+            source_trait_id="bulls-strength",
+            target_trait_id="str",
             operation="additive",
             value=2.0,
         )
-        assert set_row.operation == "additive"
-        assert set_row.value == 2.0
+        assert d.source_trait_id == "bulls-strength"
+        assert d.target_trait_id == "str"
+        assert d.operation == "additive"
+        assert d.value == 2.0
 
-    def test_status_effect_trait_supports_damage(self):
-        # HealthDamage convention: negative value against resource Trait.
-        damage = StatusEffectTraitModel.Create(
+    def test_constant_contribution_with_null_source(self):
+        # Initiative = DEX + 5 — the +5 is a constant edge.
+        d = DerivativeTraitModel.Create(
+            source_trait_id=None,
+            target_trait_id="initiative",
             operation="additive",
-            value=-8.0,
+            value=5.0,
         )
-        assert damage.value == -8.0
+        assert d.source_trait_id is None
+        assert d.value == 5.0
 
-    def test_qualifier_field_present(self):
-        # qualifier is conditional context: NULL = always; non-NULL = toggleable.
-        cond = StatusEffectTraitModel.Create(
+    def test_signed_value_for_damage(self):
+        # Wound → HealthMax, value=-1 multiplier; PersonTrait.value
+        # carries the damage magnitude. Or use static -8 here.
+        d = DerivativeTraitModel.Create(
+            source_trait_id="wound",
+            target_trait_id="health-max",
+            operation="additive",
+            value=-1.0,
+        )
+        assert d.value == -1.0
+
+    def test_phase_via_operation_and_order_index(self):
+        d = DerivativeTraitModel.Create(
+            source_trait_id="haste",
+            target_trait_id="speed",
+            operation="multiplicative",
+            value=2.0,
+            order_index=1,
+        )
+        assert d.operation == "multiplicative"
+        assert d.order_index == 1
+
+    def test_stacking_group(self):
+        d = DerivativeTraitModel.Create(
+            source_trait_id="ring-of-protection",
+            target_trait_id="ac",
+            operation="additive",
+            value=1.0,
+            stacking_group="deflection_bonus",
+        )
+        assert d.stacking_group == "deflection_bonus"
+
+    def test_qualifier_for_conditional(self):
+        d = DerivativeTraitModel.Create(
+            source_trait_id="orcbane",
+            target_trait_id="attack-bonus",
             operation="additive",
             value=2.0,
             qualifier="vs orcs",
         )
-        assert cond.qualifier == "vs orcs"
-        unconditional = StatusEffectTraitModel.Create(
-            operation="additive", value=1.0
-        )
-        assert unconditional.qualifier is None
+        assert d.qualifier == "vs orcs"
 
-    def test_person_status_effect_links_subject_to_template(self):
-        pse = PersonStatusEffectModel.Create(
-            person_id="char-1",
-            status_effect_id="effect-1",
-            source_person_id="char-2",  # caster
+    def test_clamp_operation_supported(self):
+        d = DerivativeTraitModel.Create(
+            source_trait_id=None,
+            target_trait_id="hp-current",
+            operation="clamp",
+            value=0.0,  # 0 = lower bound by convention
         )
-        assert pse.person_id == "char-1"
-        assert pse.status_effect_id == "effect-1"
-        assert pse.source_person_id == "char-2"
+        assert d.operation == "clamp"
 
-    def test_person_status_effect_fully_editable(self):
-        # GMs can retcon any aspect of an applied effect.
-        upd = PersonStatusEffectModel.Update(
+
+class TestPersonTraitFoldsStatusEffect:
+    """PersonTrait carries both durable trait values and applied-effect
+    attachments. Status effects are PersonTrait rows with started_at /
+    expires_at / source_* set; durable traits leave them NULL."""
+
+    def test_durable_attribute(self):
+        pt = PersonTraitModel.Create(
+            person_id="bob", trait_id="str", value=16.0
+        )
+        assert pt.value == 16.0
+        assert pt.started_at is None
+        assert pt.expires_at is None
+
+    def test_applied_status_effect(self):
+        from datetime import datetime
+
+        pt = PersonTraitModel.Create(
+            person_id="bob",
+            trait_id="bulls-strength",
+            started_at=datetime(2026, 1, 1, 12, 0),
+            expires_at=datetime(2026, 1, 1, 12, 10),
+            source_person_id="wizard",
+            source_item_instance_id="ii-potion",
+        )
+        assert pt.source_person_id == "wizard"
+        assert pt.source_item_instance_id == "ii-potion"
+
+    def test_wound_carries_damage_magnitude_on_value(self):
+        pt = PersonTraitModel.Create(
+            person_id="bob",
+            trait_id="wound",
+            value=-8.0,
+            source_person_id="orc",
+        )
+        assert pt.value == -8.0
+        assert pt.source_person_id == "orc"
+
+    def test_person_trait_fully_editable(self):
+        from datetime import datetime
+
+        u = PersonTraitModel.Update(
+            value=20.0,
+            expires_at=datetime(2026, 1, 1, 13, 0),
             source_person_id="caster-X",
             source_item_instance_id="ii-Y",
         )
-        assert upd.source_person_id == "caster-X"
-        assert upd.source_item_instance_id == "ii-Y"
+        assert u.value == 20.0
+        assert u.source_person_id == "caster-X"
 
 
 class TestItemOwnershipSemantics:
-    """De jure (faction) and assignment (person) ownership are
-    independent; both nullable, no XOR. Ownership ≠ equipped."""
-
     def test_neither_owner_set(self):
         ii = ItemInstanceModel.Create(quantity=1)
         assert ii.owner_person_id is None
         assert ii.owner_faction_id is None
 
     def test_both_owners_set(self):
-        # Legal: Guild owns it (faction), Bob is responsible (person).
         ii = ItemInstanceModel.Create(
-            owner_person_id="bob",
-            owner_faction_id="guild",
-            quantity=1,
+            owner_person_id="bob", owner_faction_id="guild", quantity=1
         )
         assert ii.owner_person_id == "bob"
         assert ii.owner_faction_id == "guild"
@@ -229,12 +301,11 @@ class TestItemOwnershipSemantics:
 
 
 class TestSpatialContainers:
-    """Locations are recursive and can represent the inside of a
-    container item or a person's equipment slot."""
-
     def test_nested_locations(self):
         outer = LocationModel.Create(name="Tavern")
-        inner = LocationModel.Create(name="Tavern → Cellar", parent_id="outer-id")
+        inner = LocationModel.Create(
+            name="Tavern → Cellar", parent_id="outer-id"
+        )
         assert inner.parent_id == "outer-id"
         assert outer.parent_id is None
 
@@ -255,26 +326,74 @@ class TestSpatialContainers:
         assert loc.associated_person_id == "bob"
 
 
-class TestQuestObjectiveChaining:
-    def test_objective_prerequisite(self):
-        obj = ObjectiveModel.Create(
-            name="Slay the dragon",
-            quest_id="q1",
-            prerequisite_objective_id="o-find-dragon",
-            order_index=2,
-        )
-        assert obj.prerequisite_objective_id == "o-find-dragon"
-        assert obj.order_index == 2
+class TestHookDAG:
+    """Quest+Objective fold into Hook with a kind discriminator. The
+    DAG of dependencies lives in HookDependency; presence of a row IS
+    the dependency, the reason string explains it."""
 
-    def test_quest_dual_assignment(self):
-        pq = PersonQuestModel.Create(
-            person_id="c1", quest_id="q1", status="active"
+    def test_no_quest_or_objective_models(self):
+        from serverframework.extensions.rpg_state import BLL_RPGState
+
+        assert not hasattr(BLL_RPGState, "QuestModel")
+        assert not hasattr(BLL_RPGState, "ObjectiveModel")
+        assert not hasattr(BLL_RPGState, "PersonQuestModel")
+        assert not hasattr(BLL_RPGState, "PersonObjectiveModel")
+        assert not hasattr(BLL_RPGState, "FactionQuestModel")
+
+    def test_hook_is_kind_discriminated(self):
+        major = HookModel.Create(
+            name="Slay the dragon",
+            kind="major_quest",
+            campaign_id="c1",
+            giver_faction_id="f-king",
         )
-        fq = FactionQuestModel.Create(
-            faction_id="f1", quest_id="q1", status="active"
+        thread = HookModel.Create(
+            name="The cursed amulet rumor",
+            kind="rumor",
+            campaign_id="c1",
         )
-        assert pq.status == "active"
-        assert fq.status == "active"
+        assert major.kind == "major_quest"
+        assert thread.kind == "rumor"
+
+    def test_dependency_is_presence_plus_reason(self):
+        d = HookDependencyModel.Create(
+            parent_hook_id="hook-find-dragon",
+            child_hook_id="hook-slay-dragon",
+            reason="must locate the dragon's lair before the assault",
+        )
+        assert d.parent_hook_id == "hook-find-dragon"
+        assert d.child_hook_id == "hook-slay-dragon"
+        assert "lair" in d.reason
+
+    def test_no_dependency_kind_enum(self):
+        # The HookDependency model has no `kind` or `dependency_kind`
+        # field — presence of the row IS the dependency, period.
+        for cls in (
+            HookDependencyModel.Create,
+            HookDependencyModel.Update,
+        ):
+            assert "kind" not in cls.model_fields
+            assert "dependency_kind" not in cls.model_fields
+
+    def test_person_hook_progress(self):
+        ph = PersonHookModel.Create(
+            person_id="bob",
+            hook_id="hook-slay-wolves",
+            status="active",
+            progress=3.0,  # 3 of 5 wolves slain
+        )
+        assert ph.status == "active"
+        assert ph.progress == 3.0
+
+    def test_faction_hook_progress(self):
+        fh = FactionHookModel.Create(
+            faction_id="f-guild",
+            hook_id="hook-recover-relic",
+            status="active",
+            progress=0.5,
+        )
+        assert fh.status == "active"
+        assert fh.progress == 0.5
 
 
 class TestFactionHierarchy:
@@ -283,7 +402,6 @@ class TestFactionHierarchy:
         assert party.parent_id == "guild-id"
 
     def test_no_character_factions_table(self):
-        # Membership is in relationships(kind='member_of'), not its own table.
         from serverframework.extensions.rpg_state import BLL_RPGState
 
         assert not hasattr(BLL_RPGState, "CharacterFactionModel")

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
@@ -1,9 +1,8 @@
 """Structural tests for the rpg_state extension's BLL surface.
 
-These cover model wiring (Manager↔_model linkage), the unified-trait
-calculation contract, and the ItemInstance ownership semantics. They do
-not exercise the database; integration coverage will be added once the
-extension is wired into the test app fixture.
+Cover model wiring (Manager↔_model linkage), the unified-trait
+calculation contract, ItemInstance ownership semantics, and the
+genealogy injection points (RPG_PersonModel, RPG_RelationshipModel).
 """
 
 import os
@@ -15,18 +14,6 @@ from serverframework.extensions.rpg_state.BLL_RPGState import (
     ALL_MODELS,
     CampaignManager,
     CampaignModel,
-    CharacterFactionManager,
-    CharacterFactionModel,
-    CharacterManager,
-    CharacterModel,
-    CharacterObjectiveManager,
-    CharacterObjectiveModel,
-    CharacterQuestManager,
-    CharacterQuestModel,
-    CharacterStatusEffectManager,
-    CharacterStatusEffectModel,
-    CharacterTraitManager,
-    CharacterTraitModel,
     FactionManager,
     FactionModel,
     FactionQuestManager,
@@ -41,8 +28,18 @@ from serverframework.extensions.rpg_state.BLL_RPGState import (
     LocationModel,
     ObjectiveManager,
     ObjectiveModel,
+    PersonObjectiveManager,
+    PersonObjectiveModel,
+    PersonQuestManager,
+    PersonQuestModel,
+    PersonStatusEffectManager,
+    PersonStatusEffectModel,
+    PersonTraitManager,
+    PersonTraitModel,
     QuestManager,
     QuestModel,
+    RPG_PersonModel,
+    RPG_RelationshipModel,
     StatusEffectManager,
     StatusEffectModel,
     StatusEffectTraitManager,
@@ -53,7 +50,7 @@ from serverframework.extensions.rpg_state.BLL_RPGState import (
 
 
 class TestModelManagerWiring:
-    """Every model must point to its Manager and vice versa."""
+    """Every owned model must point to its Manager and vice versa."""
 
     PAIRS = [
         (GameSystemModel, GameSystemManager),
@@ -61,19 +58,17 @@ class TestModelManagerWiring:
         (TraitModel, TraitManager),
         (StatusEffectModel, StatusEffectManager),
         (StatusEffectTraitModel, StatusEffectTraitManager),
-        (CharacterModel, CharacterManager),
-        (CharacterTraitModel, CharacterTraitManager),
-        (CharacterStatusEffectModel, CharacterStatusEffectManager),
+        (PersonTraitModel, PersonTraitManager),
+        (PersonStatusEffectModel, PersonStatusEffectManager),
         (FactionModel, FactionManager),
-        (CharacterFactionModel, CharacterFactionManager),
         (LocationModel, LocationManager),
         (ItemModel, ItemManager),
         (ItemInstanceModel, ItemInstanceManager),
         (QuestModel, QuestManager),
         (ObjectiveModel, ObjectiveManager),
-        (CharacterQuestModel, CharacterQuestManager),
+        (PersonQuestModel, PersonQuestManager),
         (FactionQuestModel, FactionQuestManager),
-        (CharacterObjectiveModel, CharacterObjectiveManager),
+        (PersonObjectiveModel, PersonObjectiveManager),
     ]
 
     def test_each_model_has_its_manager(self):
@@ -97,14 +92,64 @@ class TestCreateUpdateSearchPresent:
             assert hasattr(model, "Search"), f"{model.__name__} missing Search"
 
 
-class TestUnifiedTraitContract:
-    """STR=16 lives on CharacterTrait.value. +2 from Bull's Strength lives
-    on StatusEffectTrait(operation='additive', value=2.0)."""
+class TestPersonInjectionContract:
+    """RPG_PersonModel injects character-specific fields onto
+    genealogy.PersonModel. No CharacterModel exists in rpg_state."""
 
-    def test_character_trait_carries_value(self):
-        # Pydantic accepts the field; type is float-compatible.
-        ct = CharacterTraitModel.Create(value=16.0)
-        assert ct.value == 16.0
+    def test_rpg_person_carries_character_fields(self):
+        rp = RPG_PersonModel(
+            kind="pc",
+            campaign_id="c1",
+            user_id="user-1",
+        )
+        assert rp.kind == "pc"
+        assert rp.campaign_id == "c1"
+        assert rp.user_id == "user-1"
+
+    def test_npc_leaves_user_id_null(self):
+        rp = RPG_PersonModel(kind="npc", campaign_id="c1")
+        assert rp.user_id is None
+
+    def test_no_character_model_in_rpg_state(self):
+        from serverframework.extensions.rpg_state import BLL_RPGState
+
+        assert not hasattr(BLL_RPGState, "CharacterModel")
+        assert not hasattr(BLL_RPGState, "CharacterTraitModel")
+        assert not hasattr(BLL_RPGState, "CharacterFactionModel")
+
+
+class TestRelationshipFactionInjection:
+    """RPG_RelationshipModel adds faction_id and target_faction_id
+    so the relationships table holds Person↔Faction and Faction↔Faction
+    edges. The endpoint-XOR CHECK is enforced by the migration."""
+
+    def test_subject_faction_endpoint(self):
+        rr = RPG_RelationshipModel(faction_id="f-guild")
+        assert rr.faction_id == "f-guild"
+        assert rr.target_faction_id is None
+
+    def test_target_faction_endpoint(self):
+        rr = RPG_RelationshipModel(target_faction_id="f-thieves")
+        assert rr.target_faction_id == "f-thieves"
+
+    def test_both_faction_endpoints(self):
+        rr = RPG_RelationshipModel(
+            faction_id="f-guild",
+            target_faction_id="f-thieves",
+        )
+        assert rr.faction_id == "f-guild"
+        assert rr.target_faction_id == "f-thieves"
+
+
+class TestUnifiedTraitContract:
+    """STR=16 lives on PersonTrait.value. +2 from Bull's Strength lives
+    on StatusEffectTrait(operation='additive', value=2.0). Damage uses
+    negative values (HealthDamage = StatusEffectTrait(value=-8) against
+    a HealthMax resource Trait)."""
+
+    def test_person_trait_carries_value(self):
+        pt = PersonTraitModel.Create(value=16.0)
+        assert pt.value == 16.0
 
     def test_status_effect_trait_carries_modifier(self):
         set_row = StatusEffectTraitModel.Create(
@@ -114,64 +159,78 @@ class TestUnifiedTraitContract:
         assert set_row.operation == "additive"
         assert set_row.value == 2.0
 
-    def test_character_status_effect_links_subject_to_template(self):
-        # The character's instance row references both the affected
-        # character and the StatusEffect template; modifiers come from
-        # StatusEffectTrait, not duplicated here.
-        cse = CharacterStatusEffectModel.Create(
-            character_id="char-1",
-            status_effect_id="effect-1",
-            source_character_id="char-2",  # caster
+    def test_status_effect_trait_supports_damage(self):
+        # HealthDamage convention: negative value against resource Trait.
+        damage = StatusEffectTraitModel.Create(
+            operation="additive",
+            value=-8.0,
         )
-        assert cse.character_id == "char-1"
-        assert cse.status_effect_id == "effect-1"
-        assert cse.source_character_id == "char-2"
+        assert damage.value == -8.0
+
+    def test_qualifier_field_present(self):
+        # qualifier is conditional context: NULL = always; non-NULL = toggleable.
+        cond = StatusEffectTraitModel.Create(
+            operation="additive",
+            value=2.0,
+            qualifier="vs orcs",
+        )
+        assert cond.qualifier == "vs orcs"
+        unconditional = StatusEffectTraitModel.Create(
+            operation="additive", value=1.0
+        )
+        assert unconditional.qualifier is None
+
+    def test_person_status_effect_links_subject_to_template(self):
+        pse = PersonStatusEffectModel.Create(
+            person_id="char-1",
+            status_effect_id="effect-1",
+            source_person_id="char-2",  # caster
+        )
+        assert pse.person_id == "char-1"
+        assert pse.status_effect_id == "effect-1"
+        assert pse.source_person_id == "char-2"
+
+    def test_person_status_effect_fully_editable(self):
+        # GMs can retcon any aspect of an applied effect.
+        upd = PersonStatusEffectModel.Update(
+            source_person_id="caster-X",
+            source_item_instance_id="ii-Y",
+        )
+        assert upd.source_person_id == "caster-X"
+        assert upd.source_item_instance_id == "ii-Y"
 
 
 class TestItemOwnershipSemantics:
-    """De jure (faction) and de facto (character) ownership are
-    independent; both nullable, no XOR."""
+    """De jure (faction) and assignment (person) ownership are
+    independent; both nullable, no XOR. Ownership ≠ equipped."""
 
     def test_neither_owner_set(self):
-        # Wild loot: lying on a dungeon floor, no claim.
         ii = ItemInstanceModel.Create(quantity=1)
-        assert ii.owner_character_id is None
+        assert ii.owner_person_id is None
         assert ii.owner_faction_id is None
 
     def test_both_owners_set(self):
-        # Legal: Guild owns it (faction), Bob carries it (character).
+        # Legal: Guild owns it (faction), Bob is responsible (person).
         ii = ItemInstanceModel.Create(
-            owner_character_id="bob",
+            owner_person_id="bob",
             owner_faction_id="guild",
             quantity=1,
         )
-        assert ii.owner_character_id == "bob"
+        assert ii.owner_person_id == "bob"
         assert ii.owner_faction_id == "guild"
 
-    def test_character_only_set(self):
-        ii = ItemInstanceModel.Create(owner_character_id="bob", quantity=1)
+    def test_person_only_set(self):
+        ii = ItemInstanceModel.Create(owner_person_id="bob", quantity=1)
         assert ii.owner_faction_id is None
 
     def test_faction_only_set(self):
         ii = ItemInstanceModel.Create(owner_faction_id="guild", quantity=1)
-        assert ii.owner_character_id is None
-
-
-class TestCharacterPlayerLink:
-    """user_id on Character is the controlling player; null for NPCs."""
-
-    def test_pc_has_user_id(self):
-        c = CharacterModel.Create(name="Pip", kind="pc", user_id="user-1")
-        assert c.user_id == "user-1"
-
-    def test_npc_leaves_user_id_null(self):
-        c = CharacterModel.Create(name="Innkeeper", kind="npc")
-        assert c.user_id is None
+        assert ii.owner_person_id is None
 
 
 class TestSpatialContainers:
     """Locations are recursive and can represent the inside of a
-    container item or a character's equipment slot."""
+    container item or a person's equipment slot."""
 
     def test_nested_locations(self):
         outer = LocationModel.Create(name="Tavern")
@@ -180,7 +239,6 @@ class TestSpatialContainers:
         assert outer.parent_id is None
 
     def test_container_item_instance(self):
-        # The interior of a satchel.
         loc = LocationModel.Create(
             name="Inside the Satchel",
             container_item_instance_id="ii-satchel",
@@ -188,13 +246,13 @@ class TestSpatialContainers:
         )
         assert loc.container_item_instance_id == "ii-satchel"
 
-    def test_equipment_slot_bound_to_character(self):
+    def test_equipment_slot_bound_to_person(self):
         loc = LocationModel.Create(
             name="Bob's Left Hand",
-            associated_character_id="bob",
+            associated_person_id="bob",
             kind="equipment_slot",
         )
-        assert loc.associated_character_id == "bob"
+        assert loc.associated_person_id == "bob"
 
 
 class TestQuestObjectiveChaining:
@@ -209,18 +267,24 @@ class TestQuestObjectiveChaining:
         assert obj.order_index == 2
 
     def test_quest_dual_assignment(self):
-        cq = CharacterQuestModel.Create(
-            character_id="c1", quest_id="q1", status="active"
+        pq = PersonQuestModel.Create(
+            person_id="c1", quest_id="q1", status="active"
         )
         fq = FactionQuestModel.Create(
             faction_id="f1", quest_id="q1", status="active"
         )
-        assert cq.status == "active"
+        assert pq.status == "active"
         assert fq.status == "active"
 
 
 class TestFactionHierarchy:
     def test_subfactions_via_parent_id(self):
-        # A party = sub-faction of a guild.
         party = FactionModel.Create(name="Tavern Crew", parent_id="guild-id")
         assert party.parent_id == "guild-id"
+
+    def test_no_character_factions_table(self):
+        # Membership is in relationships(kind='member_of'), not its own table.
+        from serverframework.extensions.rpg_state import BLL_RPGState
+
+        assert not hasattr(BLL_RPGState, "CharacterFactionModel")
+        assert not hasattr(BLL_RPGState, "PersonFactionModel")

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
@@ -9,6 +9,8 @@ ItemInstance ownership semantics, and the genealogy injection points
 
 import os
 
+import pytest
+
 os.environ.setdefault("JWT_SECRET", "x" * 32)
 os.environ.setdefault("PYTEST_CURRENT_TEST", "rpg_state_test")
 
@@ -86,15 +88,26 @@ class TestCreateUpdateSearchPresent:
 class TestPersonInjectionContract:
     def test_rpg_person_carries_character_fields(self):
         rp = RPG_PersonModel(
-            kind="pc", campaign_id="c1", user_id="user-1"
+            kind="pc",
+            campaign_id="c1",
+            user_id="user-1",
+            location_id="loc-tavern",
         )
         assert rp.kind == "pc"
         assert rp.campaign_id == "c1"
         assert rp.user_id == "user-1"
+        assert rp.location_id == "loc-tavern"
 
     def test_npc_leaves_user_id_null(self):
         rp = RPG_PersonModel(kind="npc", campaign_id="c1")
         assert rp.user_id is None
+
+    def test_person_location_separate_from_body_part_locations(self):
+        # Person.location_id is the scene/region location;
+        # body parts are sub-Locations whose
+        # associated_person_id = person.id (NOT person.location_id).
+        rp = RPG_PersonModel(location_id="loc-clearing")
+        assert rp.location_id == "loc-clearing"
 
     def test_no_character_model_in_rpg_state(self):
         from serverframework.extensions.rpg_state import BLL_RPGState
@@ -150,7 +163,8 @@ class TestUnifiedTraitContract:
 
 class TestDerivativeTraitContract:
     """DerivativeTrait carries operation, value, order_index,
-    stacking_group, qualifier. source_trait_id NULL = constant."""
+    stacking_group, qualifier. source_trait_id NULL = constant.
+    operation is locked to a closed enum at the Pydantic layer."""
 
     def test_static_buff_via_derivative(self):
         # Bull's Strength → STR, +2 always.
@@ -164,6 +178,17 @@ class TestDerivativeTraitContract:
         assert d.target_trait_id == "str"
         assert d.operation == "additive"
         assert d.value == 2.0
+
+    def test_operation_rejects_unknown_value(self):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            DerivativeTraitModel.Create(
+                source_trait_id="x",
+                target_trait_id="y",
+                operation="not-a-real-op",
+                value=1.0,
+            )
 
     def test_constant_contribution_with_null_source(self):
         # Initiative = DEX + 5 — the +5 is a constant edge.
@@ -265,6 +290,26 @@ class TestPersonTraitFoldsStatusEffect:
         assert pt.value == -8.0
         assert pt.source_person_id == "orc"
 
+    def test_target_location_localises_damage_to_body_part(self):
+        # Bob takes 8 damage to his left arm (a body-part Location
+        # under his body-root Location, associated_person_id=Bob).
+        pt = PersonTraitModel.Create(
+            person_id="bob",
+            trait_id="wound",
+            value=-8.0,
+            target_location_id="loc-bob-left-arm",
+            source_person_id="orc",
+        )
+        assert pt.target_location_id == "loc-bob-left-arm"
+
+    def test_target_location_optional_for_full_body_buffs(self):
+        # Bull's Strength is whole-body — target_location_id stays NULL.
+        pt = PersonTraitModel.Create(
+            person_id="bob",
+            trait_id="bulls-strength",
+        )
+        assert pt.target_location_id is None
+
     def test_person_trait_fully_editable(self):
         from datetime import datetime
 
@@ -355,6 +400,13 @@ class TestHookDAG:
         assert major.kind == "major_quest"
         assert thread.kind == "rumor"
 
+    def test_hook_kind_rejects_unknown_value(self):
+        # kind is locked to the closed HookKind Literal.
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            HookModel.Create(name="X", kind="invented_kind")
+
     def test_dependency_is_presence_plus_reason(self):
         d = HookDependencyModel.Create(
             parent_hook_id="hook-find-dragon",
@@ -406,3 +458,34 @@ class TestFactionHierarchy:
 
         assert not hasattr(BLL_RPGState, "CharacterFactionModel")
         assert not hasattr(BLL_RPGState, "PersonFactionModel")
+
+
+class TestCycleGuardHooksRegistered:
+    """The cycle-guard hooks for FactionManager, LocationManager, and
+    HookDependencyManager are registered at import time. The full DB
+    integration is exercised under the test-app fixture; here we just
+    confirm the hook functions exist on the module so the registration
+    succeeded."""
+
+    def test_cycle_guard_hook_callables_present(self):
+        from serverframework.extensions.rpg_state import BLL_RPGState
+
+        for name in (
+            "_faction_no_cycle",
+            "_location_no_cycle",
+            "_hook_dependency_no_cycle",
+        ):
+            assert hasattr(
+                BLL_RPGState, name
+            ), f"cycle-guard hook {name} missing"
+
+    def test_cycle_guard_utility_imported(self):
+        from serverframework.lib.CycleGuard import (
+            CycleGuardError,
+            would_create_dag_cycle,
+            would_create_tree_cycle,
+        )
+
+        assert callable(would_create_tree_cycle)
+        assert callable(would_create_dag_cycle)
+        assert issubclass(CycleGuardError, Exception)

--- a/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/BLL_RPGState_test.py
@@ -190,15 +190,50 @@ class TestDerivativeTraitContract:
                 value=1.0,
             )
 
-    def test_constant_contribution_with_null_source(self):
-        # Initiative = DEX + 5 — the +5 is a constant edge.
+    def test_item_can_be_source(self):
+        # Ring of Protection: source_item_id set, source_trait_id null.
+        # Contribution applies while the person wears an ItemInstance
+        # of this Item (runtime-resolved).
+        d = DerivativeTraitModel.Create(
+            source_item_id="ring-of-protection",
+            target_trait_id="ac",
+            operation="additive",
+            value=1.0,
+            stacking_group="deflection_bonus",
+        )
+        assert d.source_item_id == "ring-of-protection"
+        assert d.source_trait_id is None
+        assert d.target_trait_id == "ac"
+        assert d.stacking_group == "deflection_bonus"
+
+    def test_item_consumable_targets_status_effect_trait(self):
+        # Potion of Bull's Strength: source_item_id=potion,
+        # target_trait_id=BullsStrength (a kind='status_effect' Trait).
+        # On consumption, the manager spawns a PersonTrait of
+        # BullsStrength on the drinker; this DerivativeTrait edge
+        # documents the "this potion grants this Trait when consumed"
+        # relationship.
+        d = DerivativeTraitModel.Create(
+            source_item_id="potion-of-bulls-strength",
+            target_trait_id="bulls-strength",
+            operation="override",
+            value=1.0,
+        )
+        assert d.source_item_id == "potion-of-bulls-strength"
+        assert d.target_trait_id == "bulls-strength"
+
+    def test_constant_contribution_with_both_sources_null(self):
+        # Initiative = DEX + 5 — the +5 is a constant edge with both
+        # source columns NULL.
         d = DerivativeTraitModel.Create(
             source_trait_id=None,
+            source_item_id=None,
             target_trait_id="initiative",
             operation="additive",
             value=5.0,
         )
         assert d.source_trait_id is None
+        assert d.source_item_id is None
         assert d.value == 5.0
 
     def test_signed_value_for_damage(self):

--- a/src/serverframework/extensions/rpg_state/EXT_RPGState.py
+++ b/src/serverframework/extensions/rpg_state/EXT_RPGState.py
@@ -1,8 +1,8 @@
 """rpg_state extension definition.
 
-Owns the present-state tables for an RPG campaign. No upstream extension
-dependencies; ``rpg_log`` depends on this for character / item / location
-references.
+Hard-depends on ``genealogy`` (widens PersonModel and RelationshipModel
+via @extension_model). ``rpg_log`` depends on rpg_state for trait /
+item / location references.
 """
 
 from typing import ClassVar, List, Type
@@ -15,9 +15,10 @@ from serverframework.extensions.AbstractExtensionProvider import (
 class RPGStateExtension(AbstractStaticExtension):
     name: ClassVar[str] = "rpg_state"
     description: ClassVar[str] = (
-        "Present-state schema for RPG campaigns (system-agnostic)"
+        "Present-state schema for RPG campaigns (system-agnostic). "
+        "Widens genealogy.PersonModel to serve as the character table."
     )
-    extension_dependencies: ClassVar[List[str]] = []
+    extension_dependencies: ClassVar[List[str]] = ["genealogy"]
 
     @classmethod
     def models(cls) -> List[Type]:

--- a/src/serverframework/extensions/rpg_state/EXT_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/EXT_RPGState_test.py
@@ -14,11 +14,12 @@ class TestExtensionMetadata:
         assert RPGStateExtension.name == "rpg_state"
         assert "RPG" in RPGStateExtension.description
 
-    def test_no_extension_dependencies(self):
-        # rpg_state is foundational; rpg_log is the consumer.
-        assert RPGStateExtension.extension_dependencies == []
+    def test_depends_on_genealogy(self):
+        # Hard dependency: rpg_state widens genealogy.PersonModel and
+        # genealogy.RelationshipModel via @extension_model.
+        assert "genealogy" in RPGStateExtension.extension_dependencies
 
     def test_models_returns_full_roster(self):
         models = RPGStateExtension.models()
         assert set(models) == set(ALL_MODELS)
-        assert len(models) == 18  # tracked count; bump when adding tables.
+        assert len(models) == 16  # bump when adding owned tables.

--- a/src/serverframework/extensions/rpg_state/EXT_RPGState_test.py
+++ b/src/serverframework/extensions/rpg_state/EXT_RPGState_test.py
@@ -22,4 +22,4 @@ class TestExtensionMetadata:
     def test_models_returns_full_roster(self):
         models = RPGStateExtension.models()
         assert set(models) == set(ALL_MODELS)
-        assert len(models) == 16  # bump when adding owned tables.
+        assert len(models) == 13  # bump when adding owned tables.

--- a/src/serverframework/extensions/rpg_state/__init__.py
+++ b/src/serverframework/extensions/rpg_state/__init__.py
@@ -8,4 +8,39 @@ other tabletop / video-game / roleplay systems plug in via the
 
 State here is the "now". Historical events (combat actions, dialogue,
 transactions) live in the sibling ``rpg_log`` extension.
+
+Membership & visibility
+-----------------------
+There is intentionally no ``CampaignMember`` table. Membership is
+inferred:
+
+- The campaign **owner** is ``CampaignModel.user_id`` (the GM).
+- A user is a **player** in a campaign iff they own at least one
+  ``CharacterModel`` with that ``campaign_id`` (i.e. their ``user_id``
+  matches and ``kind`` is typically 'pc').
+
+Anything finer-grained — observers, co-GMs, per-row visibility ("this
+NPC is GM-only"), shared handouts, per-character notes that other
+players shouldn't see — is delegated to the ``acl_rbac`` extension as an
+**optional** dependency. ``rpg_state`` does **not** carry a
+``visibility`` column on its entities; granularity belongs to ACL, not
+to a coarse public/gm enum that would constrain the GM.
+
+Progression
+-----------
+Progression dimensions (level, experience, spent XP, milestones, dice
+pools, etc.) are **Traits**, not columns on ``CharacterModel``. By
+convention they live as ``TraitModel(kind='progression')`` rows named
+'level' / 'experience' / 'spent_experience' / ..., and each character's
+current value lives on ``CharacterTraitModel.value``. This keeps level-,
+XP-, and milestone-based systems equally first-class.
+
+Item ownership (recap; canonical comment on ItemInstanceModel)
+--------------------------------------------------------------
+``owner_character_id`` is **assignment / responsibility / who-would-
+notice-it-missing** — *not* the equipping character. Equipping is a
+spatial concern modelled by an equipment-slot ``LocationModel`` bound to
+a character. The item's bearer (location chain) and its owner may
+disagree without contradiction; theft is the natural state where they
+disagree without an intervening consensual ``TransactionLog``.
 """

--- a/src/serverframework/extensions/rpg_state/__init__.py
+++ b/src/serverframework/extensions/rpg_state/__init__.py
@@ -10,11 +10,13 @@ relationship table holds Person↔Person, Person↔Faction, and
 Faction↔Faction edges; the migration adds an endpoint-XOR CHECK
 constraint.
 
-State here is the "now": GameSystems, Campaigns, Traits, StatusEffects,
-Factions, Locations, Items, Quests, and the per-person and
-per-faction join tables that wire them together. Historical events
-(combat actions, dialogue, transactions) live in the sibling
-``rpg_log`` extension.
+State here is the "now": GameSystems, Campaigns, Traits (with
+``kind='status_effect'`` for buffs/debuffs/conditions),
+DerivativeTraits (edges defining how Traits contribute to one
+another), Factions, Locations, Items, Hooks (narrative DAG; replaces
+Quest+Objective), and the per-person / per-faction join tables that
+wire them together. Historical events (combat actions, dialogue,
+transactions) live in the sibling ``rpg_log`` extension.
 
 Schema integrity
 ----------------

--- a/src/serverframework/extensions/rpg_state/__init__.py
+++ b/src/serverframework/extensions/rpg_state/__init__.py
@@ -1,46 +1,63 @@
 """rpg_state extension.
 
-Owns the present-state schema for an RPG campaign: characters, factions,
-items, locations, quests, and the unified Trait / StatusEffect property
-model. Designed to be system-agnostic — DnD, Pathfinder, FFG, WH40K, and
-other tabletop / video-game / roleplay systems plug in via the
-``GameSystem`` reference table.
+Hard-depends on ``genealogy``. RPG **does not** define a separate
+Character table — it widens ``genealogy.PersonModel`` with the
+character-specific fields (``kind``, ``campaign_id``, ``user_id``) via
+``@extension_model``. The ``persons`` table is the character table for
+RPG users. RPG also widens ``genealogy.RelationshipModel`` with Faction
+endpoints (``faction_id``, ``target_faction_id``) so that one
+relationship table holds Person↔Person, Person↔Faction, and
+Faction↔Faction edges; the migration adds an endpoint-XOR CHECK
+constraint.
 
-State here is the "now". Historical events (combat actions, dialogue,
-transactions) live in the sibling ``rpg_log`` extension.
+State here is the "now": GameSystems, Campaigns, Traits, StatusEffects,
+Factions, Locations, Items, Quests, and the per-person and
+per-faction join tables that wire them together. Historical events
+(combat actions, dialogue, transactions) live in the sibling
+``rpg_log`` extension.
+
+Schema integrity
+----------------
+The codebase enforces integrity at the database layer where it is
+non-negotiable. Cross-extension foreign keys are real
+``ForeignKeyConstraint`` declarations; required references use
+``nullable=False``; the endpoint-XOR on ``relationships`` is enforced
+by a SQL CHECK constraint added when ``rpg_state`` injects faction
+endpoints. Manager-layer validators handle invariants that don't fit
+relational constraints (cycle detection in faction/location parent
+chains; equipment-slot coherence on Locations).
 
 Membership & visibility
 -----------------------
-There is intentionally no ``CampaignMember`` table. Membership is
-inferred:
+There is no ``CampaignMember`` table. Membership is inferred:
 
 - The campaign **owner** is ``CampaignModel.user_id`` (the GM).
 - A user is a **player** in a campaign iff they own at least one
-  ``CharacterModel`` with that ``campaign_id`` (i.e. their ``user_id``
-  matches and ``kind`` is typically 'pc').
+  Person (``persons.user_id`` matches and ``persons.campaign_id`` is
+  the campaign).
 
-Anything finer-grained — observers, co-GMs, per-row visibility ("this
-NPC is GM-only"), shared handouts, per-character notes that other
-players shouldn't see — is delegated to the ``acl_rbac`` extension as an
-**optional** dependency. ``rpg_state`` does **not** carry a
-``visibility`` column on its entities; granularity belongs to ACL, not
-to a coarse public/gm enum that would constrain the GM.
+Faction membership is **not** a separate join table either — it lives
+in ``RelationshipModel`` as ``kind='member_of'`` with Person→Faction
+endpoints. Discriminator carries the role label ('leader', 'member',
+'treasurer'). Intensity carries reputation/standing.
+
+Granular visibility (GM-secret NPCs, hidden quests, shared handouts)
+is delegated to the optional ``acl_rbac`` extension. ``rpg_state`` does
+not carry visibility columns; granularity belongs to ACL.
 
 Progression
 -----------
-Progression dimensions (level, experience, spent XP, milestones, dice
-pools, etc.) are **Traits**, not columns on ``CharacterModel``. By
-convention they live as ``TraitModel(kind='progression')`` rows named
-'level' / 'experience' / 'spent_experience' / ..., and each character's
-current value lives on ``CharacterTraitModel.value``. This keeps level-,
-XP-, and milestone-based systems equally first-class.
+Progression dimensions (level, experience, spent_experience,
+milestones, dice pools) live in the unified Trait catalog as
+``TraitModel(kind='progression')`` rows joined via ``PersonTraitModel``.
+The persons table has no ``level`` column.
 
 Item ownership (recap; canonical comment on ItemInstanceModel)
 --------------------------------------------------------------
-``owner_character_id`` is **assignment / responsibility / who-would-
-notice-it-missing** — *not* the equipping character. Equipping is a
-spatial concern modelled by an equipment-slot ``LocationModel`` bound to
-a character. The item's bearer (location chain) and its owner may
-disagree without contradiction; theft is the natural state where they
-disagree without an intervening consensual ``TransactionLog``.
+``owner_person_id`` is **assignment / responsibility / who-would-
+notice-it-missing** — *not* the equipping person. Equipping is a
+spatial concern modelled by an equipment-slot ``LocationModel`` bound
+to a person via ``associated_person_id``. Theft is the natural state
+where the bearer (location chain) and the owner disagree without an
+intervening consensual ``TransactionLog``.
 """

--- a/src/serverframework/extensions/rpg_state/manifest.toml
+++ b/src/serverframework/extensions/rpg_state/manifest.toml
@@ -1,11 +1,18 @@
 name = "rpg_state"
 version = "0.1.0"
-description = "Present-state schema for an RPG campaign — characters, factions, items, quests, locations, traits"
+description = "Present-state schema for an RPG campaign — characters (via genealogy), factions, items, quests, locations, traits"
+
+# Hard dependency. rpg_state does not define its own Character table —
+# it widens genealogy.PersonModel via @extension_model so the persons
+# table is the character table for RPG users. It also widens
+# genealogy.RelationshipModel with Faction endpoints.
+[[extension_dependencies]]
+name = "genealogy"
+optional = false
 
 # Optional: when present, ACL drives per-row visibility for GM-secret
-# NPCs, hidden quests/lore, etc. Without it, every campaign member sees
-# every campaign row; that's an acceptable degraded mode for solo /
-# trusted-table use. rpg_state never carries its own visibility column.
+# NPCs, hidden quests/lore, etc. rpg_state never carries its own
+# visibility column.
 [[extension_dependencies]]
 name = "acl_rbac"
 optional = true

--- a/src/serverframework/extensions/rpg_state/manifest.toml
+++ b/src/serverframework/extensions/rpg_state/manifest.toml
@@ -2,7 +2,12 @@ name = "rpg_state"
 version = "0.1.0"
 description = "Present-state schema for an RPG campaign — characters, factions, items, quests, locations, traits"
 
-# Foundational. No upstream extension dependencies.
+# Optional: when present, ACL drives per-row visibility for GM-secret
+# NPCs, hidden quests/lore, etc. Without it, every campaign member sees
+# every campaign row; that's an acceptable degraded mode for solo /
+# trusted-table use. rpg_state never carries its own visibility column.
 [[extension_dependencies]]
+name = "acl_rbac"
+optional = true
 
 [python_dependencies]

--- a/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
@@ -184,6 +184,11 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["source_trait_id"], ["traits.id"]),
             sa.ForeignKeyConstraint(["target_trait_id"], ["traits.id"]),
+            sa.CheckConstraint(
+                "operation IS NULL OR operation IN "
+                "('override', 'additive', 'multiplicative', 'clamp')",
+                name="ck_derivative_traits_operation",
+            ),
             comment=(
                 "Edges defining how one Trait contributes to another. "
                 "Resolution pipeline: override → additive → "
@@ -264,6 +269,7 @@ def upgrade() -> None:
             sa.Column("expires_at", sa.DateTime(), nullable=True),
             sa.Column("source_person_id", sa.String(36), nullable=True),
             sa.Column("source_item_instance_id", sa.String(36), nullable=True),
+            sa.Column("target_location_id", sa.String(36), nullable=True),
             sa.Column("notes", sa.Text(), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
             sa.Column("created_by_user_id", sa.String(36), nullable=True),
@@ -277,9 +283,11 @@ def upgrade() -> None:
             sa.ForeignKeyConstraint(["source_person_id"], ["persons.id"]),
             comment=(
                 "Per-person trait instances. Multiple rows per "
-                "(person, trait) allowed (e.g. several Wound stacks). "
-                "Durable traits leave started_at/expires_at NULL; "
-                "transient applications fill them."
+                "(person, trait) allowed (e.g. several Wound stacks at "
+                "different body parts). Durable traits leave "
+                "started_at/expires_at NULL; transient applications "
+                "fill them. target_location_id localises the "
+                "application (body-part Location for damage)."
             ),
             info=_INFO,
         )
@@ -293,9 +301,13 @@ def upgrade() -> None:
         op.create_index(
             "ix_pt_active", "person_traits", ["person_id", "expires_at"]
         )
+    if "ix_pt_target_location" not in pt_idx:
+        op.create_index(
+            "ix_pt_target_location", "person_traits", ["target_location_id"]
+        )
 
-    # source_item_instance_id FK is added after item_instances exists
-    # (deferred below).
+    # Deferred FKs (added below): source_item_instance_id → item_instances,
+    # target_location_id → locations.
 
     # ---------------------------------------------------------------
     # factions
@@ -375,6 +387,37 @@ def upgrade() -> None:
     if "ix_locations_person" not in loc_idx:
         op.create_index(
             "ix_locations_person", "locations", ["associated_person_id"]
+        )
+
+    # Inject persons.location_id (current scene/region) now that the
+    # locations table exists. FK is real.
+    person_cols_post_locations = _existing_column_names("persons")
+    if "location_id" not in person_cols_post_locations:
+        op.add_column(
+            "persons",
+            sa.Column(
+                "location_id",
+                sa.String(36),
+                sa.ForeignKey("locations.id"),
+                nullable=True,
+                comment=(
+                    "Current scene/region location (rpg_state). Distinct "
+                    "from body-part sub-Locations associated with the "
+                    "person via Location.associated_person_id."
+                ),
+            ),
+        )
+    if "ix_persons_location" not in _existing_index_names("persons"):
+        op.create_index("ix_persons_location", "persons", ["location_id"])
+
+    # Add the deferred target_location_id FK on person_traits now that
+    # locations exists.
+    with op.batch_alter_table("person_traits") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_person_traits_target_location",
+            "locations",
+            ["target_location_id"],
+            ["id"],
         )
 
     # ---------------------------------------------------------------
@@ -483,6 +526,13 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
             sa.ForeignKeyConstraint(["giver_faction_id"], ["factions.id"]),
+            sa.CheckConstraint(
+                "kind IS NULL OR kind IN ("
+                "'major_quest', 'side_quest', 'objective', "
+                "'plot_thread', 'mystery', 'rumor', 'obligation', "
+                "'foreshadowing', 'hint', 'background')",
+                name="ck_hooks_kind",
+            ),
             comment=(
                 "Narrative element. Replaces Quest+Objective. Hierarchy "
                 "and prerequisites move to hook_dependencies."
@@ -675,12 +725,14 @@ def downgrade() -> None:
     # Break the deferred FKs before dropping referenced tables.
     if _has_table("person_traits"):
         with op.batch_alter_table("person_traits") as batch_op:
-            try:
-                batch_op.drop_constraint(
-                    "fk_person_traits_source_item_instance", type_="foreignkey"
-                )
-            except Exception:
-                pass
+            for fk in (
+                "fk_person_traits_source_item_instance",
+                "fk_person_traits_target_location",
+            ):
+                try:
+                    batch_op.drop_constraint(fk, type_="foreignkey")
+                except Exception:
+                    pass
     if _has_table("locations"):
         with op.batch_alter_table("locations") as batch_op:
             try:
@@ -704,7 +756,7 @@ def downgrade() -> None:
     # Drop injected character columns from persons.
     person_cols = _existing_column_names("persons")
     with op.batch_alter_table("persons") as batch_op:
-        for col in ("user_id", "campaign_id", "kind"):
+        for col in ("location_id", "user_id", "campaign_id", "kind"):
             if col in person_cols:
                 batch_op.drop_column(col)
 

--- a/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
@@ -162,13 +162,14 @@ def upgrade() -> None:
         op.create_index("ix_traits_system", "traits", ["game_system_id"])
 
     # ---------------------------------------------------------------
-    # derivative_traits — edges from one Trait to another
+    # derivative_traits — edges from one Trait or Item to a Trait
     # ---------------------------------------------------------------
     if not _has_table("derivative_traits"):
         op.create_table(
             "derivative_traits",
             sa.Column("id", sa.String(36), nullable=False),
             sa.Column("source_trait_id", sa.String(36), nullable=True),
+            sa.Column("source_item_id", sa.String(36), nullable=True),
             sa.Column("target_trait_id", sa.String(36), nullable=True),
             sa.Column("operation", sa.String(32), nullable=True),
             sa.Column("value", sa.Float(), nullable=True),
@@ -184,17 +185,24 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["source_trait_id"], ["traits.id"]),
             sa.ForeignKeyConstraint(["target_trait_id"], ["traits.id"]),
+            # source_item_id FK is deferred until items table exists
+            # (created later in this migration).
             sa.CheckConstraint(
                 "operation IS NULL OR operation IN "
                 "('override', 'additive', 'multiplicative', 'clamp')",
                 name="ck_derivative_traits_operation",
             ),
+            sa.CheckConstraint(
+                "(source_trait_id IS NULL) OR (source_item_id IS NULL)",
+                name="ck_derivative_traits_source_xor",
+            ),
             comment=(
-                "Edges defining how one Trait contributes to another. "
-                "Resolution pipeline: override → additive → "
+                "Edges defining how a Trait or Item contributes to a "
+                "Trait. Resolution pipeline: override → additive → "
                 "multiplicative → clamp; order_index sequences within "
                 "phase; stacking_group de-duplicates by max-abs. "
-                "source_trait_id NULL = constant contribution."
+                "source_trait_id XOR source_item_id at the row level "
+                "(both NULL = constant contribution)."
             ),
             info=_INFO,
         )
@@ -202,6 +210,10 @@ def upgrade() -> None:
     dt_idx = _existing_index_names("derivative_traits")
     if "ix_dt_source" not in dt_idx:
         op.create_index("ix_dt_source", "derivative_traits", ["source_trait_id"])
+    if "ix_dt_source_item" not in dt_idx:
+        op.create_index(
+            "ix_dt_source_item", "derivative_traits", ["source_item_id"]
+        )
     if "ix_dt_target" not in dt_idx:
         op.create_index("ix_dt_target", "derivative_traits", ["target_trait_id"])
     if "ix_dt_phase" not in dt_idx:
@@ -487,9 +499,9 @@ def upgrade() -> None:
             "ix_ii_owner_faction", "item_instances", ["owner_faction_id"]
         )
 
-    # Close the Location ↔ ItemInstance cycle and the
-    # PersonTrait → ItemInstance source FK now that item_instances
-    # exists.
+    # Close the Location ↔ ItemInstance cycle, the PersonTrait →
+    # ItemInstance source FK, and the DerivativeTrait → Item source FK
+    # now that items / item_instances exist.
     with op.batch_alter_table("locations") as batch_op:
         batch_op.create_foreign_key(
             "fk_locations_container_item_instance",
@@ -502,6 +514,13 @@ def upgrade() -> None:
             "fk_person_traits_source_item_instance",
             "item_instances",
             ["source_item_instance_id"],
+            ["id"],
+        )
+    with op.batch_alter_table("derivative_traits") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_derivative_traits_source_item",
+            "items",
+            ["source_item_id"],
             ["id"],
         )
 
@@ -738,6 +757,14 @@ def downgrade() -> None:
             try:
                 batch_op.drop_constraint(
                     "fk_locations_container_item_instance", type_="foreignkey"
+                )
+            except Exception:
+                pass
+    if _has_table("derivative_traits"):
+        with op.batch_alter_table("derivative_traits") as batch_op:
+            try:
+                batch_op.drop_constraint(
+                    "fk_derivative_traits_source_item", type_="foreignkey"
                 )
             except Exception:
                 pass

--- a/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
@@ -7,19 +7,36 @@ Hard-depends on ``genealogy``. This migration:
    ``persons`` table becomes the character table for RPG users.
 2. Injects Faction endpoints (``faction_id``, ``target_faction_id``)
    onto the ``relationships`` table, relaxes nullability on the
-   default Person endpoints, and adds a CHECK constraint enforcing
+   default Person endpoints, and adds two CHECK constraints enforcing
    endpoint XOR (exactly one endpoint per side).
 3. Creates the rpg_state-owned tables: game_systems, campaigns, traits,
-   status_effects, status_effect_traits, person_traits,
-   person_status_effects, factions, locations, items, item_instances,
-   quests, objectives, person_quests, faction_quests, person_objectives.
+   derivative_traits, person_traits, factions, locations, items,
+   item_instances, hooks, hook_dependencies, person_hooks,
+   faction_hooks.
+
+Trait merger
+------------
+There is no separate ``status_effects`` / ``status_effect_traits`` /
+``person_status_effects`` triple. ``traits`` carries an optional
+``default_duration_seconds`` (only meaningful when
+``kind='status_effect'``). ``derivative_traits`` replaces
+``status_effect_traits`` and is the sole edge table defining how Traits
+contribute to one another (including applied buffs/debuffs/damage).
+``person_traits`` carries the timing and source-attribution columns
+that previously lived on ``person_status_effects``.
+
+Hook DAG
+--------
+Quest+Objective fold into a single ``hooks`` table with a free-form
+``kind`` discriminator. Prerequisites and other inter-hook relations
+live in ``hook_dependencies(parent_hook_id, child_hook_id, reason)``;
+the presence of a row IS the dependency, the reason string explains
+why. ``person_hooks`` and ``faction_hooks`` carry per-actor progress.
 
 Foreign keys are enforced at the database layer where the references
-are stable. The cyclic Location ↔ ItemInstance reference (a satchel's
-interior is a Location whose ``container_item_instance_id`` points at
-the satchel ItemInstance) is resolved by adding the
-``container_item_instance_id`` and ``location_id`` FKs after both
-tables exist.
+are stable. The cyclic Location ↔ ItemInstance reference is resolved
+by adding the ``container_item_instance_id`` FK after both tables
+exist.
 """
 
 from typing import Sequence, Union
@@ -106,7 +123,7 @@ def upgrade() -> None:
         op.create_index("ix_campaigns_user", "campaigns", ["user_id"])
 
     # ---------------------------------------------------------------
-    # traits
+    # traits — unified property catalog (incl. status effects)
     # ---------------------------------------------------------------
     if not _has_table("traits"):
         op.create_table(
@@ -115,6 +132,9 @@ def upgrade() -> None:
             sa.Column("name", sa.String(255), nullable=True),
             sa.Column("description", sa.Text(), nullable=True),
             sa.Column("kind", sa.String(64), nullable=True),
+            sa.Column(
+                "default_duration_seconds", sa.Integer(), nullable=True
+            ),
             sa.Column("game_system_id", sa.String(36), nullable=True),
             sa.Column("campaign_id", sa.String(36), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
@@ -126,7 +146,12 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["game_system_id"], ["game_systems.id"]),
             sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
-            comment="Unified property catalog (attributes, skills, spells, talents, feats, resources, progression).",
+            comment=(
+                "Unified property catalog: attributes, skills, spells, "
+                "talents, feats, abilities, languages, resources, "
+                "progression, status effects. default_duration_seconds "
+                "is meaningful only for kind='status_effect'."
+            ),
             info=_INFO,
         )
 
@@ -137,36 +162,18 @@ def upgrade() -> None:
         op.create_index("ix_traits_system", "traits", ["game_system_id"])
 
     # ---------------------------------------------------------------
-    # status_effects + status_effect_traits
+    # derivative_traits — edges from one Trait to another
     # ---------------------------------------------------------------
-    if not _has_table("status_effects"):
+    if not _has_table("derivative_traits"):
         op.create_table(
-            "status_effects",
+            "derivative_traits",
             sa.Column("id", sa.String(36), nullable=False),
-            sa.Column("name", sa.String(255), nullable=True),
-            sa.Column("description", sa.Text(), nullable=True),
-            sa.Column("default_duration_seconds", sa.Integer(), nullable=True),
-            sa.Column("game_system_id", sa.String(36), nullable=True),
-            sa.Column("created_at", sa.DateTime(), nullable=False),
-            sa.Column("created_by_user_id", sa.String(36), nullable=True),
-            sa.Column("updated_at", sa.DateTime(), nullable=True),
-            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
-            sa.Column("deleted_at", sa.DateTime(), nullable=True),
-            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
-            sa.PrimaryKeyConstraint("id"),
-            sa.ForeignKeyConstraint(["game_system_id"], ["game_systems.id"]),
-            comment="Status effect templates (buffs, debuffs, conditions, damage).",
-            info=_INFO,
-        )
-
-    if not _has_table("status_effect_traits"):
-        op.create_table(
-            "status_effect_traits",
-            sa.Column("id", sa.String(36), nullable=False),
-            sa.Column("status_effect_id", sa.String(36), nullable=True),
-            sa.Column("trait_id", sa.String(36), nullable=True),
+            sa.Column("source_trait_id", sa.String(36), nullable=True),
+            sa.Column("target_trait_id", sa.String(36), nullable=True),
             sa.Column("operation", sa.String(32), nullable=True),
             sa.Column("value", sa.Float(), nullable=True),
+            sa.Column("order_index", sa.Integer(), nullable=True),
+            sa.Column("stacking_group", sa.String(64), nullable=True),
             sa.Column("qualifier", sa.String(255), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
             sa.Column("created_by_user_id", sa.String(36), nullable=True),
@@ -175,23 +182,32 @@ def upgrade() -> None:
             sa.Column("deleted_at", sa.DateTime(), nullable=True),
             sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
             sa.PrimaryKeyConstraint("id"),
-            sa.ForeignKeyConstraint(["status_effect_id"], ["status_effects.id"]),
-            sa.ForeignKeyConstraint(["trait_id"], ["traits.id"]),
-            comment="Per-trait modifiers contributed by a StatusEffect template.",
+            sa.ForeignKeyConstraint(["source_trait_id"], ["traits.id"]),
+            sa.ForeignKeyConstraint(["target_trait_id"], ["traits.id"]),
+            comment=(
+                "Edges defining how one Trait contributes to another. "
+                "Resolution pipeline: override → additive → "
+                "multiplicative → clamp; order_index sequences within "
+                "phase; stacking_group de-duplicates by max-abs. "
+                "source_trait_id NULL = constant contribution."
+            ),
             info=_INFO,
         )
 
-    set_idx = _existing_index_names("status_effect_traits")
-    if "ix_set_effect" not in set_idx:
+    dt_idx = _existing_index_names("derivative_traits")
+    if "ix_dt_source" not in dt_idx:
+        op.create_index("ix_dt_source", "derivative_traits", ["source_trait_id"])
+    if "ix_dt_target" not in dt_idx:
+        op.create_index("ix_dt_target", "derivative_traits", ["target_trait_id"])
+    if "ix_dt_phase" not in dt_idx:
         op.create_index(
-            "ix_set_effect", "status_effect_traits", ["status_effect_id"]
+            "ix_dt_phase",
+            "derivative_traits",
+            ["target_trait_id", "operation", "order_index"],
         )
-    if "ix_set_trait" not in set_idx:
-        op.create_index("ix_set_trait", "status_effect_traits", ["trait_id"])
 
     # ---------------------------------------------------------------
     # Inject character columns onto persons table.
-    # genealogy owns the table; rpg_state owns these columns.
     # ---------------------------------------------------------------
     person_cols = _existing_column_names("persons")
     if "kind" not in person_cols:
@@ -234,7 +250,7 @@ def upgrade() -> None:
         op.create_index("ix_persons_user", "persons", ["user_id"])
 
     # ---------------------------------------------------------------
-    # person_traits
+    # person_traits — base values + applied effect attachments
     # ---------------------------------------------------------------
     if not _has_table("person_traits"):
         op.create_table(
@@ -244,6 +260,10 @@ def upgrade() -> None:
             sa.Column("trait_id", sa.String(36), nullable=True),
             sa.Column("value", sa.Float(), nullable=True),
             sa.Column("rank", sa.Integer(), nullable=True),
+            sa.Column("started_at", sa.DateTime(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+            sa.Column("source_person_id", sa.String(36), nullable=True),
+            sa.Column("source_item_instance_id", sa.String(36), nullable=True),
             sa.Column("notes", sa.Text(), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
             sa.Column("created_by_user_id", sa.String(36), nullable=True),
@@ -254,7 +274,13 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
             sa.ForeignKeyConstraint(["trait_id"], ["traits.id"]),
-            comment="Per-person base trait values.",
+            sa.ForeignKeyConstraint(["source_person_id"], ["persons.id"]),
+            comment=(
+                "Per-person trait instances. Multiple rows per "
+                "(person, trait) allowed (e.g. several Wound stacks). "
+                "Durable traits leave started_at/expires_at NULL; "
+                "transient applications fill them."
+            ),
             info=_INFO,
         )
 
@@ -263,43 +289,13 @@ def upgrade() -> None:
         op.create_index("ix_pt_person", "person_traits", ["person_id"])
     if "ix_pt_trait" not in pt_idx:
         op.create_index("ix_pt_trait", "person_traits", ["trait_id"])
-
-    # ---------------------------------------------------------------
-    # person_status_effects
-    # ---------------------------------------------------------------
-    if not _has_table("person_status_effects"):
-        op.create_table(
-            "person_status_effects",
-            sa.Column("id", sa.String(36), nullable=False),
-            sa.Column("person_id", sa.String(36), nullable=True),
-            sa.Column("status_effect_id", sa.String(36), nullable=True),
-            sa.Column("started_at", sa.DateTime(), nullable=True),
-            sa.Column("expires_at", sa.DateTime(), nullable=True),
-            sa.Column("source_person_id", sa.String(36), nullable=True),
-            sa.Column("source_item_instance_id", sa.String(36), nullable=True),
-            sa.Column("created_at", sa.DateTime(), nullable=False),
-            sa.Column("created_by_user_id", sa.String(36), nullable=True),
-            sa.Column("updated_at", sa.DateTime(), nullable=True),
-            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
-            sa.Column("deleted_at", sa.DateTime(), nullable=True),
-            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
-            sa.PrimaryKeyConstraint("id"),
-            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
-            sa.ForeignKeyConstraint(["status_effect_id"], ["status_effects.id"]),
-            sa.ForeignKeyConstraint(["source_person_id"], ["persons.id"]),
-            comment="Active StatusEffect attachments per person.",
-            info=_INFO,
-        )
-
-    pse_idx = _existing_index_names("person_status_effects")
-    if "ix_pse_person" not in pse_idx:
-        op.create_index("ix_pse_person", "person_status_effects", ["person_id"])
-    if "ix_pse_active" not in pse_idx:
+    if "ix_pt_active" not in pt_idx:
         op.create_index(
-            "ix_pse_active",
-            "person_status_effects",
-            ["person_id", "expires_at"],
+            "ix_pt_active", "person_traits", ["person_id", "expires_at"]
         )
+
+    # source_item_instance_id FK is added after item_instances exists
+    # (deferred below).
 
     # ---------------------------------------------------------------
     # factions
@@ -322,8 +318,8 @@ def upgrade() -> None:
             sa.ForeignKeyConstraint(["parent_id"], ["factions.id"]),
             sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
             comment=(
-                "Hierarchical faction (parent_id self-FK fast-path for the "
-                "primary tree). Membership lives in relationships(kind='member_of')."
+                "Hierarchical faction (parent_id self-FK fast-path). "
+                "Membership lives in relationships(kind='member_of')."
             ),
             info=_INFO,
         )
@@ -345,8 +341,6 @@ def upgrade() -> None:
             sa.Column("description", sa.Text(), nullable=True),
             sa.Column("parent_id", sa.String(36), nullable=True),
             sa.Column("campaign_id", sa.String(36), nullable=True),
-            # FK on container_item_instance_id is added post-create,
-            # after item_instances exists, to break the cycle.
             sa.Column("container_item_instance_id", sa.String(36), nullable=True),
             sa.Column("associated_person_id", sa.String(36), nullable=True),
             sa.Column("kind", sa.String(64), nullable=True),
@@ -450,8 +444,9 @@ def upgrade() -> None:
             "ix_ii_owner_faction", "item_instances", ["owner_faction_id"]
         )
 
-    # Close the Location ↔ ItemInstance cycle: add the FK now that both
-    # tables exist. Use batch_alter_table for SQLite compatibility.
+    # Close the Location ↔ ItemInstance cycle and the
+    # PersonTrait → ItemInstance source FK now that item_instances
+    # exists.
     with op.batch_alter_table("locations") as batch_op:
         batch_op.create_foreign_key(
             "fk_locations_container_item_instance",
@@ -459,16 +454,24 @@ def upgrade() -> None:
             ["container_item_instance_id"],
             ["id"],
         )
+    with op.batch_alter_table("person_traits") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_person_traits_source_item_instance",
+            "item_instances",
+            ["source_item_instance_id"],
+            ["id"],
+        )
 
     # ---------------------------------------------------------------
-    # quests + objectives
+    # hooks  (replaces quests + objectives)
     # ---------------------------------------------------------------
-    if not _has_table("quests"):
+    if not _has_table("hooks"):
         op.create_table(
-            "quests",
+            "hooks",
             sa.Column("id", sa.String(36), nullable=False),
             sa.Column("name", sa.String(255), nullable=True),
             sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("kind", sa.String(64), nullable=True),
             sa.Column("campaign_id", sa.String(36), nullable=True),
             sa.Column("giver_faction_id", sa.String(36), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
@@ -480,22 +483,29 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
             sa.ForeignKeyConstraint(["giver_faction_id"], ["factions.id"]),
-            comment="Quest template",
+            comment=(
+                "Narrative element. Replaces Quest+Objective. Hierarchy "
+                "and prerequisites move to hook_dependencies."
+            ),
             info=_INFO,
         )
 
-    if "ix_quests_campaign" not in _existing_index_names("quests"):
-        op.create_index("ix_quests_campaign", "quests", ["campaign_id"])
+    hooks_idx = _existing_index_names("hooks")
+    if "ix_hooks_campaign" not in hooks_idx:
+        op.create_index("ix_hooks_campaign", "hooks", ["campaign_id"])
+    if "ix_hooks_kind" not in hooks_idx:
+        op.create_index("ix_hooks_kind", "hooks", ["kind"])
 
-    if not _has_table("objectives"):
+    # ---------------------------------------------------------------
+    # hook_dependencies — DAG edges between Hooks
+    # ---------------------------------------------------------------
+    if not _has_table("hook_dependencies"):
         op.create_table(
-            "objectives",
+            "hook_dependencies",
             sa.Column("id", sa.String(36), nullable=False),
-            sa.Column("name", sa.String(255), nullable=True),
-            sa.Column("description", sa.Text(), nullable=True),
-            sa.Column("quest_id", sa.String(36), nullable=True),
-            sa.Column("prerequisite_objective_id", sa.String(36), nullable=True),
-            sa.Column("order_index", sa.Integer(), nullable=True),
+            sa.Column("parent_hook_id", sa.String(36), nullable=True),
+            sa.Column("child_hook_id", sa.String(36), nullable=True),
+            sa.Column("reason", sa.Text(), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
             sa.Column("created_by_user_id", sa.String(36), nullable=True),
             sa.Column("updated_at", sa.DateTime(), nullable=True),
@@ -503,29 +513,35 @@ def upgrade() -> None:
             sa.Column("deleted_at", sa.DateTime(), nullable=True),
             sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
             sa.PrimaryKeyConstraint("id"),
-            sa.ForeignKeyConstraint(["quest_id"], ["quests.id"]),
-            sa.ForeignKeyConstraint(
-                ["prerequisite_objective_id"], ["objectives.id"]
+            sa.ForeignKeyConstraint(["parent_hook_id"], ["hooks.id"]),
+            sa.ForeignKeyConstraint(["child_hook_id"], ["hooks.id"]),
+            comment=(
+                "DAG edge between two Hooks. Presence of a row IS the "
+                "dependency; the reason string explains it. Cycle "
+                "prevention is enforced at the manager layer."
             ),
-            comment="Objective template; chains via prerequisite_objective_id.",
             info=_INFO,
         )
 
-    if "ix_objectives_quest" not in _existing_index_names("objectives"):
-        op.create_index("ix_objectives_quest", "objectives", ["quest_id"])
+    hd_idx = _existing_index_names("hook_dependencies")
+    if "ix_hd_parent" not in hd_idx:
+        op.create_index("ix_hd_parent", "hook_dependencies", ["parent_hook_id"])
+    if "ix_hd_child" not in hd_idx:
+        op.create_index("ix_hd_child", "hook_dependencies", ["child_hook_id"])
 
     # ---------------------------------------------------------------
-    # person_quests + faction_quests + person_objectives
+    # person_hooks + faction_hooks  (replace person_quests, faction_quests, person_objectives)
     # ---------------------------------------------------------------
-    if not _has_table("person_quests"):
+    if not _has_table("person_hooks"):
         op.create_table(
-            "person_quests",
+            "person_hooks",
             sa.Column("id", sa.String(36), nullable=False),
             sa.Column("person_id", sa.String(36), nullable=True),
-            sa.Column("quest_id", sa.String(36), nullable=True),
+            sa.Column("hook_id", sa.String(36), nullable=True),
             sa.Column("status", sa.String(32), nullable=True),
             sa.Column("accepted_at", sa.DateTime(), nullable=True),
             sa.Column("completed_at", sa.DateTime(), nullable=True),
+            sa.Column("progress", sa.Float(), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
             sa.Column("created_by_user_id", sa.String(36), nullable=True),
             sa.Column("updated_at", sa.DateTime(), nullable=True),
@@ -534,28 +550,29 @@ def upgrade() -> None:
             sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
-            sa.ForeignKeyConstraint(["quest_id"], ["quests.id"]),
-            comment="Per-person quest progress instance",
+            sa.ForeignKeyConstraint(["hook_id"], ["hooks.id"]),
+            comment="Per-person hook progress (replaces PersonQuest+PersonObjective).",
             info=_INFO,
         )
 
-    pq_idx = _existing_index_names("person_quests")
-    if "ix_pq_person" not in pq_idx:
-        op.create_index("ix_pq_person", "person_quests", ["person_id"])
-    if "ix_pq_status" not in pq_idx:
+    ph_idx = _existing_index_names("person_hooks")
+    if "ix_ph_person" not in ph_idx:
+        op.create_index("ix_ph_person", "person_hooks", ["person_id"])
+    if "ix_ph_status" not in ph_idx:
         op.create_index(
-            "ix_pq_status", "person_quests", ["person_id", "status"]
+            "ix_ph_status", "person_hooks", ["person_id", "status"]
         )
 
-    if not _has_table("faction_quests"):
+    if not _has_table("faction_hooks"):
         op.create_table(
-            "faction_quests",
+            "faction_hooks",
             sa.Column("id", sa.String(36), nullable=False),
             sa.Column("faction_id", sa.String(36), nullable=True),
-            sa.Column("quest_id", sa.String(36), nullable=True),
+            sa.Column("hook_id", sa.String(36), nullable=True),
             sa.Column("status", sa.String(32), nullable=True),
             sa.Column("accepted_at", sa.DateTime(), nullable=True),
             sa.Column("completed_at", sa.DateTime(), nullable=True),
+            sa.Column("progress", sa.Float(), nullable=True),
             sa.Column("created_at", sa.DateTime(), nullable=False),
             sa.Column("created_by_user_id", sa.String(36), nullable=True),
             sa.Column("updated_at", sa.DateTime(), nullable=True),
@@ -564,43 +581,18 @@ def upgrade() -> None:
             sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
             sa.PrimaryKeyConstraint("id"),
             sa.ForeignKeyConstraint(["faction_id"], ["factions.id"]),
-            sa.ForeignKeyConstraint(["quest_id"], ["quests.id"]),
-            comment="Per-faction quest progress instance",
+            sa.ForeignKeyConstraint(["hook_id"], ["hooks.id"]),
+            comment="Per-faction hook progress (replaces FactionQuest).",
             info=_INFO,
         )
 
-    if "ix_fq_faction" not in _existing_index_names("faction_quests"):
-        op.create_index("ix_fq_faction", "faction_quests", ["faction_id"])
-
-    if not _has_table("person_objectives"):
-        op.create_table(
-            "person_objectives",
-            sa.Column("id", sa.String(36), nullable=False),
-            sa.Column("person_id", sa.String(36), nullable=True),
-            sa.Column("objective_id", sa.String(36), nullable=True),
-            sa.Column("status", sa.String(32), nullable=True),
-            sa.Column("progress", sa.Float(), nullable=True),
-            sa.Column("completed_at", sa.DateTime(), nullable=True),
-            sa.Column("created_at", sa.DateTime(), nullable=False),
-            sa.Column("created_by_user_id", sa.String(36), nullable=True),
-            sa.Column("updated_at", sa.DateTime(), nullable=True),
-            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
-            sa.Column("deleted_at", sa.DateTime(), nullable=True),
-            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
-            sa.PrimaryKeyConstraint("id"),
-            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
-            sa.ForeignKeyConstraint(["objective_id"], ["objectives.id"]),
-            comment="Per-person objective progress instance",
-            info=_INFO,
-        )
-
-    if "ix_po_person" not in _existing_index_names("person_objectives"):
-        op.create_index("ix_po_person", "person_objectives", ["person_id"])
+    if "ix_fh_faction" not in _existing_index_names("faction_hooks"):
+        op.create_index("ix_fh_faction", "faction_hooks", ["faction_id"])
 
     # ---------------------------------------------------------------
     # Inject Faction endpoints onto the relationships table, relax
     # nullability on the default Person endpoints, and add the
-    # endpoint-XOR CHECK constraint. Owned by rpg_state via _INFO.
+    # endpoint-XOR CHECK constraints.
     # ---------------------------------------------------------------
     rel_cols = _existing_column_names("relationships")
     with op.batch_alter_table("relationships") as batch_op:
@@ -624,14 +616,12 @@ def upgrade() -> None:
                     comment="Object-side Faction endpoint (rpg_state)",
                 )
             )
-        # Both Person endpoints become nullable; existence enforced by the
-        # endpoint-XOR CHECK below rather than per-column NOT NULL.
-        batch_op.alter_column("person_id", existing_type=sa.String(36), nullable=True)
+        batch_op.alter_column(
+            "person_id", existing_type=sa.String(36), nullable=True
+        )
         batch_op.alter_column(
             "target_person_id", existing_type=sa.String(36), nullable=True
         )
-        # Endpoint XOR: exactly one endpoint per side.
-        # Boolean-as-int trick is portable across SQLite, Postgres, MySQL.
         batch_op.create_check_constraint(
             "ck_relationships_subject_xor",
             "((person_id IS NOT NULL) + (faction_id IS NOT NULL)) = 1",
@@ -653,8 +643,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Drop CHECKs and faction columns from relationships, restore
-    # NOT NULL on Person endpoints.
     rel_idx = _existing_index_names("relationships")
     for name in ("ix_rel_target_faction", "ix_rel_subject_faction"):
         if name in rel_idx:
@@ -662,12 +650,8 @@ def downgrade() -> None:
 
     rel_cols = _existing_column_names("relationships")
     with op.batch_alter_table("relationships") as batch_op:
-        batch_op.drop_constraint(
-            "ck_relationships_target_xor", type_="check"
-        )
-        batch_op.drop_constraint(
-            "ck_relationships_subject_xor", type_="check"
-        )
+        batch_op.drop_constraint("ck_relationships_target_xor", type_="check")
+        batch_op.drop_constraint("ck_relationships_subject_xor", type_="check")
         if "target_faction_id" in rel_cols:
             batch_op.drop_column("target_faction_id")
         if "faction_id" in rel_cols:
@@ -679,18 +663,24 @@ def downgrade() -> None:
             "person_id", existing_type=sa.String(36), nullable=False
         )
 
-    # Drop rpg_state-owned tables in reverse dependency order.
     for tbl in (
-        "person_objectives",
-        "faction_quests",
-        "person_quests",
-        "objectives",
-        "quests",
+        "faction_hooks",
+        "person_hooks",
+        "hook_dependencies",
+        "hooks",
     ):
         if _has_table(tbl):
             op.drop_table(tbl)
 
-    # Break the Location ↔ ItemInstance cycle before dropping.
+    # Break the deferred FKs before dropping referenced tables.
+    if _has_table("person_traits"):
+        with op.batch_alter_table("person_traits") as batch_op:
+            try:
+                batch_op.drop_constraint(
+                    "fk_person_traits_source_item_instance", type_="foreignkey"
+                )
+            except Exception:
+                pass
     if _has_table("locations"):
         with op.batch_alter_table("locations") as batch_op:
             try:
@@ -705,8 +695,8 @@ def downgrade() -> None:
         "items",
         "locations",
         "factions",
-        "person_status_effects",
         "person_traits",
+        "derivative_traits",
     ):
         if _has_table(tbl):
             op.drop_table(tbl)
@@ -718,12 +708,6 @@ def downgrade() -> None:
             if col in person_cols:
                 batch_op.drop_column(col)
 
-    for tbl in (
-        "status_effect_traits",
-        "status_effects",
-        "traits",
-        "campaigns",
-        "game_systems",
-    ):
+    for tbl in ("traits", "campaigns", "game_systems"):
         if _has_table(tbl):
             op.drop_table(tbl)

--- a/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
@@ -130,7 +130,9 @@ def upgrade() -> None:
             name VARCHAR(255),
             description TEXT,
             kind VARCHAR(64),
-            level INTEGER,
+            -- progression (level / XP / etc.) lives in the Trait catalog,
+            -- joined via character_traits, so each system can pick its
+            -- own dimensions; see traits.kind conventions.
             campaign_id VARCHAR(36),
             user_id VARCHAR(36),
             created_at TIMESTAMP NOT NULL,

--- a/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
+++ b/src/serverframework/extensions/rpg_state/migrations/versions/001_initial.py
@@ -1,475 +1,729 @@
-"""Initial migration for rpg_state — owns the present-state tables.
+"""Initial migration for rpg_state.
 
-Schema is loose (no SQL FK constraints) to match existing extension
-migrations (acl_rbac, metadata, auth_invitations). Referential integrity
-is enforced at the ORM/manager layer via ``Reference.Optional`` mixins.
+Hard-depends on ``genealogy``. This migration:
 
-Cyclic relationship resolved by the loose schema:
-- locations.container_item_instance_id → item_instances.id
-- item_instances.location_id           → locations.id
+1. Injects the RPG character columns (``kind``, ``campaign_id``,
+   ``user_id``) onto the ``persons`` table via ``op.add_column``. The
+   ``persons`` table becomes the character table for RPG users.
+2. Injects Faction endpoints (``faction_id``, ``target_faction_id``)
+   onto the ``relationships`` table, relaxes nullability on the
+   default Person endpoints, and adds a CHECK constraint enforcing
+   endpoint XOR (exactly one endpoint per side).
+3. Creates the rpg_state-owned tables: game_systems, campaigns, traits,
+   status_effects, status_effect_traits, person_traits,
+   person_status_effects, factions, locations, items, item_instances,
+   quests, objectives, person_quests, faction_quests, person_objectives.
+
+Foreign keys are enforced at the database layer where the references
+are stable. The cyclic Location ↔ ItemInstance reference (a satchel's
+interior is a Location whose ``container_item_instance_id`` points at
+the satchel ItemInstance) is resolved by adding the
+``container_item_instance_id`` and ``location_id`` FKs after both
+tables exist.
 """
 
+from typing import Sequence, Union
+
+import sqlalchemy as sa
 from alembic import op
 
 
-revision = "001_rpg_state_initial"
-down_revision = None
-branch_labels = ("rpg_state",)
-depends_on = None
+revision: str = "001_rpg_state_initial"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = ("rpg_state",)
+depends_on: Union[str, Sequence[str], None] = None
+
+_INFO = {
+    "source_module": "serverframework.extensions.rpg_state.BLL_RPGState",
+    "extension": "rpg_state",
+}
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _existing_index_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table)}
+
+
+def _existing_column_names(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if not inspector.has_table(table):
+        return set()
+    return {col["name"] for col in inspector.get_columns(table)}
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS game_systems (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # game_systems
+    # ---------------------------------------------------------------
+    if not _has_table("game_systems"):
+        op.create_table(
+            "game_systems",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            comment="Reference catalog of supported RPG systems",
+            info=_INFO,
         )
-        """
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS campaigns (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            game_system_id VARCHAR(36),
-            user_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # campaigns
+    # ---------------------------------------------------------------
+    if not _has_table("campaigns"):
+        op.create_table(
+            "campaigns",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("game_system_id", sa.String(36), nullable=True),
+            sa.Column("user_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["game_system_id"], ["game_systems.id"]),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+            comment="Top-level campaign owning all in-game state. user_id = GM/owner.",
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_campaigns_user ON campaigns(user_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS traits (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            kind VARCHAR(64),
-            game_system_id VARCHAR(36),
-            campaign_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
-        )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_traits_kind ON traits(kind)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_traits_system ON traits(game_system_id)"
-    )
+    if "ix_campaigns_user" not in _existing_index_names("campaigns"):
+        op.create_index("ix_campaigns_user", "campaigns", ["user_id"])
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS status_effects (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            default_duration_seconds INTEGER,
-            game_system_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # traits
+    # ---------------------------------------------------------------
+    if not _has_table("traits"):
+        op.create_table(
+            "traits",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("kind", sa.String(64), nullable=True),
+            sa.Column("game_system_id", sa.String(36), nullable=True),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["game_system_id"], ["game_systems.id"]),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            comment="Unified property catalog (attributes, skills, spells, talents, feats, resources, progression).",
+            info=_INFO,
         )
-        """
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS status_effect_traits (
-            id VARCHAR(36) PRIMARY KEY,
-            status_effect_id VARCHAR(36),
-            trait_id VARCHAR(36),
-            operation VARCHAR(32),
-            value REAL,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
-        )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_set_effect ON status_effect_traits(status_effect_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_set_trait ON status_effect_traits(trait_id)"
-    )
+    traits_idx = _existing_index_names("traits")
+    if "ix_traits_kind" not in traits_idx:
+        op.create_index("ix_traits_kind", "traits", ["kind"])
+    if "ix_traits_system" not in traits_idx:
+        op.create_index("ix_traits_system", "traits", ["game_system_id"])
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS characters (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            kind VARCHAR(64),
-            -- progression (level / XP / etc.) lives in the Trait catalog,
-            -- joined via character_traits, so each system can pick its
-            -- own dimensions; see traits.kind conventions.
-            campaign_id VARCHAR(36),
-            user_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # status_effects + status_effect_traits
+    # ---------------------------------------------------------------
+    if not _has_table("status_effects"):
+        op.create_table(
+            "status_effects",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("default_duration_seconds", sa.Integer(), nullable=True),
+            sa.Column("game_system_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["game_system_id"], ["game_systems.id"]),
+            comment="Status effect templates (buffs, debuffs, conditions, damage).",
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_characters_campaign ON characters(campaign_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_characters_user ON characters(user_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS character_traits (
-            id VARCHAR(36) PRIMARY KEY,
-            character_id VARCHAR(36),
-            trait_id VARCHAR(36),
-            value REAL,
-            rank INTEGER,
-            notes TEXT,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    if not _has_table("status_effect_traits"):
+        op.create_table(
+            "status_effect_traits",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("status_effect_id", sa.String(36), nullable=True),
+            sa.Column("trait_id", sa.String(36), nullable=True),
+            sa.Column("operation", sa.String(32), nullable=True),
+            sa.Column("value", sa.Float(), nullable=True),
+            sa.Column("qualifier", sa.String(255), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["status_effect_id"], ["status_effects.id"]),
+            sa.ForeignKeyConstraint(["trait_id"], ["traits.id"]),
+            comment="Per-trait modifiers contributed by a StatusEffect template.",
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_ct_character ON character_traits(character_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_ct_trait ON character_traits(trait_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS character_status_effects (
-            id VARCHAR(36) PRIMARY KEY,
-            character_id VARCHAR(36),
-            status_effect_id VARCHAR(36),
-            started_at TIMESTAMP,
-            expires_at TIMESTAMP,
-            source_character_id VARCHAR(36),
-            source_item_instance_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    set_idx = _existing_index_names("status_effect_traits")
+    if "ix_set_effect" not in set_idx:
+        op.create_index(
+            "ix_set_effect", "status_effect_traits", ["status_effect_id"]
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cse_character "
-        "ON character_status_effects(character_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cse_active "
-        "ON character_status_effects(character_id, expires_at)"
-    )
+    if "ix_set_trait" not in set_idx:
+        op.create_index("ix_set_trait", "status_effect_traits", ["trait_id"])
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS factions (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            parent_id VARCHAR(36),
-            campaign_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # Inject character columns onto persons table.
+    # genealogy owns the table; rpg_state owns these columns.
+    # ---------------------------------------------------------------
+    person_cols = _existing_column_names("persons")
+    if "kind" not in person_cols:
+        op.add_column(
+            "persons",
+            sa.Column(
+                "kind",
+                sa.String(64),
+                nullable=True,
+                comment="pc|npc|monster|creature|vehicle|construct|... (rpg_state)",
+            ),
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_factions_campaign ON factions(campaign_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_factions_parent ON factions(parent_id)"
-    )
+    if "campaign_id" not in person_cols:
+        op.add_column(
+            "persons",
+            sa.Column(
+                "campaign_id",
+                sa.String(36),
+                sa.ForeignKey("campaigns.id"),
+                nullable=True,
+                comment="Campaign this actor belongs to (rpg_state)",
+            ),
+        )
+    if "user_id" not in person_cols:
+        op.add_column(
+            "persons",
+            sa.Column(
+                "user_id",
+                sa.String(36),
+                sa.ForeignKey("users.id"),
+                nullable=True,
+                comment="Controlling player; NULL = NPC (rpg_state)",
+            ),
+        )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS character_factions (
-            id VARCHAR(36) PRIMARY KEY,
-            character_id VARCHAR(36),
-            faction_id VARCHAR(36),
-            role VARCHAR(64),
-            reputation REAL,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
-        )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cf_character ON character_factions(character_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cf_faction ON character_factions(faction_id)"
-    )
+    persons_idx = _existing_index_names("persons")
+    if "ix_persons_campaign" not in persons_idx:
+        op.create_index("ix_persons_campaign", "persons", ["campaign_id"])
+    if "ix_persons_user" not in persons_idx:
+        op.create_index("ix_persons_user", "persons", ["user_id"])
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS locations (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            parent_id VARCHAR(36),
-            campaign_id VARCHAR(36),
-            container_item_instance_id VARCHAR(36),
-            associated_character_id VARCHAR(36),
-            kind VARCHAR(64),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # person_traits
+    # ---------------------------------------------------------------
+    if not _has_table("person_traits"):
+        op.create_table(
+            "person_traits",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("person_id", sa.String(36), nullable=True),
+            sa.Column("trait_id", sa.String(36), nullable=True),
+            sa.Column("value", sa.Float(), nullable=True),
+            sa.Column("rank", sa.Integer(), nullable=True),
+            sa.Column("notes", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["trait_id"], ["traits.id"]),
+            comment="Per-person base trait values.",
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_locations_campaign ON locations(campaign_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_locations_parent ON locations(parent_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_locations_container "
-        "ON locations(container_item_instance_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_locations_character "
-        "ON locations(associated_character_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS items (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            game_system_id VARCHAR(36),
-            weight REAL,
-            base_value REAL,
-            stack_size INTEGER DEFAULT 1,
-            kind VARCHAR(64),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
-        )
-        """
-    )
+    pt_idx = _existing_index_names("person_traits")
+    if "ix_pt_person" not in pt_idx:
+        op.create_index("ix_pt_person", "person_traits", ["person_id"])
+    if "ix_pt_trait" not in pt_idx:
+        op.create_index("ix_pt_trait", "person_traits", ["trait_id"])
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS item_instances (
-            id VARCHAR(36) PRIMARY KEY,
-            item_id VARCHAR(36),
-            location_id VARCHAR(36),
-            owner_character_id VARCHAR(36),
-            owner_faction_id VARCHAR(36),
-            quantity INTEGER DEFAULT 1,
-            durability REAL,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # person_status_effects
+    # ---------------------------------------------------------------
+    if not _has_table("person_status_effects"):
+        op.create_table(
+            "person_status_effects",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("person_id", sa.String(36), nullable=True),
+            sa.Column("status_effect_id", sa.String(36), nullable=True),
+            sa.Column("started_at", sa.DateTime(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+            sa.Column("source_person_id", sa.String(36), nullable=True),
+            sa.Column("source_item_instance_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["status_effect_id"], ["status_effects.id"]),
+            sa.ForeignKeyConstraint(["source_person_id"], ["persons.id"]),
+            comment="Active StatusEffect attachments per person.",
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_ii_location ON item_instances(location_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_ii_owner_char "
-        "ON item_instances(owner_character_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_ii_owner_faction "
-        "ON item_instances(owner_faction_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS quests (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            campaign_id VARCHAR(36),
-            giver_faction_id VARCHAR(36),
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    pse_idx = _existing_index_names("person_status_effects")
+    if "ix_pse_person" not in pse_idx:
+        op.create_index("ix_pse_person", "person_status_effects", ["person_id"])
+    if "ix_pse_active" not in pse_idx:
+        op.create_index(
+            "ix_pse_active",
+            "person_status_effects",
+            ["person_id", "expires_at"],
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_quests_campaign ON quests(campaign_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS objectives (
-            id VARCHAR(36) PRIMARY KEY,
-            name VARCHAR(255),
-            description TEXT,
-            quest_id VARCHAR(36),
-            prerequisite_objective_id VARCHAR(36),
-            order_index INTEGER,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # factions
+    # ---------------------------------------------------------------
+    if not _has_table("factions"):
+        op.create_table(
+            "factions",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("parent_id", sa.String(36), nullable=True),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["parent_id"], ["factions.id"]),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            comment=(
+                "Hierarchical faction (parent_id self-FK fast-path for the "
+                "primary tree). Membership lives in relationships(kind='member_of')."
+            ),
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_objectives_quest ON objectives(quest_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS character_quests (
-            id VARCHAR(36) PRIMARY KEY,
-            character_id VARCHAR(36),
-            quest_id VARCHAR(36),
-            status VARCHAR(32),
-            accepted_at TIMESTAMP,
-            completed_at TIMESTAMP,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
-        )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cq_character ON character_quests(character_id)"
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_cq_status "
-        "ON character_quests(character_id, status)"
-    )
+    fac_idx = _existing_index_names("factions")
+    if "ix_factions_campaign" not in fac_idx:
+        op.create_index("ix_factions_campaign", "factions", ["campaign_id"])
+    if "ix_factions_parent" not in fac_idx:
+        op.create_index("ix_factions_parent", "factions", ["parent_id"])
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS faction_quests (
-            id VARCHAR(36) PRIMARY KEY,
-            faction_id VARCHAR(36),
-            quest_id VARCHAR(36),
-            status VARCHAR(32),
-            accepted_at TIMESTAMP,
-            completed_at TIMESTAMP,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    # ---------------------------------------------------------------
+    # locations  (cyclic FK with item_instances; resolved post-create)
+    # ---------------------------------------------------------------
+    if not _has_table("locations"):
+        op.create_table(
+            "locations",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("parent_id", sa.String(36), nullable=True),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            # FK on container_item_instance_id is added post-create,
+            # after item_instances exists, to break the cycle.
+            sa.Column("container_item_instance_id", sa.String(36), nullable=True),
+            sa.Column("associated_person_id", sa.String(36), nullable=True),
+            sa.Column("kind", sa.String(64), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["parent_id"], ["locations.id"]),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            sa.ForeignKeyConstraint(["associated_person_id"], ["persons.id"]),
+            comment=(
+                "Recursive spatial node. Equipment is a Location bound to "
+                "a person via associated_person_id; equipping is a move."
+            ),
+            info=_INFO,
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_fq_faction ON faction_quests(faction_id)"
-    )
 
-    op.execute(
-        """
-        CREATE TABLE IF NOT EXISTS character_objectives (
-            id VARCHAR(36) PRIMARY KEY,
-            character_id VARCHAR(36),
-            objective_id VARCHAR(36),
-            status VARCHAR(32),
-            progress REAL,
-            completed_at TIMESTAMP,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP,
-            deleted_at TIMESTAMP,
-            created_by_user_id VARCHAR(36),
-            updated_by_user_id VARCHAR(36),
-            deleted_by_user_id VARCHAR(36)
+    loc_idx = _existing_index_names("locations")
+    if "ix_locations_campaign" not in loc_idx:
+        op.create_index("ix_locations_campaign", "locations", ["campaign_id"])
+    if "ix_locations_parent" not in loc_idx:
+        op.create_index("ix_locations_parent", "locations", ["parent_id"])
+    if "ix_locations_container" not in loc_idx:
+        op.create_index(
+            "ix_locations_container",
+            "locations",
+            ["container_item_instance_id"],
         )
-        """
-    )
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_co_character "
-        "ON character_objectives(character_id)"
-    )
+    if "ix_locations_person" not in loc_idx:
+        op.create_index(
+            "ix_locations_person", "locations", ["associated_person_id"]
+        )
+
+    # ---------------------------------------------------------------
+    # items + item_instances
+    # ---------------------------------------------------------------
+    if not _has_table("items"):
+        op.create_table(
+            "items",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("game_system_id", sa.String(36), nullable=True),
+            sa.Column("weight", sa.Float(), nullable=True),
+            sa.Column("base_value", sa.Float(), nullable=True),
+            sa.Column("stack_size", sa.Integer(), nullable=True, server_default="1"),
+            sa.Column("kind", sa.String(64), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["game_system_id"], ["game_systems.id"]),
+            comment="Item template (catalog).",
+            info=_INFO,
+        )
+
+    if not _has_table("item_instances"):
+        op.create_table(
+            "item_instances",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("item_id", sa.String(36), nullable=True),
+            sa.Column("location_id", sa.String(36), nullable=True),
+            sa.Column("owner_person_id", sa.String(36), nullable=True),
+            sa.Column("owner_faction_id", sa.String(36), nullable=True),
+            sa.Column("quantity", sa.Integer(), nullable=True, server_default="1"),
+            sa.Column("durability", sa.Float(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["item_id"], ["items.id"]),
+            sa.ForeignKeyConstraint(["location_id"], ["locations.id"]),
+            sa.ForeignKeyConstraint(["owner_person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["owner_faction_id"], ["factions.id"]),
+            comment=(
+                "Per-instance item row. owner_* = assignment / "
+                "responsibility / who-would-notice-missing — distinct "
+                "from equipping (which is spatial via location_id)."
+            ),
+            info=_INFO,
+        )
+
+    ii_idx = _existing_index_names("item_instances")
+    if "ix_ii_location" not in ii_idx:
+        op.create_index("ix_ii_location", "item_instances", ["location_id"])
+    if "ix_ii_owner_person" not in ii_idx:
+        op.create_index(
+            "ix_ii_owner_person", "item_instances", ["owner_person_id"]
+        )
+    if "ix_ii_owner_faction" not in ii_idx:
+        op.create_index(
+            "ix_ii_owner_faction", "item_instances", ["owner_faction_id"]
+        )
+
+    # Close the Location ↔ ItemInstance cycle: add the FK now that both
+    # tables exist. Use batch_alter_table for SQLite compatibility.
+    with op.batch_alter_table("locations") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_locations_container_item_instance",
+            "item_instances",
+            ["container_item_instance_id"],
+            ["id"],
+        )
+
+    # ---------------------------------------------------------------
+    # quests + objectives
+    # ---------------------------------------------------------------
+    if not _has_table("quests"):
+        op.create_table(
+            "quests",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("campaign_id", sa.String(36), nullable=True),
+            sa.Column("giver_faction_id", sa.String(36), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["campaign_id"], ["campaigns.id"]),
+            sa.ForeignKeyConstraint(["giver_faction_id"], ["factions.id"]),
+            comment="Quest template",
+            info=_INFO,
+        )
+
+    if "ix_quests_campaign" not in _existing_index_names("quests"):
+        op.create_index("ix_quests_campaign", "quests", ["campaign_id"])
+
+    if not _has_table("objectives"):
+        op.create_table(
+            "objectives",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("name", sa.String(255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("quest_id", sa.String(36), nullable=True),
+            sa.Column("prerequisite_objective_id", sa.String(36), nullable=True),
+            sa.Column("order_index", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["quest_id"], ["quests.id"]),
+            sa.ForeignKeyConstraint(
+                ["prerequisite_objective_id"], ["objectives.id"]
+            ),
+            comment="Objective template; chains via prerequisite_objective_id.",
+            info=_INFO,
+        )
+
+    if "ix_objectives_quest" not in _existing_index_names("objectives"):
+        op.create_index("ix_objectives_quest", "objectives", ["quest_id"])
+
+    # ---------------------------------------------------------------
+    # person_quests + faction_quests + person_objectives
+    # ---------------------------------------------------------------
+    if not _has_table("person_quests"):
+        op.create_table(
+            "person_quests",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("person_id", sa.String(36), nullable=True),
+            sa.Column("quest_id", sa.String(36), nullable=True),
+            sa.Column("status", sa.String(32), nullable=True),
+            sa.Column("accepted_at", sa.DateTime(), nullable=True),
+            sa.Column("completed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["quest_id"], ["quests.id"]),
+            comment="Per-person quest progress instance",
+            info=_INFO,
+        )
+
+    pq_idx = _existing_index_names("person_quests")
+    if "ix_pq_person" not in pq_idx:
+        op.create_index("ix_pq_person", "person_quests", ["person_id"])
+    if "ix_pq_status" not in pq_idx:
+        op.create_index(
+            "ix_pq_status", "person_quests", ["person_id", "status"]
+        )
+
+    if not _has_table("faction_quests"):
+        op.create_table(
+            "faction_quests",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("faction_id", sa.String(36), nullable=True),
+            sa.Column("quest_id", sa.String(36), nullable=True),
+            sa.Column("status", sa.String(32), nullable=True),
+            sa.Column("accepted_at", sa.DateTime(), nullable=True),
+            sa.Column("completed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["faction_id"], ["factions.id"]),
+            sa.ForeignKeyConstraint(["quest_id"], ["quests.id"]),
+            comment="Per-faction quest progress instance",
+            info=_INFO,
+        )
+
+    if "ix_fq_faction" not in _existing_index_names("faction_quests"):
+        op.create_index("ix_fq_faction", "faction_quests", ["faction_id"])
+
+    if not _has_table("person_objectives"):
+        op.create_table(
+            "person_objectives",
+            sa.Column("id", sa.String(36), nullable=False),
+            sa.Column("person_id", sa.String(36), nullable=True),
+            sa.Column("objective_id", sa.String(36), nullable=True),
+            sa.Column("status", sa.String(32), nullable=True),
+            sa.Column("progress", sa.Float(), nullable=True),
+            sa.Column("completed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.Column("created_by_user_id", sa.String(36), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(36), nullable=True),
+            sa.Column("deleted_at", sa.DateTime(), nullable=True),
+            sa.Column("deleted_by_user_id", sa.String(36), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(["person_id"], ["persons.id"]),
+            sa.ForeignKeyConstraint(["objective_id"], ["objectives.id"]),
+            comment="Per-person objective progress instance",
+            info=_INFO,
+        )
+
+    if "ix_po_person" not in _existing_index_names("person_objectives"):
+        op.create_index("ix_po_person", "person_objectives", ["person_id"])
+
+    # ---------------------------------------------------------------
+    # Inject Faction endpoints onto the relationships table, relax
+    # nullability on the default Person endpoints, and add the
+    # endpoint-XOR CHECK constraint. Owned by rpg_state via _INFO.
+    # ---------------------------------------------------------------
+    rel_cols = _existing_column_names("relationships")
+    with op.batch_alter_table("relationships") as batch_op:
+        if "faction_id" not in rel_cols:
+            batch_op.add_column(
+                sa.Column(
+                    "faction_id",
+                    sa.String(36),
+                    sa.ForeignKey("factions.id"),
+                    nullable=True,
+                    comment="Subject-side Faction endpoint (rpg_state)",
+                )
+            )
+        if "target_faction_id" not in rel_cols:
+            batch_op.add_column(
+                sa.Column(
+                    "target_faction_id",
+                    sa.String(36),
+                    sa.ForeignKey("factions.id"),
+                    nullable=True,
+                    comment="Object-side Faction endpoint (rpg_state)",
+                )
+            )
+        # Both Person endpoints become nullable; existence enforced by the
+        # endpoint-XOR CHECK below rather than per-column NOT NULL.
+        batch_op.alter_column("person_id", existing_type=sa.String(36), nullable=True)
+        batch_op.alter_column(
+            "target_person_id", existing_type=sa.String(36), nullable=True
+        )
+        # Endpoint XOR: exactly one endpoint per side.
+        # Boolean-as-int trick is portable across SQLite, Postgres, MySQL.
+        batch_op.create_check_constraint(
+            "ck_relationships_subject_xor",
+            "((person_id IS NOT NULL) + (faction_id IS NOT NULL)) = 1",
+        )
+        batch_op.create_check_constraint(
+            "ck_relationships_target_xor",
+            "((target_person_id IS NOT NULL) + (target_faction_id IS NOT NULL)) = 1",
+        )
+
+    rel_idx = _existing_index_names("relationships")
+    if "ix_rel_subject_faction" not in rel_idx:
+        op.create_index(
+            "ix_rel_subject_faction", "relationships", ["faction_id"]
+        )
+    if "ix_rel_target_faction" not in rel_idx:
+        op.create_index(
+            "ix_rel_target_faction", "relationships", ["target_faction_id"]
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE IF EXISTS character_objectives")
-    op.execute("DROP TABLE IF EXISTS faction_quests")
-    op.execute("DROP TABLE IF EXISTS character_quests")
-    op.execute("DROP TABLE IF EXISTS objectives")
-    op.execute("DROP TABLE IF EXISTS quests")
-    op.execute("DROP TABLE IF EXISTS item_instances")
-    op.execute("DROP TABLE IF EXISTS items")
-    op.execute("DROP TABLE IF EXISTS locations")
-    op.execute("DROP TABLE IF EXISTS character_factions")
-    op.execute("DROP TABLE IF EXISTS factions")
-    op.execute("DROP TABLE IF EXISTS character_status_effects")
-    op.execute("DROP TABLE IF EXISTS character_traits")
-    op.execute("DROP TABLE IF EXISTS characters")
-    op.execute("DROP TABLE IF EXISTS status_effect_traits")
-    op.execute("DROP TABLE IF EXISTS status_effects")
-    op.execute("DROP TABLE IF EXISTS traits")
-    op.execute("DROP TABLE IF EXISTS campaigns")
-    op.execute("DROP TABLE IF EXISTS game_systems")
+    # Drop CHECKs and faction columns from relationships, restore
+    # NOT NULL on Person endpoints.
+    rel_idx = _existing_index_names("relationships")
+    for name in ("ix_rel_target_faction", "ix_rel_subject_faction"):
+        if name in rel_idx:
+            op.drop_index(name, table_name="relationships")
+
+    rel_cols = _existing_column_names("relationships")
+    with op.batch_alter_table("relationships") as batch_op:
+        batch_op.drop_constraint(
+            "ck_relationships_target_xor", type_="check"
+        )
+        batch_op.drop_constraint(
+            "ck_relationships_subject_xor", type_="check"
+        )
+        if "target_faction_id" in rel_cols:
+            batch_op.drop_column("target_faction_id")
+        if "faction_id" in rel_cols:
+            batch_op.drop_column("faction_id")
+        batch_op.alter_column(
+            "target_person_id", existing_type=sa.String(36), nullable=False
+        )
+        batch_op.alter_column(
+            "person_id", existing_type=sa.String(36), nullable=False
+        )
+
+    # Drop rpg_state-owned tables in reverse dependency order.
+    for tbl in (
+        "person_objectives",
+        "faction_quests",
+        "person_quests",
+        "objectives",
+        "quests",
+    ):
+        if _has_table(tbl):
+            op.drop_table(tbl)
+
+    # Break the Location ↔ ItemInstance cycle before dropping.
+    if _has_table("locations"):
+        with op.batch_alter_table("locations") as batch_op:
+            try:
+                batch_op.drop_constraint(
+                    "fk_locations_container_item_instance", type_="foreignkey"
+                )
+            except Exception:
+                pass
+
+    for tbl in (
+        "item_instances",
+        "items",
+        "locations",
+        "factions",
+        "person_status_effects",
+        "person_traits",
+    ):
+        if _has_table(tbl):
+            op.drop_table(tbl)
+
+    # Drop injected character columns from persons.
+    person_cols = _existing_column_names("persons")
+    with op.batch_alter_table("persons") as batch_op:
+        for col in ("user_id", "campaign_id", "kind"):
+            if col in person_cols:
+                batch_op.drop_column(col)
+
+    for tbl in (
+        "status_effect_traits",
+        "status_effects",
+        "traits",
+        "campaigns",
+        "game_systems",
+    ):
+        if _has_table(tbl):
+            op.drop_table(tbl)

--- a/src/serverframework/lib/CycleGuard.py
+++ b/src/serverframework/lib/CycleGuard.py
@@ -1,0 +1,181 @@
+"""Cycle detection for parent-chain trees and DAG dependency edges.
+
+Used by managers that own self-referential or many-to-many graph
+relationships (FactionModel.parent_id, LocationModel.parent_id,
+HookDependencyModel parent/child) to reject mutations that would close
+a cycle.
+
+Two kinds of structures are covered:
+
+1. **Single-parent trees** — each node has at most one parent
+   (``parent_id``); the structure is a forest of trees. Use
+   ``would_create_tree_cycle`` to check whether assigning a new parent
+   to a node would close a cycle.
+
+2. **DAGs over many-to-many edges** — nodes connect via a separate
+   edge table (e.g. ``hook_dependencies``), each row a directed edge
+   ``parent → child``; multiple parents per node are allowed but
+   cycles are rejected. Use ``would_create_dag_cycle`` to check
+   whether adding a new edge would close a cycle.
+
+Doctrine: cycle guards are correctness, not granularity. They reject
+logical impossibilities (a Location whose ancestor chain is itself; a
+Hook that prerequisites itself transitively). They do **not** impose
+depth caps — depth is unlimited; only termination is enforced via a
+``max_iterations`` safety bound on the walk.
+
+Usage from a manager hook:
+
+.. code-block:: python
+
+    @hook_bll(FactionManager.update, timing=HookTiming.BEFORE)
+    def faction_no_cycle(context: HookContext):
+        update = context.kwarg("update_data") or context.arg(0)
+        if update is None or not getattr(update, "parent_id", None):
+            return
+        node_id = context.kwarg("id") or context.arg(1)
+
+        def get_parent_id(faction_id: str) -> Optional[str]:
+            row = context.manager.get(id=faction_id)
+            return getattr(row, "parent_id", None) if row else None
+
+        if would_create_tree_cycle(node_id, update.parent_id, get_parent_id):
+            raise CycleGuardError(
+                f"Setting parent_id={update.parent_id} on faction "
+                f"{node_id} would close a cycle."
+            )
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Optional
+
+
+class CycleGuardError(Exception):
+    """Raised when a mutation would close a cycle, or when a walk
+    exceeds ``max_iterations`` (indicating either pre-existing
+    corruption or a malicious / extreme structure)."""
+
+
+def would_create_tree_cycle(
+    node_id: str,
+    candidate_parent_id: Optional[str],
+    get_parent_id: Callable[[str], Optional[str]],
+    max_iterations: int = 256,
+) -> bool:
+    """Return True if setting ``node_id``'s parent to
+    ``candidate_parent_id`` would close a cycle.
+
+    Walks up from ``candidate_parent_id`` following ``get_parent_id``;
+    if the walk reaches ``node_id``, the new edge would create a cycle.
+    Returns False if ``candidate_parent_id`` is None (clearing the
+    parent never creates a cycle) or if the walk reaches a root
+    (parent_id is None).
+
+    Raises ``CycleGuardError`` if the walk exceeds ``max_iterations``
+    (probable pre-existing cycle or corrupted data).
+    """
+    if candidate_parent_id is None:
+        return False
+    if candidate_parent_id == node_id:
+        return True  # self-parent
+    current: Optional[str] = candidate_parent_id
+    visited = set()
+    iterations = 0
+    while current is not None:
+        if iterations >= max_iterations:
+            raise CycleGuardError(
+                f"parent walk from {candidate_parent_id!r} exceeded "
+                f"{max_iterations} iterations — probable pre-existing cycle "
+                f"or corrupt data."
+            )
+        if current == node_id:
+            return True
+        if current in visited:
+            # Pre-existing cycle that doesn't touch node_id; not our
+            # problem here, but signal so callers can repair.
+            raise CycleGuardError(
+                f"pre-existing cycle detected in parent chain "
+                f"starting at {candidate_parent_id!r}."
+            )
+        visited.add(current)
+        iterations += 1
+        current = get_parent_id(current)
+    return False
+
+
+def would_create_dag_cycle(
+    new_parent_id: str,
+    new_child_id: str,
+    get_parents: Callable[[str], Iterable[str]],
+    max_iterations: int = 1024,
+) -> bool:
+    """Return True if adding the directed edge
+    ``new_parent_id → new_child_id`` would close a cycle in the DAG.
+
+    Walks the existing-graph ancestors of ``new_parent_id`` via
+    ``get_parents`` (which returns the set of immediate parents of a
+    node). If the walk encounters ``new_child_id``, the new edge would
+    close a cycle (because there's already a path
+    ``new_child_id → ... → new_parent_id``, and the new edge would
+    extend it back to ``new_child_id``).
+
+    Self-loops (``new_parent_id == new_child_id``) are cycles by
+    definition.
+
+    Raises ``CycleGuardError`` if the walk exceeds ``max_iterations``.
+    """
+    if new_parent_id == new_child_id:
+        return True
+    visited = {new_parent_id}
+    frontier = [new_parent_id]
+    iterations = 0
+    while frontier:
+        if iterations >= max_iterations:
+            raise CycleGuardError(
+                f"ancestor walk from {new_parent_id!r} exceeded "
+                f"{max_iterations} iterations — probable pre-existing cycle "
+                f"or corrupt data."
+            )
+        iterations += 1
+        node = frontier.pop()
+        for parent in get_parents(node):
+            if parent == new_child_id:
+                return True
+            if parent in visited:
+                continue
+            visited.add(parent)
+            frontier.append(parent)
+    return False
+
+
+def detect_existing_tree_cycle(
+    start_id: str,
+    get_parent_id: Callable[[str], Optional[str]],
+    max_iterations: int = 256,
+) -> bool:
+    """Return True if walking up from ``start_id`` reaches ``start_id``
+    again — i.e. an already-corrupt parent chain. Diagnostic-only."""
+    visited = set()
+    current: Optional[str] = start_id
+    iterations = 0
+    while current is not None:
+        if iterations >= max_iterations:
+            raise CycleGuardError(
+                f"parent walk from {start_id!r} exceeded {max_iterations} "
+                f"iterations — probable corruption."
+            )
+        if current in visited:
+            return True
+        visited.add(current)
+        iterations += 1
+        current = get_parent_id(current)
+    return False
+
+
+__all__ = [
+    "CycleGuardError",
+    "would_create_tree_cycle",
+    "would_create_dag_cycle",
+    "detect_existing_tree_cycle",
+]

--- a/src/serverframework/lib/CycleGuard_test.py
+++ b/src/serverframework/lib/CycleGuard_test.py
@@ -1,0 +1,218 @@
+"""Tests for the CycleGuard utility — pure-algorithm coverage."""
+
+from __future__ import annotations
+
+import pytest
+
+from serverframework.lib.CycleGuard import (
+    CycleGuardError,
+    detect_existing_tree_cycle,
+    would_create_dag_cycle,
+    would_create_tree_cycle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tree cycles (single-parent / parent_id chains)
+# ---------------------------------------------------------------------------
+
+
+class TestTreeCycle:
+    def test_no_parent_never_creates_cycle(self):
+        # Clearing the parent (None) never creates a cycle.
+        assert (
+            would_create_tree_cycle(
+                "leaf", None, get_parent_id=lambda _: None
+            )
+            is False
+        )
+
+    def test_self_parent_is_cycle(self):
+        assert (
+            would_create_tree_cycle(
+                "x", "x", get_parent_id=lambda _: None
+            )
+            is True
+        )
+
+    def test_unrelated_chain_is_not_a_cycle(self):
+        # candidate parent is in a separate chain that terminates.
+        parents = {"b": "a", "a": None}
+        assert (
+            would_create_tree_cycle(
+                "leaf", "b", get_parent_id=lambda x: parents.get(x)
+            )
+            is False
+        )
+
+    def test_setting_parent_to_descendant_creates_cycle(self):
+        # node X has child Y has child Z. Setting X.parent = Z would
+        # close a cycle.
+        parents = {"y": "x", "z": "y"}
+        assert (
+            would_create_tree_cycle(
+                "x", "z", get_parent_id=lambda i: parents.get(i)
+            )
+            is True
+        )
+
+    def test_setting_parent_to_grandparent_is_not_a_cycle(self):
+        # node X is a child of Y is a child of Z. Setting X.parent = Z
+        # is just a flatter tree — not a cycle.
+        parents = {"y": "z"}
+        assert (
+            would_create_tree_cycle(
+                "x", "z", get_parent_id=lambda i: parents.get(i)
+            )
+            is False
+        )
+
+    def test_pre_existing_cycle_raises(self):
+        # candidate parent chain loops on itself, not touching node_id.
+        # The guard should refuse rather than spin.
+        parents = {"a": "b", "b": "a"}
+        with pytest.raises(CycleGuardError, match="pre-existing cycle"):
+            would_create_tree_cycle(
+                "leaf", "a", get_parent_id=lambda i: parents.get(i)
+            )
+
+    def test_max_iterations_caps_runaway_walks(self):
+        # An infinite synthetic chain bounded by max_iterations.
+        def get_parent(i: str) -> str:
+            return f"p{int(i[1:]) + 1}"
+
+        with pytest.raises(CycleGuardError, match="exceeded"):
+            would_create_tree_cycle(
+                "x", "p0", get_parent_id=get_parent, max_iterations=10
+            )
+
+    def test_unlimited_depth_within_iteration_budget(self):
+        # 100-deep tree resolves cleanly with the default 256 budget.
+        parents = {f"n{i}": f"n{i + 1}" for i in range(100)}
+        assert (
+            would_create_tree_cycle(
+                "leaf", "n0", get_parent_id=lambda i: parents.get(i)
+            )
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# DAG cycles (many-to-many edges, e.g. hook dependencies)
+# ---------------------------------------------------------------------------
+
+
+class TestDAGCycle:
+    def test_self_loop_is_cycle(self):
+        assert (
+            would_create_dag_cycle("h", "h", get_parents=lambda _: [])
+            is True
+        )
+
+    def test_disconnected_nodes_no_cycle(self):
+        # No existing edges; new edge can't close a cycle.
+        assert (
+            would_create_dag_cycle(
+                "parent", "child", get_parents=lambda _: []
+            )
+            is False
+        )
+
+    def test_simple_chain_no_cycle(self):
+        # Existing: A → B. Adding B → C is fine.
+        parents = {"b": ["a"]}
+        assert (
+            would_create_dag_cycle(
+                "b", "c", get_parents=lambda i: parents.get(i, [])
+            )
+            is False
+        )
+
+    def test_back_edge_creates_cycle(self):
+        # Existing: A → B → C. Adding C → A would close A→B→C→A.
+        # Walking ancestors of new_parent=C: parents(C)=[B], parents(B)=[A].
+        # We hit A which is the new_child_id → cycle.
+        parents = {"c": ["b"], "b": ["a"]}
+        assert (
+            would_create_dag_cycle(
+                "c", "a", get_parents=lambda i: parents.get(i, [])
+            )
+            is True
+        )
+
+    def test_diamond_pattern_no_cycle(self):
+        # Existing: A → B, A → C, B → D, C → D.
+        # Adding D → E is fine.
+        parents = {
+            "b": ["a"],
+            "c": ["a"],
+            "d": ["b", "c"],
+        }
+        assert (
+            would_create_dag_cycle(
+                "d", "e", get_parents=lambda i: parents.get(i, [])
+            )
+            is False
+        )
+
+    def test_multi_parent_back_edge_detected(self):
+        # Existing: A → B, X → B, B → C.
+        # Adding C → A: ancestors of C include B; ancestors of B
+        # include A and X. Hits A → cycle.
+        parents = {
+            "b": ["a", "x"],
+            "c": ["b"],
+        }
+        assert (
+            would_create_dag_cycle(
+                "c", "a", get_parents=lambda i: parents.get(i, [])
+            )
+            is True
+        )
+
+    def test_max_iterations_cap(self):
+        # Pathological get_parents that always yields a fresh ancestor.
+        counter = {"n": 0}
+
+        def get_parents(_: str):
+            counter["n"] += 1
+            return [f"p{counter['n']}"]
+
+        with pytest.raises(CycleGuardError, match="exceeded"):
+            would_create_dag_cycle(
+                "p", "child", get_parents=get_parents, max_iterations=10
+            )
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic: detect_existing_tree_cycle
+# ---------------------------------------------------------------------------
+
+
+class TestDetectExisting:
+    def test_clean_chain_no_cycle(self):
+        parents = {"b": "a", "a": None}
+        assert (
+            detect_existing_tree_cycle(
+                "b", get_parent_id=lambda i: parents.get(i)
+            )
+            is False
+        )
+
+    def test_corrupted_self_loop(self):
+        parents = {"a": "a"}
+        assert (
+            detect_existing_tree_cycle(
+                "a", get_parent_id=lambda i: parents.get(i)
+            )
+            is True
+        )
+
+    def test_corrupted_two_node_loop(self):
+        parents = {"a": "b", "b": "a"}
+        assert (
+            detect_existing_tree_cycle(
+                "a", get_parent_id=lambda i: parents.get(i)
+            )
+            is True
+        )


### PR DESCRIPTION
- Clarify ItemInstance owner semantics: ownership = assignment /
  responsibility / who-would-notice-it-missing. Equipping is a spatial
  concern via equipment-slot Locations bound to a character; the bearer
  may differ from the owner without contradiction. Updated table_comment,
  field descriptions, and the module-level docstring.

- Drop CharacterModel.level. Progression dimensions (level, experience,
  spent_experience, milestones, ...) live in the unified Trait catalog
  as kind='progression' Traits joined via CharacterTrait. Treats level-
  based, XP-based, and milestone-based systems equally first-class.

- Document membership inference: campaign owner = Campaign.user_id (GM);
  player = any user owning a Character with that campaign_id. No
  CampaignMember table. Anything finer goes through acl_rbac.

- Declare acl_rbac as an optional dependency for per-row visibility
  (GM-secret NPCs, hidden quests). rpg_state never carries a visibility
  column; granularity belongs to ACL.

- Make CharacterStatusEffect.Update fully editable so GMs can retcon
  start_at, source_character_id, and source_item_instance_id alongside
  expires_at.

- Document conventional Trait kinds (attribute|skill|spell|talent|feat|
  ability|language|resource|progression) and naming conventions for
  progression Traits.

https://claude.ai/code/session_01UW3G2NUqpDt44gveKfxD1r