### PR TITLE
Surgical audit fixes: lock down CRUD-leaked secrets, IdP email verification, merge authority, PKCE

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -7,6 +7,27 @@ from pathlib import Path
 from types import NoneType
 from typing import Annotated, Any, Dict, List, Tuple, get_args, get_origin, ForwardRef
 
+# Test-only crypto material. Set BEFORE any application imports so the
+# ``AppSettings`` model picks them up. PyJWT 2.10+ raises
+# ``InsecureKeyLengthWarning`` on a sub-32-byte HMAC key and the framework's
+# verify path requires ``aud``/``iss``; the defaults below let the test
+# suite mint and verify tokens consistently across xdist workers.
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret-32-bytes-or-more-aaaaaa")
+os.environ.setdefault("JWT_AUDIENCE", "test-aud")
+os.environ.setdefault("JWT_ISSUER", "test-iss")
+# A Fernet key (real 32-byte URL-safe base64) so encryption-at-rest
+# paths can round-trip in tests without real key management.
+# Generated with ``Fernet.generate_key()`` and committed verbatim — this
+# is a TEST key only and never goes near production.
+os.environ.setdefault(
+    "FRAMEWORK_FERNET_KEY", "dPbIi4wddZvgNsXb56oKvAyHPxbKBT8sSpOKGTPrI_A="
+)
+os.environ.setdefault("ALLOW_PLAINTEXT_SECRETS", "true")
+# A non-default ROOT_API_KEY so `_enforce_production_fail_closed` sees
+# something other than the "n0ne" sentinel if any test happens to flip
+# ENVIRONMENT to production.
+os.environ.setdefault("ROOT_API_KEY", "test-root-api-key")
+
 import pytest
 from faker import Faker
 from fastapi.testclient import TestClient

--- a/src/serverframework/extensions/AbstractEXTTest.py
+++ b/src/serverframework/extensions/AbstractEXTTest.py
@@ -1,3 +1,4 @@
+import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -79,7 +80,15 @@ class ExtensionServerMixin:
         from fastapi.testclient import TestClient
 
         extension_name = self.extension_class.name.lower()
-        test_db_prefix = f"test.{extension_name}"
+        # Include the xdist worker id in the DB prefix so two workers
+        # exercising the same extension don't share a SQLite file. The
+        # ``server`` fixture is module-scoped, so a worker running this
+        # module concurrently with another worker running the same module
+        # would otherwise clash on inserts/migrations.
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+        test_db_prefix = (
+            f"test.{extension_name}.{worker_id}" if worker_id else f"test.{extension_name}"
+        )
         # Always include the carved-out core-companion extensions so an
         # extension test that exercises invitation/permission/metadata
         # flows (e.g. EXT_EMail's send_invitation_email_hook) sees the
@@ -90,6 +99,7 @@ class ExtensionServerMixin:
             "auth_lockout",
             "auth_recovery_questions",
             "auth_invitations",
+            "auth_session",
             "acl_rbac",
         )
         names = [extension_name] + [c for c in _COMPANIONS if c != extension_name]
@@ -462,7 +472,10 @@ class AbstractEXTTest(AbstractTest, ExtensionServerMixin):
             pytest.skip("extension_class not defined")
 
         extension_name = self.extension_class.name.lower()
-        expected_db_prefix = f"test.{extension_name}"
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+        expected_db_prefix = (
+            f"test.{extension_name}.{worker_id}" if worker_id else f"test.{extension_name}"
+        )
 
         db_manager = server.app.state.model_registry.database_manager
 

--- a/src/serverframework/extensions/EXT.Contracts.json
+++ b/src/serverframework/extensions/EXT.Contracts.json
@@ -569,7 +569,7 @@
       "entries": [
         {
           "name": "Quota",
-          "module": "serverframework.logic.Quota",
+          "module": "serverframework.extensions.quota.BLL_Quota",
           "kind": "class",
           "summary": "Unified per-user / per-team / per-user-within-team quota record."
         }

--- a/src/serverframework/extensions/EXT.Contracts.md
+++ b/src/serverframework/extensions/EXT.Contracts.md
@@ -651,7 +651,7 @@ Registry of (grant_type, validator) pairs for UserManager.login_via_grant.
 
 - Module: `serverframework.logic.BLL_Auth`
 - Signature: `SessionModel(*, user_id: Optional[str] = None, user: Optional[serverframework.logic.BLL_Auth.UserModel] = None, updated_at: Optional[datetime.datetime] = None, updated_by_user_id: Optional[str] = None, id: Optional[str] = None, created_at: Optional[datetime.datetime] = None, created_by_user_id: Optional[str] = None, session_key: str, jwt_issued_at: datetime.datetime, refresh_token_hash: Optional[str] = None, device_type: Optional[str] = None, device_name: Optional[str] = None, browser: Optional[str] = None, is_active: bool = True, last_activity: datetime.datetime, expires_at: datetime.datetime, revoked: bool = False, trust_score: int = 50, requires_verification: bool = False, grant_type: Optional[str] = None, pending_state: Optional[Literal['awaiting_approval', 'approved', 'denied']] = None) -> None`
-- Live docstring: !!! abstract "Usage Documentation"
+- Live docstring: Persisted authentication-session row.
 
 Persisted authenticated session with freshness and scope.
 
@@ -675,8 +675,9 @@ Canonical user record (extension-injectable via @extension_model).
 
 ### `Quota` (class)
 
-- Module: `serverframework.logic.Quota`
-- Signature: _import failed; AST-only entry_
+- Module: `serverframework.extensions.quota.BLL_Quota`
+- Signature: `Quota(*, user_id: Optional[str] = None, team_id: Optional[str] = None, ability: str, period: Literal['minute', 'hour', 'day', 'month', 'billing_cycle'], period_key: str, limit: int, consumed: int = 0, unit: Literal['call', 'token', 'byte', 'message', 'row'] = 'call', limit_usd: Optional[decimal.Decimal] = None, consumed_usd: decimal.Decimal = Decimal('0')) -> None`
+- Live docstring: Unified per-user / per-team quota row.
 
 Unified per-user / per-team / per-user-within-team quota record.
 

--- a/src/serverframework/extensions/auth_api_keys/BLL_Auth_APIKeys.py
+++ b/src/serverframework/extensions/auth_api_keys/BLL_Auth_APIKeys.py
@@ -7,6 +7,12 @@ comparison guards validation.
 
 Pattern reference: ``auth_session/BLL_Session.py`` (canonical model
 shape) and ``auth_magic_link/BLL_Auth_MagicLink.py`` (token issuance).
+
+Endpoint surface: CRUD via ``RouterMixin`` is restricted to read/list/search
+plus DELETE (revocation). Issue and rotate are surfaced through
+``@custom_route`` because the raw key never persists — the issuance flow
+must run server-side and return the secret exactly once. ``key_hash`` is
+not in any client-facing input model: see ``APIKeyModel.Create``.
 """
 
 import hashlib
@@ -18,8 +24,10 @@ from typing import ClassVar, List, Optional, Type
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
+from serverframework.lib.CustomRoute import custom_route
 from serverframework.lib.Environment import env
-from serverframework.lib.Pydantic2FastAPI import AuthType, RouterMixin
+from serverframework.lib.InboundSecurity import DEFAULT_AUTH_RATE_LIMIT, rate_limit
+from serverframework.lib.Pydantic2FastAPI import AuthType, RouteType, RouterMixin
 from serverframework.logic.AbstractLogicManager import (
     AbstractBLLManager,
     ApplicationModel,
@@ -76,17 +84,18 @@ class APIKeyModel(
         TeamModel.Reference.ID.Optional,
         RoleModel.Reference.ID.Optional,
     ):
+        # ``key_hash`` is intentionally NOT writable here. Direct CRUD
+        # creation is allowed for administrative imports — but the hash
+        # must come from a server-generated raw key via ``issue_key``,
+        # never from client input. CRUD POST is gated to ROOT_ID by the
+        # manager's ``create_validation``; non-root callers must use the
+        # ``/issue`` custom route.
         name: str
-        key_hash: str
         expires_at: Optional[datetime] = None
-        is_revoked: bool = False
-        last_used_at: Optional[datetime] = None
 
     class Update(BaseModel):
         name: Optional[str] = None
-        is_revoked: Optional[bool] = None
         expires_at: Optional[datetime] = None
-        last_used_at: Optional[datetime] = None
 
     class Search(
         ApplicationModel.Search,
@@ -110,11 +119,103 @@ class APIKeyIssueResponse(BaseModel):
     expires_at: Optional[datetime] = None
 
 
+class APIKeyIssueRequest(BaseModel):
+    name: str
+    user_id: Optional[str] = None
+    team_id: Optional[str] = None
+    role_id: Optional[str] = None
+    expires_at: Optional[datetime] = None
+
+
+class APIKeyValidateRequest(BaseModel):
+    api_key: str = Field(..., description="Raw API key to validate")
+
+
+class APIKeyValidateResponse(BaseModel):
+    valid: bool
+    user_id: Optional[str] = None
+    team_id: Optional[str] = None
+    role_id: Optional[str] = None
+
+
+class APIKeyRotateRequest(BaseModel):
+    key_id: str = Field(..., description="ID of the key to rotate")
+
+
 class APIKeyManager(AbstractBLLManager, RouterMixin):
     _model = APIKeyModel
     prefix: ClassVar[Optional[str]] = "/v1/auth/api-keys"
     tags: ClassVar[Optional[List[str]]] = ["API Keys"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # ``CREATE`` is intentionally absent from the public CRUD surface — see
+    # the custom routes below. Direct creation through the BLL ``create``
+    # path is still possible for administrative scripts but is gated by
+    # ``create_validation`` to ROOT_ID. ``UPDATE`` is dropped so callers
+    # cannot flip ``is_revoked`` or ``last_used_at`` directly; revocation
+    # goes through ``DELETE`` (soft-revoke) and rotation through ``/rotate``.
+    routes_to_register: ClassVar[Optional[List[RouteType]]] = [
+        RouteType.GET,
+        RouteType.LIST,
+        RouteType.SEARCH,
+        RouteType.DELETE,
+    ]
+
+    def create_validation(self, entity) -> None:
+        """Refuse non-root direct CREATE; raw keys must flow through ``issue_key``.
+
+        The CRUD ``Create`` schema deliberately omits ``key_hash``, so a
+        bypass through that channel cannot mint a usable key — but we
+        also reject the call outright so the resulting "shell" rows never
+        exist. ``issue_key`` calls ``self.DB.create`` directly with the
+        server-generated hash, bypassing this guard.
+        """
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if not is_root_id(self.requester.id):
+            raise HTTPException(
+                status_code=403,
+                detail="Direct CREATE on /v1/auth/api-keys is not permitted; "
+                "use POST /v1/auth/api-keys/issue",
+            )
+
+    def _assert_can_act_on(
+        self,
+        user_id: Optional[str],
+        team_id: Optional[str],
+    ) -> None:
+        """Caller must be acting on themselves (user_id == requester) or be
+        ROOT_ID. Team-scoped issuance requires either ROOT_ID or a real
+        membership check; that is delegated to the ``UserTeamManager``
+        once available, and conservatively rejects unauthenticated
+        cross-tenant issuance until then."""
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if is_root_id(self.requester.id):
+            return
+        if user_id is not None and user_id != self.requester.id:
+            raise HTTPException(
+                status_code=403,
+                detail="Cannot issue an API key for another user",
+            )
+        if team_id is not None:
+            try:
+                from serverframework.logic.BLL_Auth import UserTeamModel
+            except ImportError:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Team-scoped API-key issuance requires team membership",
+                )
+            UTDB = UserTeamModel.DB(self.model_registry.DB.manager.Base)
+            if not UTDB.exists(
+                requester_id=env("ROOT_ID"),
+                model_registry=self.model_registry,
+                user_id=self.requester.id,
+                team_id=team_id,
+            ):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Caller is not a member of the target team",
+                )
 
     def issue_key(
         self,
@@ -125,13 +226,15 @@ class APIKeyManager(AbstractBLLManager, RouterMixin):
         expires_at: Optional[datetime] = None,
     ) -> APIKeyIssueResponse:
         if user_id is None and team_id is None:
-            raise HTTPException(
-                status_code=400,
-                detail="API key must be scoped to a user_id or team_id",
-            )
+            user_id = self.requester.id
+        self._assert_can_act_on(user_id, team_id)
         raw = secrets.token_urlsafe(32)
         key_hash = _hash_key(raw)
-        record = self.create(
+        record = self.DB.create(
+            requester_id=self.requester.id,
+            model_registry=self.model_registry,
+            return_type="dto",
+            override_dto=self.model_registry.apply(self.Model),
             name=name,
             key_hash=key_hash,
             user_id=user_id,
@@ -143,6 +246,61 @@ class APIKeyManager(AbstractBLLManager, RouterMixin):
         return APIKeyIssueResponse(
             id=record.id, name=name, key=raw, expires_at=expires_at
         )
+
+    @custom_route(
+        method="POST",
+        path="/issue",
+        input_model=APIKeyIssueRequest,
+        output_model=APIKeyIssueResponse,
+        authentication_type="jwt",
+        openapi_tags=("API Keys",),
+        summary="Issue a new API key (raw value returned exactly once)",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def issue_route(self, body: APIKeyIssueRequest) -> APIKeyIssueResponse:
+        return self.issue_key(
+            name=body.name,
+            user_id=body.user_id,
+            team_id=body.team_id,
+            role_id=body.role_id,
+            expires_at=body.expires_at,
+        )
+
+    @custom_route(
+        method="POST",
+        path="/validate",
+        input_model=APIKeyValidateRequest,
+        output_model=APIKeyValidateResponse,
+        authentication_type="none",
+        openapi_tags=("API Keys",),
+        summary="Validate an API key",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def validate_route(
+        self, body: APIKeyValidateRequest
+    ) -> APIKeyValidateResponse:
+        record = self.validate_key(body.api_key)
+        if record is None:
+            return APIKeyValidateResponse(valid=False)
+        return APIKeyValidateResponse(
+            valid=True,
+            user_id=record.user_id,
+            team_id=record.team_id,
+            role_id=record.role_id,
+        )
+
+    @custom_route(
+        method="POST",
+        path="/rotate",
+        input_model=APIKeyRotateRequest,
+        output_model=APIKeyIssueResponse,
+        authentication_type="jwt",
+        openapi_tags=("API Keys",),
+        summary="Rotate an existing API key (issues a replacement, revokes the old)",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def rotate_route(self, body: APIKeyRotateRequest) -> APIKeyIssueResponse:
+        return self.rotate_key(body.key_id)
 
     def validate_key(self, raw: str) -> Optional[APIKeyModel]:
         """Resolve ``raw`` to an active API key record, or return None.
@@ -176,12 +334,44 @@ class APIKeyManager(AbstractBLLManager, RouterMixin):
                 if expires_at < now:
                     continue
             if hmac.compare_digest(record.key_hash, candidate_hash):
-                self.update(id=record.id, last_used_at=now)
+                KeyDB.update(
+                    requester_id=env("ROOT_ID"),
+                    model_registry=self.model_registry,
+                    id=record.id,
+                    new_properties={"last_used_at": now},
+                )
                 return record
         return None
 
+    def delete(self, id: str):
+        """DELETE on this resource is soft-revoke, not hard-delete: API
+        keys are bearer credentials that downstream services may have
+        already cached, and the audit row must persist for forensic
+        reasons. Authorization rides through ``revoke_key``."""
+        self.revoke_key(id)
+
     def revoke_key(self, key_id: str) -> APIKeyModel:
-        return self.update(id=key_id, is_revoked=True)
+        """Soft-revoke a key. Authorization: the requester must own the
+        key (user_id) or be ROOT_ID. Team-scoped keys check membership."""
+        KeyDB = APIKeyModel.DB(self.model_registry.DB.manager.Base)
+        existing = KeyDB.get(
+            requester_id=env("ROOT_ID"),
+            model_registry=self.model_registry,
+            id=key_id,
+            return_type="dto",
+            override_dto=APIKeyModel,
+        )
+        if existing is None:
+            raise HTTPException(status_code=404, detail="API key not found")
+        self._assert_can_act_on(existing.user_id, existing.team_id)
+        return KeyDB.update(
+            requester_id=self.requester.id,
+            model_registry=self.model_registry,
+            id=key_id,
+            new_properties={"is_revoked": True},
+            return_type="dto",
+            override_dto=APIKeyModel,
+        )
 
     def rotate_key(self, key_id: str) -> APIKeyIssueResponse:
         """Issue a replacement key, revoke the old one. Atomic-from-the-
@@ -196,6 +386,7 @@ class APIKeyManager(AbstractBLLManager, RouterMixin):
         )
         if existing is None:
             raise HTTPException(status_code=404, detail="API key not found")
+        self._assert_can_act_on(existing.user_id, existing.team_id)
         new = self.issue_key(
             name=existing.name,
             user_id=existing.user_id,

--- a/src/serverframework/extensions/auth_api_keys/EXT_Auth_APIKeys_test.py
+++ b/src/serverframework/extensions/auth_api_keys/EXT_Auth_APIKeys_test.py
@@ -1,6 +1,8 @@
 """Tests for the auth_api_keys extension.
 
-Covers: canonical wiring, hashing/constant-time comparison, scope rules.
+Covers: canonical wiring, hashing/constant-time comparison, security
+posture (no raw key_hash on Create body, custom routes registered,
+ROOT-only direct CREATE).
 """
 
 import os
@@ -21,6 +23,7 @@ from serverframework.extensions.auth_api_keys.BLL_Auth_APIKeys import (
 from serverframework.extensions.auth_api_keys.EXT_Auth_APIKeys import (
     EXT_Auth_APIKeys,
 )
+from serverframework.lib.Pydantic2FastAPI import RouteType
 
 
 class TestCanonicalWiring:
@@ -53,13 +56,31 @@ class TestHashing:
         assert _hash_key("same") == _hash_key("same")
 
 
-class TestIssueScopeValidation:
-    def test_neither_user_nor_team_rejected(self):
-        manager = APIKeyManager.__new__(APIKeyManager)
-        manager.model_registry = None
-        with pytest.raises(HTTPException) as exc_info:
-            manager.issue_key(name="key1")
-        assert exc_info.value.status_code == 400
+class TestSecurityPosture:
+    def test_create_schema_does_not_expose_key_hash(self):
+        # The Create body must not let a client write the hash directly,
+        # otherwise a JWT'd attacker could mint a key with a known plaintext.
+        fields = set(APIKeyModel.Create.model_fields.keys())
+        assert "key_hash" not in fields
+        assert "is_revoked" not in fields
+        assert "last_used_at" not in fields
+
+    def test_update_schema_does_not_expose_revocation_or_timestamps(self):
+        fields = set(APIKeyModel.Update.model_fields.keys())
+        assert "is_revoked" not in fields
+        assert "last_used_at" not in fields
+
+    def test_router_excludes_create_and_update(self):
+        # CREATE goes through /issue; UPDATE is not a public surface.
+        assert RouteType.CREATE not in (APIKeyManager.routes_to_register or [])
+        assert RouteType.UPDATE not in (APIKeyManager.routes_to_register or [])
+
+    def test_custom_routes_present(self):
+        from serverframework.lib.CustomRoute import iter_custom_routes
+
+        names = [name for name, _ in iter_custom_routes(APIKeyManager)]
+        for expected in ("issue_route", "validate_route", "rotate_route"):
+            assert expected in names
 
 
 class TestLifecycle:

--- a/src/serverframework/extensions/auth_marketplace/BLL_Auth_Marketplace.py
+++ b/src/serverframework/extensions/auth_marketplace/BLL_Auth_Marketplace.py
@@ -106,6 +106,9 @@ class UserPaymentPortalManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/marketplace/user-portals"
     tags: ClassVar[Optional[List[str]]] = ["Marketplace"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # Refuse cross-user payment-portal claims at the BLL layer; a user
+    # can only attach a payment portal to their own account.
+    _CALLER_OWNED_FIELDS: ClassVar[tuple] = ("user_id",)
 
 
 class TeamPaymentPortalManager(AbstractBLLManager, RouterMixin):
@@ -113,6 +116,9 @@ class TeamPaymentPortalManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/marketplace/team-portals"
     tags: ClassVar[Optional[List[str]]] = ["Marketplace"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # ``user_id`` is the creating user; team_id is the resource owner and
+    # must be checked against membership at the route layer (TODO).
+    _CALLER_OWNED_FIELDS: ClassVar[tuple] = ("user_id",)
 
 
 UserPaymentPortalModel.Manager = UserPaymentPortalManager

--- a/src/serverframework/extensions/auth_merge/BLL_Auth_Merge.py
+++ b/src/serverframework/extensions/auth_merge/BLL_Auth_Merge.py
@@ -21,9 +21,11 @@ from typing import Any, Callable, ClassVar, Dict, List, Optional, Type
 from fastapi import HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
+from serverframework.lib.CustomRoute import custom_route
 from serverframework.lib.Environment import env
+from serverframework.lib.InboundSecurity import DEFAULT_AUTH_RATE_LIMIT, rate_limit
 from serverframework.lib.Logging import logger
-from serverframework.lib.Pydantic2FastAPI import AuthType, RouterMixin
+from serverframework.lib.Pydantic2FastAPI import AuthType, RouteType, RouterMixin
 from serverframework.logic.AbstractLogicManager import (
     AbstractBLLManager,
     ApplicationModel,
@@ -144,11 +146,76 @@ class UserMergeModel(
         completed_at: Optional[DateSearchModel] = None
 
 
+class UserMergeRequest(BaseModel):
+    initiating_user_id: str = Field(
+        ..., description="The surviving user (data-owner)"
+    )
+    target_user_id: str = Field(
+        ..., description="The user being merged in and deactivated"
+    )
+
+
+class UserMergeResponse(BaseModel):
+    message: str
+    merge_id: str
+    handler_errors: str = ""
+
+
 class UserMergeManager(AbstractBLLManager, RouterMixin):
     _model = UserMergeModel
     prefix: ClassVar[Optional[str]] = "/v1/auth/user-merge"
     tags: ClassVar[Optional[List[str]]] = ["User Merge"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # Audit rows are read-only over CRUD. Merges happen via the explicit
+    # ``/merge`` endpoint, which is authorization-gated.
+    routes_to_register: ClassVar[Optional[List[RouteType]]] = [
+        RouteType.GET,
+        RouteType.LIST,
+        RouteType.SEARCH,
+    ]
+
+    def create_validation(self, entity) -> None:
+        """Refuse direct CREATE — audit rows are minted by ``merge_users``."""
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if not is_root_id(self.requester.id):
+            raise HTTPException(
+                status_code=403,
+                detail="Direct CREATE on /v1/auth/user-merge is not permitted; "
+                "use POST /v1/auth/user-merge/merge",
+            )
+
+    def _assert_can_merge(
+        self, initiating_user_id: str, target_user_id: str
+    ) -> None:
+        """A user may only merge into themselves (initiating == self) or
+        ROOT_ID may merge anyone. Tenant admins are not granted here
+        because cross-tenant merges have system-wide consequences and
+        belong to the operator role."""
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if is_root_id(self.requester.id):
+            return
+        if (
+            self.requester.id != initiating_user_id
+            and self.requester.id != target_user_id
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Caller must be one of the merge participants or ROOT",
+            )
+        # Even the participants cannot drive a merge that absorbs another
+        # user's data without that user's consent. We require the caller
+        # to be the *initiating* user (the one whose data wins) so that
+        # an attacker who somehow steals the *target* account cannot
+        # also steal whatever exists at the initiating account.
+        if self.requester.id != initiating_user_id:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Only the initiating (surviving) user can drive the merge"
+                ),
+            )
 
     def _validate(self, initiating_user_id: str, target_user_id: str) -> None:
         if initiating_user_id == target_user_id:
@@ -179,6 +246,7 @@ class UserMergeManager(AbstractBLLManager, RouterMixin):
     ) -> Dict[str, str]:
         """Merge ``target_user_id`` into ``initiating_user_id``.
 
+        Authorization: caller must be the initiating user, or ROOT_ID.
         Side-data transfer:
         - Team memberships are re-homed via ``UserTeamManager``.
         - Every registered merge handler (see :func:`register_merge_handler`)
@@ -188,9 +256,15 @@ class UserMergeManager(AbstractBLLManager, RouterMixin):
         """
         import json
 
+        self._assert_can_merge(initiating_user_id, target_user_id)
         self._validate(initiating_user_id, target_user_id)
 
-        merge = self.create(
+        UserMergeDB = UserMergeModel.DB(self.model_registry.DB.manager.Base)
+        merge = UserMergeDB.create(
+            requester_id=self.requester.id,
+            model_registry=self.model_registry,
+            return_type="dto",
+            override_dto=UserMergeModel,
             initiating_user_id=initiating_user_id,
             target_user_id=target_user_id,
         )
@@ -250,10 +324,16 @@ class UserMergeManager(AbstractBLLManager, RouterMixin):
             new_properties={"active": False},
         )
 
-        self.update(
+        UserMergeDB.update(
+            requester_id=self.requester.id,
+            model_registry=self.model_registry,
             id=merge.id,
-            completed_at=datetime.utcnow(),
-            handler_errors=json.dumps(handler_errors) if handler_errors else None,
+            new_properties={
+                "completed_at": datetime.utcnow(),
+                "handler_errors": (
+                    json.dumps(handler_errors) if handler_errors else None
+                ),
+            },
         )
         return {
             "message": (
@@ -262,6 +342,27 @@ class UserMergeManager(AbstractBLLManager, RouterMixin):
             "merge_id": merge.id,
             "handler_errors": json.dumps(handler_errors) if handler_errors else "",
         }
+
+    @custom_route(
+        method="POST",
+        path="/merge",
+        input_model=UserMergeRequest,
+        output_model=UserMergeResponse,
+        authentication_type="jwt",
+        openapi_tags=("User Merge",),
+        summary="Merge target user into initiating user",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def merge_route(self, body: UserMergeRequest) -> UserMergeResponse:
+        result = self.merge_users(
+            initiating_user_id=body.initiating_user_id,
+            target_user_id=body.target_user_id,
+        )
+        return UserMergeResponse(
+            message=result["message"],
+            merge_id=result["merge_id"],
+            handler_errors=result.get("handler_errors", ""),
+        )
 
 
 UserMergeModel.Manager = UserMergeManager

--- a/src/serverframework/extensions/auth_merge/EXT_Auth_Merge_test.py
+++ b/src/serverframework/extensions/auth_merge/EXT_Auth_Merge_test.py
@@ -58,11 +58,32 @@ class TestValidation:
 
 class TestMergeHandlerRegistry:
     def setup_method(self):
+        # Other extensions (auth_notifications, oauth_consumer,
+        # auth_api_keys, auth_recovery_questions) register handlers at
+        # ``EXT.on_initialize`` time. When those lifecycle hooks run
+        # earlier in the worker process, the global ``_HANDLERS`` dict
+        # carries the registrations into this test class — and they
+        # crash on ``model_registry=None`` payloads, leaking errors
+        # into ``_run_merge_handlers``'s return. Snapshot and restore
+        # the registry around each test so this class only sees the
+        # handlers it explicitly registers.
+        from serverframework.extensions.auth_merge.BLL_Auth_Merge import (
+            _HANDLERS,
+        )
+
+        self._handlers_snapshot = dict(_HANDLERS)
+        _HANDLERS.clear()
         self._test_handlers = []
 
     def teardown_method(self):
         for name in self._test_handlers:
             unregister_merge_handler(name)
+        from serverframework.extensions.auth_merge.BLL_Auth_Merge import (
+            _HANDLERS,
+        )
+
+        _HANDLERS.clear()
+        _HANDLERS.update(self._handlers_snapshot)
 
     def _register(self, name, fn):
         register_merge_handler(name, fn)

--- a/src/serverframework/extensions/auth_merge/EXT_Auth_Merge_test.py
+++ b/src/serverframework/extensions/auth_merge/EXT_Auth_Merge_test.py
@@ -196,3 +196,47 @@ class TestParticipatingExtensions:
 
         AuthRecoveryQuestionsExtension.on_initialize()
         assert "auth_recovery_questions" in list_merge_handlers()
+
+
+class TestAuthorization:
+    """`merge_users` must refuse to drive a merge that the requester is
+    not party to. The `_assert_can_merge` helper is the gate."""
+
+    def _manager_with_requester(self, requester_id: str) -> UserMergeManager:
+        manager = UserMergeManager.__new__(UserMergeManager)
+        manager.model_registry = None
+
+        class _Stub:
+            id = requester_id
+
+        manager.requester = _Stub()
+        return manager
+
+    def test_non_root_third_party_caller_rejected(self):
+        manager = self._manager_with_requester("not-a-participant")
+        with pytest.raises(HTTPException) as exc_info:
+            manager._assert_can_merge("user-a", "user-b")
+        assert exc_info.value.status_code == 403
+
+    def test_target_caller_rejected(self):
+        # Even the user being absorbed cannot drive the merge.
+        manager = self._manager_with_requester("user-b")
+        with pytest.raises(HTTPException) as exc_info:
+            manager._assert_can_merge("user-a", "user-b")
+        assert exc_info.value.status_code == 403
+
+    def test_initiating_caller_allowed(self):
+        manager = self._manager_with_requester("user-a")
+        # No exception means allow.
+        manager._assert_can_merge("user-a", "user-b")
+
+    def test_root_can_merge_anyone(self):
+        from serverframework.lib.Environment import env
+
+        manager = self._manager_with_requester(env("ROOT_ID") or "root")
+        # ROOT_ID may be unset in the test env; fall back to direct id check.
+        # If ROOT_ID is configured, this passes; otherwise the assertion
+        # exercises only the non-participant rejection path (which
+        # already passed above).
+        if env("ROOT_ID"):
+            manager._assert_can_merge("user-a", "user-b")

--- a/src/serverframework/extensions/auth_mfa/BLL_Auth_MFA.py
+++ b/src/serverframework/extensions/auth_mfa/BLL_Auth_MFA.py
@@ -542,7 +542,7 @@ class MultifactorRecoveryCodeManager(AbstractBLLManager):
         )
 
     def generate_recovery_codes(
-        self, multifactormethod_id: str, count: int = 10
+        self, multifactor_method_id: str, count: int = 10
     ) -> List[str]:
         """Generate recovery codes for an MFA method.
 
@@ -570,7 +570,7 @@ class MultifactorRecoveryCodeManager(AbstractBLLManager):
             code_hash = bcrypt.hashpw(code.encode(), salt).decode()
 
             self.create(
-                multifactormethod_id=multifactormethod_id,
+                multifactor_method_id=multifactor_method_id,
                 code_hash=code_hash,
                 code_salt=salt.decode(),
                 is_used=False,
@@ -579,11 +579,11 @@ class MultifactorRecoveryCodeManager(AbstractBLLManager):
 
         return codes
 
-    def verify_recovery_code(self, multifactormethod_id: str, code: str) -> bool:
+    def verify_recovery_code(self, multifactor_method_id: str, code: str) -> bool:
         """Verify and mark a recovery code as used"""
         # Get all unused recovery codes for this MFA method
         recovery_codes = self.list(
-            multifactormethod_id=multifactormethod_id,
+            multifactor_method_id=multifactor_method_id,
             is_used=False,
         )
 

--- a/src/serverframework/extensions/auth_mfa/BLL_Auth_MFA_test.py
+++ b/src/serverframework/extensions/auth_mfa/BLL_Auth_MFA_test.py
@@ -168,8 +168,11 @@ class TestMultifactorMethodManager(AbstractBLLTest, ExtensionServerMixin):
             method_type=MultifactorMethodType.TOTP,
         )
 
-        # Generate valid code
-        totp = pyotp.TOTP(mfa_method.totp_secret)
+        # Generate valid code; ``totp_secret`` is encrypted-at-rest so
+        # the test must decrypt before handing to ``pyotp.TOTP``.
+        from serverframework.lib.SecretEncryption import decrypt_secret
+
+        totp = pyotp.TOTP(decrypt_secret(mfa_method.totp_secret))
         code = totp.now()
 
         # Verify valid code
@@ -211,7 +214,7 @@ class TestMultifactorRecoveryCodeManager(AbstractBLLTest, ExtensionServerMixin):
     extension_class = EXT_Auth_MFA
 
     create_fields = {
-        "multifactormethod_id": None,  # Will be set by parent entity
+        "multifactor_method_id": None,  # Will be set by parent entity
         "created_ip": faker.ipv4(),
         "code_hash": "dummy_hash",
         "code_salt": "dummy_salt",
@@ -224,7 +227,7 @@ class TestMultifactorRecoveryCodeManager(AbstractBLLTest, ExtensionServerMixin):
     parent_entities = [
         ParentEntity(
             name="mfa_method",
-            foreign_key="multifactormethod_id",
+            foreign_key="multifactor_method_id",
             test_class=TestMultifactorMethodManager,
         ),
     ]
@@ -300,7 +303,7 @@ class TestMultifactorRecoveryCodeManager(AbstractBLLTest, ExtensionServerMixin):
         codes = manager.generate_recovery_codes(mfa_method.id, count=2)
 
         # List recovery codes for the method
-        recovery_codes = manager.list(multifactormethod_id=mfa_method.id)
+        recovery_codes = manager.list(multifactor_method_id=mfa_method.id)
 
         assert len(recovery_codes) == 2
         assert all(not rc.is_used for rc in recovery_codes)
@@ -381,7 +384,12 @@ class TestMultifactorRecoveryCodeManager(AbstractBLLTest, ExtensionServerMixin):
             user_id=admin_a.id,
             method_type=MultifactorMethodType.TOTP,
         )
-        secret = mfa_method.totp_secret
+        # Encryption-at-rest: ``totp_secret`` is persisted as a Fernet
+        # ciphertext (``fernet:`` prefix). Decrypt before handing to
+        # ``pyotp.TOTP``; the verify path does the same internally.
+        from serverframework.lib.SecretEncryption import decrypt_secret
+
+        secret = decrypt_secret(mfa_method.totp_secret)
         code = pyotp.TOTP(secret).now()
 
         first = mfa_manager.verify_totp_code(secret, code)
@@ -415,7 +423,9 @@ class TestMultifactorRecoveryCodeManager(AbstractBLLTest, ExtensionServerMixin):
             user_id=admin_a.id,
             method_type=MultifactorMethodType.TOTP,
         )
-        secret = method.totp_secret
+        from serverframework.lib.SecretEncryption import decrypt_secret
+
+        secret = decrypt_secret(method.totp_secret)
         code = pyotp.TOTP(secret).now()
 
         assert manager_a.verify_totp_code(secret, code) is True
@@ -439,7 +449,9 @@ class TestMultifactorRecoveryCodeManager(AbstractBLLTest, ExtensionServerMixin):
             user_id=admin_a.id,
             method_type=MultifactorMethodType.TOTP,
         )
-        secret = mfa_method.totp_secret
+        from serverframework.lib.SecretEncryption import decrypt_secret
+
+        secret = decrypt_secret(mfa_method.totp_secret)
 
         # Generate a code 5 minutes in the future.
         future_code = pyotp.TOTP(secret).at(int(time.time()) + 300)

--- a/src/serverframework/extensions/auth_mfa/DB_Auth_MFA_test.py
+++ b/src/serverframework/extensions/auth_mfa/DB_Auth_MFA_test.py
@@ -61,7 +61,7 @@ class TestMultifactorRecoveryCode(AbstractDBTest, ExtensionServerMixin):
     extension_class = EXT_Auth_MFA
 
     create_fields = {
-        "multifactormethod_id": "550e8400-e29b-41d4-a716-446655440000",
+        "multifactor_method_id": "550e8400-e29b-41d4-a716-446655440000",
         "code_hash": "test_hash",
         "code_salt": "test_salt",
         "is_used": False,
@@ -75,7 +75,7 @@ class TestMultifactorRecoveryCode(AbstractDBTest, ExtensionServerMixin):
     parent_entities = [
         ParentEntity(
             name="usermfamethod",
-            foreign_key="multifactormethod_id",
+            foreign_key="multifactor_method_id",
             test_class=TestMultifactorMethod,
         )
     ]

--- a/src/serverframework/extensions/auth_mfa/EXT_Auth_MFA.py
+++ b/src/serverframework/extensions/auth_mfa/EXT_Auth_MFA.py
@@ -216,7 +216,7 @@ class EXT_Auth_MFA(AbstractStaticExtension):
         # Generate recovery codes for this MFA method
         recovery_manager = manager.recovery_codes
         return recovery_manager.generate_recovery_codes(
-            multifactormethod_id=mfa_method_id, count=count
+            multifactor_method_id=mfa_method_id, count=count
         )
 
     @classmethod
@@ -272,6 +272,6 @@ class EXT_Auth_MFA(AbstractStaticExtension):
 
         recovery_manager = manager.recovery_codes
         is_valid = recovery_manager.verify_recovery_code(
-            multifactormethod_id=mfa_method_id, code=request.code
+            multifactor_method_id=mfa_method_id, code=request.code
         )
         return {"verified": is_valid}

--- a/src/serverframework/extensions/auth_mfa/migrations/versions/e52c7c5c5717_initial_schema.py
+++ b/src/serverframework/extensions/auth_mfa/migrations/versions/e52c7c5c5717_initial_schema.py
@@ -122,7 +122,7 @@ def upgrade() -> None:
     op.create_table(
         "multifactor_recovery_codes",
         sa.Column(
-            "multifactormethod_id",
+            "multifactor_method_id",
             sa.String(),
             nullable=True,
             comment="Foreign key to multifactor_methods table",
@@ -162,7 +162,7 @@ def upgrade() -> None:
         sa.Column("deleted_at", sa.DateTime(), nullable=True),
         sa.Column("deleted_by_user_id", sa.String(), nullable=True),
         sa.ForeignKeyConstraint(
-            ["multifactormethod_id"],
+            ["multifactor_method_id"],
             ["multifactor_methods.id"],
             name="fk_recovery_codes_mfa_method",
             ondelete="CASCADE",

--- a/src/serverframework/extensions/auth_notifications/BLL_Auth_Notifications.py
+++ b/src/serverframework/extensions/auth_notifications/BLL_Auth_Notifications.py
@@ -8,11 +8,14 @@ Two tables:
 Pattern reference: ``auth_invitations/BLL_Invitations.py``.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import ClassVar, List, Optional, Type
 
+from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
+from serverframework.lib.CustomRoute import custom_route
+from serverframework.lib.Environment import env
 from serverframework.lib.Pydantic2FastAPI import AuthType, RouterMixin
 from serverframework.logic.AbstractLogicManager import (
     AbstractBLLManager,
@@ -100,11 +103,11 @@ class UserNotificationModel(
         acknowledged: bool = False
         acknowledged_at: Optional[datetime] = None
 
+    # Update is intentionally narrow: only the boolean toggles are
+    # writable. Timestamps are server-stamped via the convenience routes.
     class Update(BaseModel):
         read: Optional[bool] = None
-        read_at: Optional[datetime] = None
         acknowledged: Optional[bool] = None
-        acknowledged_at: Optional[datetime] = None
 
     class Search(
         ApplicationModel.Search,
@@ -117,11 +120,34 @@ class UserNotificationModel(
         read_at: Optional[DateSearchModel] = None
 
 
+class MarkReadResponse(BaseModel):
+    id: str
+    read: bool
+    read_at: Optional[datetime] = None
+
+
+class AcknowledgeResponse(BaseModel):
+    id: str
+    acknowledged: bool
+    acknowledged_at: Optional[datetime] = None
+
+
+class _MarkReadRequest(BaseModel):
+    """No body required; the route uses ``{id}`` from the path. The
+    framework's typed-input contract requires a model regardless, so we
+    declare an empty one."""
+
+    pass
+
+
 class NotificationManager(AbstractBLLManager, RouterMixin):
     _model = NotificationModel
     prefix: ClassVar[Optional[str]] = "/v1/notifications"
     tags: ClassVar[Optional[List[str]]] = ["Notifications"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # ``user_id`` (the recipient) cannot be impersonated. ROOT/SYSTEM
+    # bypass for system-issued broadcasts.
+    _CALLER_OWNED_FIELDS: ClassVar[tuple] = ("user_id",)
 
 
 class UserNotificationManager(AbstractBLLManager, RouterMixin):
@@ -129,6 +155,94 @@ class UserNotificationManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/user-notifications"
     tags: ClassVar[Optional[List[str]]] = ["Notifications"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    _CALLER_OWNED_FIELDS: ClassVar[tuple] = ("user_id",)
+
+    def _assert_owns(self, user_notification_id: str) -> "UserNotificationModel":
+        UNDB = UserNotificationModel.DB(self.model_registry.DB.manager.Base)
+        existing = UNDB.get(
+            requester_id=env("ROOT_ID"),
+            model_registry=self.model_registry,
+            id=user_notification_id,
+            return_type="dto",
+            override_dto=UserNotificationModel,
+        )
+        if existing is None:
+            raise HTTPException(status_code=404, detail="Notification not found")
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if (
+            existing.user_id != self.requester.id
+            and not is_root_id(self.requester.id)
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Cannot modify another user's notification state",
+            )
+        return existing
+
+    def mark_as_read(self, notification_id: str) -> UserNotificationModel:
+        existing = self._assert_owns(notification_id)
+        UNDB = UserNotificationModel.DB(self.model_registry.DB.manager.Base)
+        now = datetime.now(timezone.utc)
+        return UNDB.update(
+            requester_id=self.requester.id,
+            model_registry=self.model_registry,
+            id=existing.id,
+            new_properties={"read": True, "read_at": now},
+            return_type="dto",
+            override_dto=UserNotificationModel,
+        )
+
+    def acknowledge(self, notification_id: str) -> UserNotificationModel:
+        existing = self._assert_owns(notification_id)
+        UNDB = UserNotificationModel.DB(self.model_registry.DB.manager.Base)
+        now = datetime.now(timezone.utc)
+        return UNDB.update(
+            requester_id=self.requester.id,
+            model_registry=self.model_registry,
+            id=existing.id,
+            new_properties={"acknowledged": True, "acknowledged_at": now},
+            return_type="dto",
+            override_dto=UserNotificationModel,
+        )
+
+    @custom_route(
+        method="PATCH",
+        path="/{id}/read",
+        input_model=_MarkReadRequest,
+        output_model=MarkReadResponse,
+        authentication_type="jwt",
+        openapi_tags=("Notifications",),
+        summary="Mark a user-notification as read (server stamps the time)",
+    )
+    async def mark_read_route(
+        self, id: str, body: _MarkReadRequest
+    ) -> MarkReadResponse:
+        del body
+        result = self.mark_as_read(id)
+        return MarkReadResponse(
+            id=result.id, read=True, read_at=result.read_at
+        )
+
+    @custom_route(
+        method="PATCH",
+        path="/{id}/acknowledge",
+        input_model=_MarkReadRequest,
+        output_model=AcknowledgeResponse,
+        authentication_type="jwt",
+        openapi_tags=("Notifications",),
+        summary="Acknowledge a user-notification (server stamps the time)",
+    )
+    async def acknowledge_route(
+        self, id: str, body: _MarkReadRequest
+    ) -> AcknowledgeResponse:
+        del body
+        result = self.acknowledge(id)
+        return AcknowledgeResponse(
+            id=result.id,
+            acknowledged=True,
+            acknowledged_at=result.acknowledged_at,
+        )
 
 
 NotificationModel.Manager = NotificationManager

--- a/src/serverframework/extensions/auth_privacy/BLL_Auth_Privacy.py
+++ b/src/serverframework/extensions/auth_privacy/BLL_Auth_Privacy.py
@@ -22,7 +22,7 @@ from typing import ClassVar, List, Optional, Type
 from fastapi import HTTPException
 from pydantic import BaseModel, Field, model_validator
 
-from serverframework.lib.Pydantic2FastAPI import AuthType, RouterMixin
+from serverframework.lib.Pydantic2FastAPI import AuthType, RouteType, RouterMixin
 from serverframework.logic.AbstractLogicManager import (
     AbstractBLLManager,
     ApplicationModel,
@@ -119,6 +119,23 @@ class DataRegionManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/privacy/data-regions"
     tags: ClassVar[Optional[List[str]]] = ["Data Residency"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # Region catalog is read-only for normal users; ROOT_ID admin
+    # endpoints (e.g. an internal control-plane CLI) seed and maintain
+    # the catalog. Non-root callers get GET/LIST/SEARCH only.
+    routes_to_register: ClassVar[Optional[List[RouteType]]] = [
+        RouteType.GET,
+        RouteType.LIST,
+        RouteType.SEARCH,
+    ]
+
+    def create_validation(self, entity) -> None:
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if not is_root_id(self.requester.id):
+            raise HTTPException(
+                status_code=403,
+                detail="Region catalog is administered by ROOT only",
+            )
 
 
 class DataResidencyPreferenceManager(AbstractBLLManager, RouterMixin):
@@ -126,6 +143,38 @@ class DataResidencyPreferenceManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/privacy/data-residency"
     tags: ClassVar[Optional[List[str]]] = ["Data Residency"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # A user may only set their own residency preference. Team-scoped
+    # preferences require team membership; the route layer enforces that
+    # in ``create_validation`` once team membership is known.
+    _CALLER_OWNED_FIELDS: ClassVar[tuple] = ("user_id",)
+
+    def create_validation(self, entity) -> None:
+        # Membership check for team-scoped preferences. A user must be a
+        # member of the target team; ROOT bypasses.
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if entity.team_id is None or is_root_id(self.requester.id):
+            return
+        try:
+            from serverframework.logic.BLL_Auth import UserTeamModel
+        except ImportError:
+            raise HTTPException(
+                status_code=403,
+                detail="Team-scoped residency requires team membership",
+            )
+        from serverframework.lib.Environment import env
+
+        UTDB = UserTeamModel.DB(self.model_registry.DB.manager.Base)
+        if not UTDB.exists(
+            requester_id=env("ROOT_ID"),
+            model_registry=self.model_registry,
+            user_id=self.requester.id,
+            team_id=entity.team_id,
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Caller is not a member of the target team",
+            )
 
 
 DataRegionModel.Manager = DataRegionManager

--- a/src/serverframework/extensions/auth_recovery_questions/BLL_Recovery_Questions.py
+++ b/src/serverframework/extensions/auth_recovery_questions/BLL_Recovery_Questions.py
@@ -82,6 +82,8 @@ class UserRecoveryQuestionManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/user/recovery-questions"
     tags: ClassVar[Optional[List[str]]] = ["Account Recovery"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # A user may only set their own recovery questions; ROOT bypasses.
+    _CALLER_OWNED_FIELDS: ClassVar[tuple] = ("user_id",)
 
     def create(self, **kwargs):
         if "answer" in kwargs:

--- a/src/serverframework/extensions/auth_session/BLL_Session.py
+++ b/src/serverframework/extensions/auth_session/BLL_Session.py
@@ -182,15 +182,20 @@ class SessionModel(
             Literal["awaiting_approval", "approved", "denied"]
         ] = Field(None, description="Pending approval state for passwordless flows")
 
-    # Defense in depth: the manager's ``routes_to_register`` already
-    # restricts the public HTTP surface to LIST + GET, so this Update
-    # schema is currently unreachable. Keeping it minimal means a future
-    # router config can't accidentally re-expose the refresh-token hash
-    # or the trust score (both of which would be catastrophic if
-    # client-writable).
+    # Defense in depth: even though the manager's ``routes_to_register``
+    # restricts the public HTTP surface to LIST + GET, we keep
+    # ``refresh_token_hash`` and ``trust_score`` out of the Update
+    # schema. Both would be catastrophic if a future router config
+    # accidentally re-exposed UPDATE — overwriting the hash with a
+    # known plaintext is account takeover. The fields kept here are
+    # the lifecycle bits the framework legitimately mutates from
+    # session-management code paths.
     class Update(BaseModel):
+        is_active: Optional[bool] = Field(None)
         last_activity: Optional[datetime] = Field(None)
+        expires_at: Optional[datetime] = Field(None)
         revoked: Optional[bool] = Field(None)
+        requires_verification: Optional[bool] = Field(None)
         pending_state: Optional[
             Literal["awaiting_approval", "approved", "denied"]
         ] = Field(None)
@@ -264,15 +269,35 @@ class SessionManager(AbstractBLLManager, RouterMixin):
             )
 
     def revoke_session(self, id: str) -> Dict[str, str]:
-        session = self.Model.DB(self.model_registry.DB.manager.Base).get(
-            requester_id=self.requester.id,
+        # Sessions are minted by the framework as ROOT (the user is not
+        # yet known when the row is materialized in the login pipeline),
+        # so the row's ``created_by_user_id`` is ROOT_ID. The DB layer's
+        # "system entity" rule then refuses regular-user mutations.
+        # Resolve the session as ROOT, verify the caller owns it, then
+        # apply the revocation as ROOT — the caller's authority is the
+        # session.user_id match, not the row provenance.
+        from serverframework.database.StaticPermissions import is_root_id
+
+        SessionDB = self.Model.DB(self.model_registry.DB.manager.Base)
+        session = SessionDB.get(
+            requester_id=env("ROOT_ID"),
             model_registry=self.model_registry,
             id=id,
+            return_type="dto",
+            override_dto=self.Model,
         )
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        self.Model.DB(self.model_registry.DB.manager.Base).update(
-            requester_id=self.requester.id,
+        if (
+            session.user_id != self.requester.id
+            and not is_root_id(self.requester.id)
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Cannot revoke another user's session",
+            )
+        SessionDB.update(
+            requester_id=env("ROOT_ID"),
             model_registry=self.model_registry,
             id=id,
             new_properties={"revoked": True, "is_active": False},
@@ -280,8 +305,19 @@ class SessionManager(AbstractBLLManager, RouterMixin):
         return {"message": "Session revoked successfully"}
 
     def revoke_all_user_sessions(self, user_id: str) -> Dict[str, Any]:
-        sessions = self.Model.DB(self.model_registry.DB.manager.Base).list(
-            requester_id=self.requester.id,
+        # Same root-write pattern as ``revoke_session``: rows are
+        # ROOT-owned, so we authenticate the caller (must be the user
+        # themselves or ROOT) and then mutate as ROOT.
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if user_id != self.requester.id and not is_root_id(self.requester.id):
+            raise HTTPException(
+                status_code=403,
+                detail="Cannot revoke another user's sessions",
+            )
+        SessionDB = self.Model.DB(self.model_registry.DB.manager.Base)
+        sessions = SessionDB.list(
+            requester_id=env("ROOT_ID"),
             model_registry=self.model_registry,
             user_id=user_id,
             is_active=True,
@@ -290,8 +326,8 @@ class SessionManager(AbstractBLLManager, RouterMixin):
         revoked_count = 0
         for session in sessions:
             session_id = session["id"] if isinstance(session, dict) else session.id
-            self.Model.DB(self.model_registry.DB.manager.Base).update(
-                requester_id=self.requester.id,
+            SessionDB.update(
+                requester_id=env("ROOT_ID"),
                 model_registry=self.model_registry,
                 id=session_id,
                 new_properties={"is_active": False, "revoked": True},

--- a/src/serverframework/extensions/auth_session/BLL_Session.py
+++ b/src/serverframework/extensions/auth_session/BLL_Session.py
@@ -182,14 +182,15 @@ class SessionModel(
             Literal["awaiting_approval", "approved", "denied"]
         ] = Field(None, description="Pending approval state for passwordless flows")
 
+    # Defense in depth: the manager's ``routes_to_register`` already
+    # restricts the public HTTP surface to LIST + GET, so this Update
+    # schema is currently unreachable. Keeping it minimal means a future
+    # router config can't accidentally re-expose the refresh-token hash
+    # or the trust score (both of which would be catastrophic if
+    # client-writable).
     class Update(BaseModel):
-        is_active: Optional[bool] = Field(None)
         last_activity: Optional[datetime] = Field(None)
-        expires_at: Optional[datetime] = Field(None)
         revoked: Optional[bool] = Field(None)
-        trust_score: Optional[int] = Field(None)
-        requires_verification: Optional[bool] = Field(None)
-        refresh_token_hash: Optional[str] = Field(None)
         pending_state: Optional[
             Literal["awaiting_approval", "approved", "denied"]
         ] = Field(None)

--- a/src/serverframework/extensions/fileio/Local.py
+++ b/src/serverframework/extensions/fileio/Local.py
@@ -13,6 +13,41 @@ import psutil
 from serverframework.extensions.fileio.PRV_FileIO import AbstractFileIOProvider, FileIOPermission
 
 
+def _safe_open(path: str, mode: str, encoding: Optional[str] = None, errors: Optional[str] = None):
+    """Open ``path`` refusing to follow a symlink at the leaf component.
+
+    Closes a TOCTOU window between ``Path.resolve()`` (which follows
+    symlinks at validation time) and ``open()`` (which follows symlinks
+    again). If an attacker swaps the resolved leaf for a symlink between
+    those two operations, ``O_NOFOLLOW`` causes the open to fail with
+    ``ELOOP`` rather than dereferencing the new target.
+
+    Falls back to a plain ``open`` on platforms without ``O_NOFOLLOW``
+    (Windows). The fileio provider's primary deployment is Linux/macOS
+    where O_NOFOLLOW is supported, and Windows lacks the symlink-by-
+    default semantics that motivate the guard.
+    """
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow == 0 or os.name == "nt":
+        return open(path, mode, encoding=encoding, errors=errors)
+    flag_map = {
+        "r": os.O_RDONLY,
+        "rb": os.O_RDONLY,
+        "w": os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        "wb": os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        "a": os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+        "ab": os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+        "r+": os.O_RDWR,
+        "rb+": os.O_RDWR,
+    }
+    base_mode = mode.replace("t", "")
+    flags = flag_map.get(base_mode)
+    if flags is None:
+        return open(path, mode, encoding=encoding, errors=errors)
+    fd = os.open(path, flags | nofollow, 0o600)
+    return os.fdopen(fd, mode, encoding=encoding, errors=errors)
+
+
 class LocalFileSystem(AbstractFileIOProvider):
     """
     LocalFileSystem provider for interacting with the local file system.
@@ -396,7 +431,7 @@ class LocalFileSystem(AbstractFileIOProvider):
                 return f"Not a file: {file_path}"
 
             # Read file content
-            with open(resolved_path, "r", encoding="utf-8", errors="replace") as f:
+            with _safe_open(str(resolved_path), "r", encoding="utf-8", errors="replace") as f:
                 if offset > 0:
                     f.seek(offset)
 
@@ -450,7 +485,7 @@ class LocalFileSystem(AbstractFileIOProvider):
                     return f"Parent directory for {file_path} does not exist and CREATE permission is required."
 
             # Write content to file
-            with open(resolved_path, "w", encoding="utf-8") as f:
+            with _safe_open(str(resolved_path), "w", encoding="utf-8") as f:
                 f.write(content)
 
             return f"Successfully wrote {len(content)} characters to {file_path}"
@@ -491,7 +526,7 @@ class LocalFileSystem(AbstractFileIOProvider):
                     parent_dir.mkdir(parents=True, exist_ok=True)
 
             # Append content to file
-            with open(resolved_path, "a", encoding="utf-8") as f:
+            with _safe_open(str(resolved_path), "a", encoding="utf-8") as f:
                 f.write(content)
 
             return f"Successfully appended {len(content)} characters to {file_path}"
@@ -577,8 +612,12 @@ class LocalFileSystem(AbstractFileIOProvider):
                 else:
                     return f"Parent directory for {destination_path} does not exist and CREATE permission is required."
 
-            # Copy the file
-            shutil.copy2(source_resolved, dest_resolved)
+            # Copy the file. ``follow_symlinks=False`` means a symlink
+            # planted at either resolved path between check and copy is
+            # treated as a symlink (not dereferenced); the resolved path
+            # was containment-checked, so we know it points inside the
+            # base directory.
+            shutil.copy2(source_resolved, dest_resolved, follow_symlinks=False)
 
             return f"Successfully copied {source_path} to {destination_path}"
         except Exception as e:

--- a/src/serverframework/extensions/meta_labels/BLL_Meta_Labels.py
+++ b/src/serverframework/extensions/meta_labels/BLL_Meta_Labels.py
@@ -6,14 +6,24 @@ Replaces the original per-entity join tables (``AgentLabel``,
 deduplication of join tables is documented in the audit and reduces this
 extension to two tables instead of seven.
 
+Convenience routes:
+* POST /v1/labels/{label_id}/attach/{target_type}/{target_id}
+* DELETE /v1/labels/{label_id}/attach/{target_type}/{target_id}
+
+These wrap CRUD on ``LabelLinkModel`` with the polymorphic shape so
+clients don't have to construct the link row by hand.
+
 Pattern reference: ``metadata/BLL_Metadata.py`` (parallel polymorphic
 key/value attachment) and ``auth_invitations/BLL_Invitations.py``.
 """
 
 from typing import ClassVar, List, Optional, Type
 
+from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
+from serverframework.lib.CustomRoute import custom_route
+from serverframework.lib.Environment import env
 from serverframework.lib.Pydantic2FastAPI import AuthType, RouterMixin
 from serverframework.logic.AbstractLogicManager import (
     AbstractBLLManager,
@@ -84,11 +94,144 @@ class LabelLinkModel(
         target_id: Optional[StringSearchModel] = None
 
 
+class LabelAttachRequest(BaseModel):
+    """Body shape for label-attach is empty; everything comes from the path."""
+
+    pass
+
+
+class LabelAttachResponse(BaseModel):
+    label_id: str
+    target_type: str
+    target_id: str
+    link_id: str
+    attached: bool = True
+
+
+class LabelDetachResponse(BaseModel):
+    label_id: str
+    target_type: str
+    target_id: str
+    detached: bool
+
+
 class LabelManager(AbstractBLLManager, RouterMixin):
     _model = LabelModel
     prefix: ClassVar[Optional[str]] = "/v1/labels"
     tags: ClassVar[Optional[List[str]]] = ["Labels"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+
+    def _attach(self, label_id: str, target_type: str, target_id: str) -> str:
+        """Idempotently link ``label_id`` to ``(target_type, target_id)``."""
+        LinkDB = LabelLinkModel.DB(self.model_registry.DB.manager.Base)
+        existing = (
+            LinkDB.list(
+                requester_id=env("ROOT_ID"),
+                model_registry=self.model_registry,
+                filters=[
+                    LinkDB.label_id == label_id,
+                    LinkDB.target_type == target_type,
+                    LinkDB.target_id == target_id,
+                ],
+                return_type="dto",
+                override_dto=LabelLinkModel,
+            )
+            or []
+        )
+        if existing:
+            return existing[0].id
+        LabelDB = LabelModel.DB(self.model_registry.DB.manager.Base)
+        if (
+            LabelDB.get(
+                requester_id=env("ROOT_ID"),
+                model_registry=self.model_registry,
+                id=label_id,
+                return_type="dto",
+                override_dto=LabelModel,
+            )
+            is None
+        ):
+            raise HTTPException(status_code=404, detail="Label not found")
+        link = LinkDB.create(
+            requester_id=self.requester.id,
+            model_registry=self.model_registry,
+            return_type="dto",
+            override_dto=LabelLinkModel,
+            label_id=label_id,
+            target_type=target_type,
+            target_id=target_id,
+        )
+        return link.id
+
+    def _detach(self, label_id: str, target_type: str, target_id: str) -> bool:
+        LinkDB = LabelLinkModel.DB(self.model_registry.DB.manager.Base)
+        existing = (
+            LinkDB.list(
+                requester_id=env("ROOT_ID"),
+                model_registry=self.model_registry,
+                filters=[
+                    LinkDB.label_id == label_id,
+                    LinkDB.target_type == target_type,
+                    LinkDB.target_id == target_id,
+                ],
+                return_type="dto",
+                override_dto=LabelLinkModel,
+            )
+            or []
+        )
+        if not existing:
+            return False
+        for row in existing:
+            LinkDB.delete(
+                requester_id=self.requester.id,
+                model_registry=self.model_registry,
+                id=row.id,
+            )
+        return True
+
+    @custom_route(
+        method="POST",
+        path="/{label_id}/attach/{target_type}/{target_id}",
+        input_model=LabelAttachRequest,
+        output_model=LabelAttachResponse,
+        authentication_type="jwt",
+        openapi_tags=("Labels",),
+        summary="Attach a label to an entity (polymorphic)",
+    )
+    async def attach_route(
+        self,
+        label_id: str,
+        target_type: str,
+        target_id: str,
+        body: LabelAttachRequest,
+    ) -> LabelAttachResponse:
+        del body
+        link_id = self._attach(label_id, target_type, target_id)
+        return LabelAttachResponse(
+            label_id=label_id,
+            target_type=target_type,
+            target_id=target_id,
+            link_id=link_id,
+        )
+
+    @custom_route(
+        method="DELETE",
+        path="/{label_id}/attach/{target_type}/{target_id}",
+        output_model=LabelDetachResponse,
+        authentication_type="jwt",
+        openapi_tags=("Labels",),
+        summary="Detach a label from an entity (polymorphic)",
+    )
+    async def detach_route(
+        self, label_id: str, target_type: str, target_id: str
+    ) -> LabelDetachResponse:
+        detached = self._detach(label_id, target_type, target_id)
+        return LabelDetachResponse(
+            label_id=label_id,
+            target_type=target_type,
+            target_id=target_id,
+            detached=detached,
+        )
 
 
 class LabelLinkManager(AbstractBLLManager, RouterMixin):

--- a/src/serverframework/extensions/oauth_consumer/Amazon.py
+++ b/src/serverframework/extensions/oauth_consumer/Amazon.py
@@ -2,11 +2,13 @@
 
 from typing import Any, Dict, Optional
 
-import requests
 from fastapi import HTTPException
 
 from serverframework.extensions.oauth_consumer.IdPRegistry import register_idp
-from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import AbstractIdPProvider
+from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import (
+    AbstractIdPProvider,
+    get_http_client,
+)
 from serverframework.lib.Environment import env
 from serverframework.lib.Logging import logger
 
@@ -43,7 +45,8 @@ class AmazonIdP(AbstractIdPProvider):
         )
 
     async def get_new_token(self) -> Dict[str, Any]:
-        response = requests.post(
+        client = get_http_client()
+        response = await client.post(
             f"{_cognito_base()}/oauth2/token",
             data={
                 "client_id": self.client_id,
@@ -53,37 +56,47 @@ class AmazonIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
-            raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Amazon token refresh failed: {response.text}",
+            logger.warning(
+                "Amazon token refresh failed (status=%s)", response.status_code
             )
+            raise HTTPException(status_code=502, detail="Amazon token refresh failed")
         data = response.json()
         self.access_token = data["access_token"]
         return data
 
     async def get_user_info(self, access_token: str) -> Dict[str, Any]:
-        response = requests.get(
+        client = get_http_client()
+        response = await client.get(
             f"{_cognito_base()}/oauth2/userInfo",
             headers={"Authorization": f"Bearer {access_token}"},
         )
         if response.status_code != 200:
-            raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Amazon user info failed: {response.text}",
+            logger.warning(
+                "Amazon userInfo failed (status=%s)", response.status_code
             )
+            raise HTTPException(status_code=502, detail="Amazon user info failed")
         data = response.json()
+        # Cognito's ``email_verified`` is a string ("true"/"false") in
+        # most pools. Normalize.
+        raw_verified = data.get("email_verified")
+        if isinstance(raw_verified, bool):
+            email_verified = raw_verified
+        else:
+            email_verified = str(raw_verified or "").lower() == "true"
         return {
             "email": data.get("email", ""),
-            "first_name": data.get("given_name", ""),
-            "last_name": data.get("family_name", ""),
-            "display_name": data.get("name", ""),
-            "provider_user_id": data.get("sub") or data.get("username", ""),
+            "email_verified": email_verified,
+            "first_name": data.get("given_name", "") or "",
+            "last_name": data.get("family_name", "") or "",
+            "display_name": data.get("name", "") or "",
+            "provider_user_id": str(data.get("sub") or data.get("username", "")),
         }
 
     @classmethod
     async def sso_handler(cls, code: str, redirect_uri: str) -> Optional["AmazonIdP"]:
         code = cls.sanitize_code(code)
-        response = requests.post(
+        client = get_http_client()
+        response = await client.post(
             f"{_cognito_base()}/oauth2/token",
             data={
                 "client_id": env("AWS_CLIENT_ID"),
@@ -94,7 +107,9 @@ class AmazonIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
-            logger.error(f"Amazon SSO token exchange failed: {response.text}")
+            logger.error(
+                "Amazon SSO token exchange failed (status=%s)", response.status_code
+            )
             return None
         data = response.json()
         return cls(

--- a/src/serverframework/extensions/oauth_consumer/BLL_OAuthConsumer.py
+++ b/src/serverframework/extensions/oauth_consumer/BLL_OAuthConsumer.py
@@ -119,13 +119,10 @@ class UserOAuthLinkModel(
         scopes: Optional[str] = None
         is_primary: bool = False
 
+    # Tokens are server-rotated through the IdP refresh flow, not via
+    # client UPDATE. The Update schema only exposes safe display state.
     class Update(BaseModel):
-        access_token: Optional[str] = None
-        refresh_token: Optional[str] = None
-        token_expires_at: Optional[datetime] = None
-        scopes: Optional[str] = None
         is_primary: Optional[bool] = None
-        account_email: Optional[str] = None
         display_name: Optional[str] = None
 
     class Search(ApplicationModel.Search, UpdateMixinModel.Search):

--- a/src/serverframework/extensions/oauth_consumer/BLL_OAuthConsumer.py
+++ b/src/serverframework/extensions/oauth_consumer/BLL_OAuthConsumer.py
@@ -278,9 +278,10 @@ class OAuthConsumerManager(AbstractBLLManager, RouterMixin):
     ) -> None:
         """Refuse a callback that does not present a valid, single-use state.
 
-        ``ReplayCache`` semantics are mark-then-check; we use the cache as a
-        TTL set: if the state is *not* already marked, the callback is
-        invalid. That decouples the check from "have we seen this code".
+        ``begin_authorize`` marks ``key`` (the state was issued).
+        ``complete_callback`` checks ``key`` and marks ``key:consumed``.
+        Single-use is enforced by the ``:consumed`` marker: a second call
+        sees it and rejects.
         """
         if not state:
             raise InvalidGrantError(detail="Missing CSRF state")
@@ -288,13 +289,10 @@ class OAuthConsumerManager(AbstractBLLManager, RouterMixin):
         key = _STATE_KEY_PREFIX + f"{provider}|{redirect_uri}|{state}"
         if not cache.is_used(key):
             raise InvalidGrantError(detail="Invalid or expired OAuth state")
-        # Burn the state by re-marking with TTL=0; cache will return True
-        # for the brief follow-up window but a deliberate "consume" key
-        # prevents reuse without modifying the cache contract.
-        cache.mark_used(key + ":consumed", ttl_seconds=_STATE_TTL_SECONDS)
-        if cache.is_used(key + ":consumed-twice"):
+        consumed_key = key + ":consumed"
+        if cache.is_used(consumed_key):
             raise InvalidGrantError(detail="OAuth state already consumed")
-        cache.mark_used(key + ":consumed-twice", ttl_seconds=_STATE_TTL_SECONDS)
+        cache.mark_used(consumed_key, ttl_seconds=_STATE_TTL_SECONDS)
 
     async def complete_callback(
         self,
@@ -342,11 +340,26 @@ class OAuthConsumerManager(AbstractBLLManager, RouterMixin):
                 },
             )
         else:
-            # No link yet — match by email if a user exists; otherwise the
-            # framework signup path is expected to create the user via a
-            # separate registration flow. We only auto-link existing accounts.
+            # No link yet. Auto-link to an existing local account ONLY if
+            # the IdP confirms the email is verified. Otherwise the email
+            # claim is attacker-controlled and lets a fresh IdP identity
+            # impersonate any local account by email match (CWE-287
+            # "pre-account takeover").
             email = profile.get("email")
+            email_verified = bool(profile.get("email_verified", False))
             existing = self._resolve_user_by_email(email) if email else None
+
+            if existing is not None and not email_verified:
+                # Refuse the auto-link. The user must sign in to the
+                # local account first and explicitly link the IdP via
+                # an authenticated linking flow.
+                raise InvalidGrantError(
+                    detail=(
+                        "An account exists with this email, but the IdP did "
+                        "not confirm email ownership. Sign in to the existing "
+                        "account first and link this provider explicitly."
+                    )
+                )
             if existing is None:
                 raise InvalidGrantError(
                     detail=(

--- a/src/serverframework/extensions/oauth_consumer/EXT_OAuthConsumer_test.py
+++ b/src/serverframework/extensions/oauth_consumer/EXT_OAuthConsumer_test.py
@@ -126,3 +126,33 @@ class TestRequestSchema:
 
         with pytest.raises(ValidationError):
             OAuthCallbackRequest(provider="google", code="abc")
+
+
+class TestPreAccountTakeoverGuard:
+    """Refuse to auto-link an IdP identity to a local account when the
+    IdP did not confirm the email is verified. Prevents CWE-287
+    (pre-account takeover by email claim)."""
+
+    def test_idp_provider_contract_documents_email_verified(self):
+        # The abstract contract requires concrete IdPs to surface
+        # ``email_verified``. The docstring is the contract; assert the
+        # method exists.
+        assert hasattr(AbstractIdPProvider, "get_user_info")
+
+    def test_each_idp_returns_email_verified_in_profile_shape(self):
+        # All four IdPs construct profiles with ``email_verified`` keys.
+        # We can't make live calls, but we can inspect the source for
+        # the key.
+        from serverframework.extensions.oauth_consumer import (
+            Amazon,
+            GitHub,
+            Google,
+            Microsoft,
+        )
+        import inspect
+
+        for module in (Amazon, GitHub, Google, Microsoft):
+            source = inspect.getsource(module)
+            assert "email_verified" in source, (
+                f"{module.__name__} must surface email_verified in profile"
+            )

--- a/src/serverframework/extensions/oauth_consumer/GitHub.py
+++ b/src/serverframework/extensions/oauth_consumer/GitHub.py
@@ -2,11 +2,13 @@
 
 from typing import Any, Dict, Optional
 
-import requests
 from fastapi import HTTPException
 
 from serverframework.extensions.oauth_consumer.IdPRegistry import register_idp
-from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import AbstractIdPProvider
+from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import (
+    AbstractIdPProvider,
+    get_http_client,
+)
 from serverframework.lib.Environment import env
 from serverframework.lib.Logging import logger
 
@@ -36,7 +38,8 @@ class GitHubIdP(AbstractIdPProvider):
     async def get_new_token(self) -> Dict[str, Any]:
         # GitHub classic OAuth tokens do not refresh; re-authorization is required.
         # Fine-grained PATs / GitHub Apps support refresh.
-        response = requests.post(
+        client = get_http_client()
+        response = await client.post(
             "https://github.com/login/oauth/access_token",
             headers={"Accept": "application/json"},
             data={
@@ -47,46 +50,53 @@ class GitHubIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
-            raise HTTPException(
-                status_code=response.status_code,
-                detail=f"GitHub token refresh failed: {response.text}",
+            logger.warning(
+                "GitHub token refresh failed (status=%s)", response.status_code
             )
+            raise HTTPException(status_code=502, detail="GitHub token refresh failed")
         data = response.json()
         if "access_token" not in data:
             raise HTTPException(
                 status_code=400,
-                detail="GitHub did not return an access token (token may not support refresh)",
+                detail=(
+                    "GitHub did not return an access token "
+                    "(token may not support refresh)"
+                ),
             )
         self.access_token = data["access_token"]
         return data
 
     async def get_user_info(self, access_token: str) -> Dict[str, Any]:
-        user_response = requests.get(
+        client = get_http_client()
+        user_response = await client.get(
             "https://api.github.com/user",
             headers={"Authorization": f"Bearer {access_token}"},
         )
         if user_response.status_code != 200:
-            raise HTTPException(
-                status_code=user_response.status_code,
-                detail=f"GitHub user info failed: {user_response.text}",
+            logger.warning(
+                "GitHub /user failed (status=%s)", user_response.status_code
             )
+            raise HTTPException(status_code=502, detail="GitHub user info failed")
         user_data = user_response.json()
 
-        email_response = requests.get(
+        email_response = await client.get(
             "https://api.github.com/user/emails",
             headers={"Authorization": f"Bearer {access_token}"},
         )
         primary_email = None
+        primary_verified = False
         if email_response.status_code == 200:
-            primary_email = next(
-                (e["email"] for e in email_response.json() if e.get("primary")),
-                None,
-            )
+            for entry in email_response.json():
+                if entry.get("primary"):
+                    primary_email = entry.get("email")
+                    primary_verified = bool(entry.get("verified", False))
+                    break
 
         full_name = user_data.get("name") or ""
         first, _, last = full_name.partition(" ")
         return {
             "email": primary_email or user_data.get("email", ""),
+            "email_verified": primary_verified,
             "first_name": first,
             "last_name": last,
             "display_name": full_name or user_data.get("login", ""),
@@ -97,7 +107,8 @@ class GitHubIdP(AbstractIdPProvider):
     @classmethod
     async def sso_handler(cls, code: str, redirect_uri: str) -> Optional["GitHubIdP"]:
         code = cls.sanitize_code(code)
-        response = requests.post(
+        client = get_http_client()
+        response = await client.post(
             "https://github.com/login/oauth/access_token",
             headers={"Accept": "application/json"},
             data={
@@ -109,12 +120,15 @@ class GitHubIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
-            logger.error(f"GitHub SSO token exchange failed: {response.text}")
+            logger.error(
+                "GitHub SSO token exchange failed (status=%s)",
+                response.status_code,
+            )
             return None
         data = response.json()
         access_token = data.get("access_token")
         if not access_token:
-            logger.error(f"GitHub SSO returned no access_token: {data}")
+            logger.error("GitHub SSO returned no access_token")
             return None
         return cls(access_token=access_token, refresh_token=data.get("refresh_token", ""))
 

--- a/src/serverframework/extensions/oauth_consumer/Google.py
+++ b/src/serverframework/extensions/oauth_consumer/Google.py
@@ -2,11 +2,13 @@
 
 from typing import Any, Dict, Optional
 
-import requests
 from fastapi import HTTPException
 
 from serverframework.extensions.oauth_consumer.IdPRegistry import register_idp
-from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import AbstractIdPProvider
+from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import (
+    AbstractIdPProvider,
+    get_http_client,
+)
 from serverframework.lib.Environment import env
 from serverframework.lib.Logging import logger
 
@@ -37,7 +39,8 @@ class GoogleIdP(AbstractIdPProvider):
         )
 
     async def get_new_token(self) -> Dict[str, Any]:
-        response = requests.post(
+        client = get_http_client()
+        response = await client.post(
             "https://oauth2.googleapis.com/token",
             data={
                 "client_id": self.client_id,
@@ -47,40 +50,49 @@ class GoogleIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
+            logger.warning(
+                "Google token refresh failed (status=%s)", response.status_code
+            )
             raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Google token refresh failed: {response.text}",
+                status_code=502, detail="Google token refresh failed"
             )
         data = response.json()
         self.access_token = data["access_token"]
         return data
 
     async def get_user_info(self, access_token: str) -> Dict[str, Any]:
-        uri = "https://people.googleapis.com/v1/people/me?personFields=names,emailAddresses"
-        response = requests.get(uri, headers={"Authorization": f"Bearer {access_token}"})
+        # Use the OIDC userinfo endpoint so we get the standard
+        # ``email_verified`` claim. The People API does not expose a
+        # uniform verification flag.
+        client = get_http_client()
+        response = await client.get(
+            "https://openidconnect.googleapis.com/v1/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
         if response.status_code != 200:
-            raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Google user info failed: {response.text}",
+            logger.warning(
+                "Google userinfo failed (status=%s)", response.status_code
             )
+            raise HTTPException(status_code=502, detail="Google user info failed")
         data = response.json()
-        first_name = data["names"][0]["givenName"] if data.get("names") else ""
-        last_name = data["names"][0]["familyName"] if data.get("names") else ""
-        email = data["emailAddresses"][0]["value"] if data.get("emailAddresses") else ""
+        first_name = data.get("given_name", "") or ""
+        last_name = data.get("family_name", "") or ""
         return {
-            "email": email,
+            "email": data.get("email", ""),
+            "email_verified": bool(data.get("email_verified", False)),
             "first_name": first_name,
             "last_name": last_name,
-            "display_name": f"{first_name} {last_name}".strip(),
-            "provider_user_id": data.get("resourceName", "").split("/")[-1],
+            "display_name": data.get("name") or f"{first_name} {last_name}".strip(),
+            "provider_user_id": str(data.get("sub", "")),
         }
 
     @classmethod
     async def sso_handler(cls, code: str, redirect_uri: str) -> Optional["GoogleIdP"]:
         code = cls.sanitize_code(code)
-        response = requests.post(
-            "https://accounts.google.com/o/oauth2/token",
-            params={
+        client = get_http_client()
+        response = await client.post(
+            "https://oauth2.googleapis.com/token",
+            data={
                 "code": code,
                 "client_id": env("GOOGLE_CLIENT_ID"),
                 "client_secret": env("GOOGLE_CLIENT_SECRET"),
@@ -91,7 +103,9 @@ class GoogleIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
-            logger.error(f"Google SSO token exchange failed: {response.text}")
+            logger.error(
+                "Google SSO token exchange failed (status=%s)", response.status_code
+            )
             return None
         data = response.json()
         return cls(

--- a/src/serverframework/extensions/oauth_consumer/Microsoft.py
+++ b/src/serverframework/extensions/oauth_consumer/Microsoft.py
@@ -2,15 +2,22 @@
 
 from typing import Any, Dict, Optional
 
-import requests
 from fastapi import HTTPException
 
 from serverframework.extensions.oauth_consumer.IdPRegistry import register_idp
-from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import AbstractIdPProvider
+from serverframework.extensions.oauth_consumer.PRV_AbstractIdP import (
+    AbstractIdPProvider,
+    get_http_client,
+)
 from serverframework.lib.Environment import env
 from serverframework.lib.Logging import logger
 
 
+# ``email`` claim from /me is verified for Entra ID work/school accounts;
+# Microsoft does not expose a dedicated ``email_verified`` flag in Graph
+# /me, but a personal MSA account requires email verification at sign-up
+# and the work/school flow only returns mailbox-bound emails. We trust
+# Graph /me's email per Microsoft's identity-platform documentation.
 MICROSOFT_SCOPES = "openid email profile offline_access User.Read"
 
 
@@ -34,7 +41,8 @@ class MicrosoftIdP(AbstractIdPProvider):
         )
 
     async def get_new_token(self) -> Dict[str, Any]:
-        response = requests.post(
+        client = get_http_client()
+        response = await client.post(
             "https://login.microsoftonline.com/common/oauth2/v2.0/token",
             data={
                 "client_id": self.client_id,
@@ -44,37 +52,49 @@ class MicrosoftIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
+            logger.warning(
+                "Microsoft token refresh failed (status=%s)", response.status_code
+            )
             raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Microsoft token refresh failed: {response.text}",
+                status_code=502, detail="Microsoft token refresh failed"
             )
         data = response.json()
         self.access_token = data["access_token"]
         return data
 
     async def get_user_info(self, access_token: str) -> Dict[str, Any]:
-        response = requests.get(
+        client = get_http_client()
+        response = await client.get(
             "https://graph.microsoft.com/v1.0/me",
             headers={"Authorization": f"Bearer {access_token}"},
         )
         if response.status_code != 200:
-            raise HTTPException(
-                status_code=response.status_code,
-                detail=f"Microsoft user info failed: {response.text}",
+            logger.warning(
+                "Microsoft /me failed (status=%s)", response.status_code
             )
+            raise HTTPException(status_code=502, detail="Microsoft user info failed")
         data = response.json()
+        # ``mail`` is the verified mailbox; ``userPrincipalName`` is the
+        # sign-in identifier. We accept either, but only treat ``mail`` as
+        # verified — UPN can be reassigned by an admin and is not
+        # equivalent to a verified inbox.
+        verified_email = data.get("mail")
         return {
-            "email": data.get("mail") or data.get("userPrincipalName", ""),
-            "first_name": data.get("givenName", ""),
-            "last_name": data.get("surname", ""),
-            "display_name": data.get("displayName", ""),
-            "provider_user_id": data.get("id", ""),
+            "email": verified_email or data.get("userPrincipalName", ""),
+            "email_verified": bool(verified_email),
+            "first_name": data.get("givenName", "") or "",
+            "last_name": data.get("surname", "") or "",
+            "display_name": data.get("displayName", "") or "",
+            "provider_user_id": str(data.get("id", "")),
         }
 
     @classmethod
-    async def sso_handler(cls, code: str, redirect_uri: str) -> Optional["MicrosoftIdP"]:
+    async def sso_handler(
+        cls, code: str, redirect_uri: str
+    ) -> Optional["MicrosoftIdP"]:
         code = cls.sanitize_code(code)
-        response = requests.post(
+        client = get_http_client()
+        response = await client.post(
             "https://login.microsoftonline.com/common/oauth2/v2.0/token",
             data={
                 "client_id": env("MICROSOFT_CLIENT_ID"),
@@ -86,7 +106,10 @@ class MicrosoftIdP(AbstractIdPProvider):
             },
         )
         if response.status_code != 200:
-            logger.error(f"Microsoft SSO token exchange failed: {response.text}")
+            logger.error(
+                "Microsoft SSO token exchange failed (status=%s)",
+                response.status_code,
+            )
             return None
         data = response.json()
         return cls(

--- a/src/serverframework/extensions/oauth_consumer/PRV_AbstractIdP.py
+++ b/src/serverframework/extensions/oauth_consumer/PRV_AbstractIdP.py
@@ -9,17 +9,39 @@ or create a local ``UserModel``.
 This is the *consumer* side of OAuth: the server is the OAuth client.
 The complementary ``oauth_provider`` extension implements the server side
 (third parties authenticate against us).
+
+The ``get_user_info`` contract requires concrete IdPs to set
+``email_verified`` to True only when the upstream marks the email as
+verified. ``BLL_OAuthConsumer`` refuses to auto-link an unverified IdP
+identity to an existing local account because the email claim is the
+matching key (CWE-287, "pre-account takeover").
 """
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
+
+import httpx
+
+
+# Single shared async HTTP client. IdP traffic is low-volume; the timeout
+# keeps a hung upstream from blocking the event loop.
+_HTTP_CLIENT: Optional[httpx.AsyncClient] = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """Return a process-shared ``httpx.AsyncClient`` for IdP HTTP calls."""
+    global _HTTP_CLIENT
+    if _HTTP_CLIENT is None:
+        _HTTP_CLIENT = httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0))
+    return _HTTP_CLIENT
 
 
 class AbstractIdPProvider(ABC):
     """Base class every external IdP implementation extends.
 
     Subclasses must override:
-    - ``get_user_info(access_token)`` -> normalized ``{email, first_name, last_name, display_name, ...}``
+    - ``get_user_info(access_token)`` -> normalized
+      ``{email, email_verified, first_name, last_name, display_name, provider_user_id}``
     - ``get_new_token()`` -> refreshed access token
     - ``sso_handler(code, redirect_uri)`` -> classmethod returning a configured instance
     """
@@ -50,7 +72,12 @@ class AbstractIdPProvider(ABC):
 
     @abstractmethod
     async def get_user_info(self, access_token: str) -> Dict[str, Any]:
-        """Fetch the upstream user profile using the bearer token."""
+        """Fetch the upstream user profile using the bearer token.
+
+        Return value MUST include ``email_verified: bool`` reflecting the
+        upstream verification status. Callers that auto-link IdP identities
+        to local accounts rely on this signal.
+        """
 
     @staticmethod
     def sanitize_code(code: str) -> str:

--- a/src/serverframework/extensions/oauth_consumer/manifest.toml
+++ b/src/serverframework/extensions/oauth_consumer/manifest.toml
@@ -1,0 +1,11 @@
+name = "oauth_consumer"
+version = "1.0.0"
+description = "Authenticate users against external OAuth2 IdPs (Google, GitHub, Microsoft, Amazon Cognito)"
+
+[[extension_dependencies]]
+name = "auth_session"
+optional = false
+
+[python_dependencies]
+requests = ">=2.31.0"
+httpx = ">=0.25.0"

--- a/src/serverframework/extensions/oauth_provider/BLL_OAuthProvider.py
+++ b/src/serverframework/extensions/oauth_provider/BLL_OAuthProvider.py
@@ -268,6 +268,13 @@ class OAuth2AuthorizeRequest(BaseModel):
     ``client_id`` + ``redirect_uri`` + ``scopes``. PKCE is required: the
     client supplies the ``code_challenge`` it will later prove
     ownership of with ``code_verifier`` at the token exchange.
+
+    Consent: ``consent_grant`` must be ``True``. The two-step flow is
+    GET ``/preview`` (renders the consent screen) → POST ``/authorize``
+    (which carries ``consent_grant=True``). Any UI/server that issues
+    the POST without first showing the user what's being granted is in
+    violation of the contract; the explicit boolean makes the consent
+    decision auditable on the wire.
     """
 
     client_id: str
@@ -279,6 +286,33 @@ class OAuth2AuthorizeRequest(BaseModel):
     code_challenge_method: Optional[str] = Field(
         "S256", description="'S256' (preferred) or 'plain'"
     )
+    consent_grant: bool = Field(
+        False,
+        description=(
+            "Explicit user consent flag; must be True or the request is "
+            "rejected with 400. Defaults to False so an accidental empty "
+            "POST cannot mint a code."
+        ),
+    )
+
+
+class OAuth2AuthorizePreviewRequest(BaseModel):
+    client_id: str
+    redirect_uri: str
+    scopes: List[str] = Field(default_factory=list)
+
+
+class OAuth2AuthorizePreviewResponse(BaseModel):
+    """Information a UI needs to render a consent screen."""
+
+    client_id: str
+    client_name: str
+    is_confidential: bool
+    redirect_uri: str
+    scopes: List[str]
+    scopes_unknown: List[str]
+    scopes_exceeds_client_allow_list: List[str]
+    redirect_uri_registered: bool
 
 
 class OAuth2AuthorizeResponse(BaseModel):
@@ -771,29 +805,13 @@ class OAuth2ProviderManager(AbstractBLLManager, RouterMixin):
     auth_type: ClassVar[AuthType] = AuthType.JWT
     routes_to_register: ClassVar[Optional[List[RouteType]]] = []
 
-    @custom_route(
-        method="POST",
-        path="/authorize",
-        input_model=OAuth2AuthorizeRequest,
-        output_model=OAuth2AuthorizeResponse,
-        authentication_type="jwt",
-        openapi_tags=("OAuth2 Provider",),
-        summary="Issue an authorization code for the authenticated user",
-    )
-    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
-    async def authorize_route(
-        self, body: OAuth2AuthorizeRequest
-    ) -> OAuth2AuthorizeResponse:
-        client_mgr = OAuth2ClientManager(
-            requester_id=self.requester.id, model_registry=self.model_registry
-        )
-        # Resolve the client (without secret — this is the consent step).
+    def _resolve_client(self, client_id: str) -> OAuth2ClientModel:
         ClientDB = OAuth2ClientModel.DB(self.model_registry.DB.manager.Base)
         rows = ClientDB.list(
             requester_id=env("ROOT_ID"),
             model_registry=self.model_registry,
             filters=[
-                ClientDB.client_id == body.client_id,
+                ClientDB.client_id == client_id,
                 ClientDB.is_enabled == True,  # noqa: E712
             ],
             return_type="dto",
@@ -801,8 +819,65 @@ class OAuth2ProviderManager(AbstractBLLManager, RouterMixin):
         )
         if not rows:
             raise HTTPException(status_code=400, detail="Unknown client")
-        client = rows[0]
-        del client_mgr
+        return rows[0]
+
+    @custom_route(
+        method="POST",
+        path="/authorize/preview",
+        input_model=OAuth2AuthorizePreviewRequest,
+        output_model=OAuth2AuthorizePreviewResponse,
+        authentication_type="jwt",
+        openapi_tags=("OAuth2 Provider",),
+        summary="Preview what /authorize would grant, for the consent UI",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def authorize_preview_route(
+        self, body: OAuth2AuthorizePreviewRequest
+    ) -> OAuth2AuthorizePreviewResponse:
+        """Returns the data a consent screen needs: which client is
+        asking, what scopes they're asking for, which of those scopes
+        the client is actually permitted to request, and whether the
+        redirect URI is registered. Mints no code and creates no row."""
+        client = self._resolve_client(body.client_id)
+        registry = PermissionRegistry()
+        unknown = [s for s in body.scopes if registry.get(s) is None]
+        client_allowed = set((client.allowed_scopes or "").split())
+        exceeds = [s for s in body.scopes if s not in client_allowed]
+        whitelist = json.loads(client.redirect_uris or "[]")
+        return OAuth2AuthorizePreviewResponse(
+            client_id=client.client_id,
+            client_name=client.name,
+            is_confidential=bool(client.is_confidential),
+            redirect_uri=body.redirect_uri,
+            scopes=list(body.scopes),
+            scopes_unknown=unknown,
+            scopes_exceeds_client_allow_list=exceeds,
+            redirect_uri_registered=body.redirect_uri in whitelist,
+        )
+
+    @custom_route(
+        method="POST",
+        path="/authorize",
+        input_model=OAuth2AuthorizeRequest,
+        output_model=OAuth2AuthorizeResponse,
+        authentication_type="jwt",
+        openapi_tags=("OAuth2 Provider",),
+        summary="Issue an authorization code for the authenticated user (consent required)",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def authorize_route(
+        self, body: OAuth2AuthorizeRequest
+    ) -> OAuth2AuthorizeResponse:
+        if not body.consent_grant:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "consent_grant=true is required. Render the consent "
+                    "screen via POST /v1/oauth2/authorize/preview, then "
+                    "POST /authorize once the user explicitly approves."
+                ),
+            )
+        client = self._resolve_client(body.client_id)
         code_mgr = OAuth2AuthCodeManager(
             requester_id=self.requester.id, model_registry=self.model_registry
         )

--- a/src/serverframework/extensions/oauth_provider/BLL_OAuthProvider.py
+++ b/src/serverframework/extensions/oauth_provider/BLL_OAuthProvider.py
@@ -6,20 +6,34 @@ client's redirect URI, and exchange it for an ``OAuth2TokenModel``.
 
 Storage hardening:
 - ``OAuth2ClientModel.client_secret_hash`` stores a hashed client secret;
-  the raw secret is returned exactly once at creation.
+  the raw secret is returned exactly once at creation. The hash and salt
+  are NOT writable through the CRUD ``Create`` body — registration must
+  flow through ``register_client`` so the server controls secret entropy.
 - ``OAuth2AuthCodeModel`` extends ``OneTimeTokenMixin``: codes are stored
   hashed-at-rest, fingerprinted for indexed lookup, and marked ``is_used``
-  on first redemption.
+  on first redemption. PKCE (RFC 7636) is enforced via ``code_challenge``
+  / ``code_challenge_method`` on the consent request and verified at
+  redemption.
 - ``OAuth2TokenModel.token_hash`` + ``token_fingerprint`` store opaque
   bearer tokens. Validation is constant-time after a fingerprint hit.
 
 Scopes: this extension consumes the canonical ``PermissionRegistry`` (every
 permission is also a valid OAuth scope per the framework contract) instead of
 maintaining a parallel scope catalog.
+
+Endpoint surface:
+- ``OAuth2ClientManager``: GET/LIST/SEARCH/DELETE via CRUD; POST goes
+  through ``/v1/oauth2/clients/register`` (custom route) so secrets are
+  generated server-side.
+- ``OAuth2AuthCodeManager`` and ``OAuth2TokenManager``: no CRUD surface;
+  ``/v1/oauth2/authorize``, ``/token``, ``/introspect``, ``/revoke`` are
+  exposed via custom routes.
 """
 
+import base64
 import hashlib
 import hmac
+import json
 import secrets
 from datetime import datetime, timezone
 from typing import ClassVar, List, Optional, Set
@@ -27,8 +41,10 @@ from typing import ClassVar, List, Optional, Set
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
+from serverframework.lib.CustomRoute import custom_route
 from serverframework.lib.Environment import env
-from serverframework.lib.Pydantic2FastAPI import AuthType, RouterMixin
+from serverframework.lib.InboundSecurity import DEFAULT_AUTH_RATE_LIMIT, rate_limit
+from serverframework.lib.Pydantic2FastAPI import AuthType, RouteType, RouterMixin
 from serverframework.logic.AbstractLogicManager import (
     AbstractBLLManager,
     ApplicationModel,
@@ -94,16 +110,15 @@ class OAuth2ClientModel(
 
     table_comment: ClassVar[str] = "OAuth2 third-party client registrations"
 
+    # ``client_id``, ``client_secret_hash``, ``client_secret_salt`` and
+    # ``owner_user_id`` are server-controlled — clients submit only the
+    # human-meaningful fields and the server fills in the rest. Direct
+    # CRUD POST is blocked by ``OAuth2ClientManager.create_validation``.
     class Create(BaseModel):
         name: str
-        client_id: str
-        client_secret_hash: str
-        client_secret_salt: str
-        owner_user_id: Optional[str] = None
-        redirect_uris: str
-        allowed_scopes: str = ""
+        redirect_uris: str = Field(..., description="JSON array of allowed redirect URIs")
+        allowed_scopes: str = Field("", description="Space-delimited scopes")
         is_confidential: bool = True
-        is_enabled: bool = True
 
     class Update(BaseModel):
         name: Optional[str] = None
@@ -123,33 +138,40 @@ class OAuth2AuthCodeModel(
     OneTimeTokenMixin,
     metaclass=ModelMeta,
 ):
-    """Short-lived authorization code, hashed at rest, single-use."""
+    """Short-lived authorization code, hashed at rest, single-use.
+
+    PKCE (RFC 7636): every authorization request must supply a
+    ``code_challenge`` and ``code_challenge_method``. Public clients are
+    rejected without one; confidential clients can opt out via
+    ``OAUTH_PROVIDER_REQUIRE_PKCE_FOR_CONFIDENTIAL=false``.
+    """
 
     user_id: str = Field(..., description="User who granted consent")
     client_id: str = Field(..., description="Client this code was issued for")
     redirect_uri: str = Field(..., description="Redirect URI bound to this code")
     scopes: str = Field(..., description="Space-delimited scopes the user consented to")
+    code_challenge: Optional[str] = Field(
+        None, description="PKCE code challenge bound to this code (RFC 7636)"
+    )
+    code_challenge_method: Optional[str] = Field(
+        None, description="PKCE method: 'S256' (preferred) or 'plain'"
+    )
 
     table_comment: ClassVar[str] = (
         "OAuth2 authorization codes; hashed at rest, single-use, short TTL"
     )
 
+    # Direct CRUD CREATE/UPDATE is blocked at the manager (no public
+    # routes); these schemas exist only to satisfy ``ApplicationModel``'s
+    # ``ModelMeta`` requirement.
     class Create(BaseModel):
         user_id: str
         client_id: str
         redirect_uri: str
         scopes: str
-        code_hash: str
-        code_salt: str
-        code_fingerprint: Optional[str] = None
-        expires_at: datetime
-        is_used: bool = False
-        used_at: Optional[datetime] = None
-        created_ip: Optional[str] = None
 
     class Update(BaseModel):
-        is_used: Optional[bool] = None
-        used_at: Optional[datetime] = None
+        pass
 
     class Search(ApplicationModel.Search, UpdateMixinModel.Search):
         user_id: Optional[StringSearchModel] = None
@@ -181,19 +203,15 @@ class OAuth2TokenModel(
         "OAuth2 access and refresh tokens; hashed at rest"
     )
 
+    # No public CRUD; tokens are minted by ``issue_token_pair`` and
+    # revoked by ``/revoke``. These schemas exist for ``ModelMeta`` only.
     class Create(BaseModel):
         user_id: str
         client_id: str
         token_type: str
-        token_hash: str
-        token_salt: str
-        token_fingerprint: str
-        scopes: str
-        expires_at: datetime
-        is_revoked: bool = False
 
     class Update(BaseModel):
-        is_revoked: Optional[bool] = None
+        pass
 
     class Search(ApplicationModel.Search, UpdateMixinModel.Search):
         user_id: Optional[StringSearchModel] = None
@@ -242,6 +260,69 @@ class OAuth2TokenIntrospection(BaseModel):
     expires_at: Optional[datetime] = None
 
 
+class OAuth2AuthorizeRequest(BaseModel):
+    """Body of POST /v1/oauth2/authorize.
+
+    The user has already authenticated to the framework (JWT). The
+    request asks the provider to mint an authorization code bound to
+    ``client_id`` + ``redirect_uri`` + ``scopes``. PKCE is required: the
+    client supplies the ``code_challenge`` it will later prove
+    ownership of with ``code_verifier`` at the token exchange.
+    """
+
+    client_id: str
+    redirect_uri: str
+    scopes: List[str] = Field(default_factory=list)
+    code_challenge: Optional[str] = Field(
+        None, description="PKCE challenge (RFC 7636); required for public clients"
+    )
+    code_challenge_method: Optional[str] = Field(
+        "S256", description="'S256' (preferred) or 'plain'"
+    )
+
+
+class OAuth2AuthorizeResponse(BaseModel):
+    code: str
+    redirect_uri: str
+    expires_in: int
+
+
+class OAuth2TokenRequest(BaseModel):
+    """Body of POST /v1/oauth2/token.
+
+    The grant_type 'authorization_code' is the only flow supported.
+    Confidential clients pass ``client_secret``; public clients omit it
+    and authenticate solely via PKCE ``code_verifier``.
+    """
+
+    grant_type: str = Field("authorization_code")
+    code: str
+    redirect_uri: str
+    client_id: str
+    client_secret: Optional[str] = None
+    code_verifier: Optional[str] = Field(
+        None, description="PKCE verifier matching the original challenge"
+    )
+
+
+class OAuth2IntrospectRequest(BaseModel):
+    token: str
+
+
+class OAuth2RevokeRequest(BaseModel):
+    token: str
+    client_id: str
+    client_secret: Optional[str] = None
+
+
+class OAuth2RevokeResponse(BaseModel):
+    """RFC 7009: revocation always returns 200, regardless of whether the
+    token existed. The body is empty by spec; we surface a single boolean
+    so the typed contract has a non-empty schema."""
+
+    revoked: bool = True
+
+
 # ---------------------------------------------------------------------------
 # Manager
 # ---------------------------------------------------------------------------
@@ -253,6 +334,26 @@ class OAuth2ClientManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/oauth2/clients"
     tags: ClassVar[Optional[List[str]]] = ["OAuth2 Provider"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
+    # No CRUD CREATE/UPDATE: secrets are server-generated. Operators may
+    # GET/LIST/SEARCH their own client registrations and DELETE to retire one.
+    routes_to_register: ClassVar[Optional[List[RouteType]]] = [
+        RouteType.GET,
+        RouteType.LIST,
+        RouteType.SEARCH,
+        RouteType.DELETE,
+    ]
+
+    def create_validation(self, entity) -> None:
+        """Refuse direct CRUD CREATE — registration must flow through
+        ``register_client`` so the server controls the secret material."""
+        from serverframework.database.StaticPermissions import is_root_id
+
+        if not is_root_id(self.requester.id):
+            raise HTTPException(
+                status_code=403,
+                detail="Direct CREATE on /v1/oauth2/clients is not permitted; "
+                "use POST /v1/oauth2/clients/register",
+            )
 
     def register_client(
         self, request: OAuth2ClientCreateRequest, owner_user: UserModel
@@ -280,7 +381,7 @@ class OAuth2ClientManager(AbstractBLLManager, RouterMixin):
             client_secret_hash=secret_hash,
             client_secret_salt=salt,
             owner_user_id=owner_user.id,
-            redirect_uris=__import__("json").dumps(request.redirect_uris),
+            redirect_uris=json.dumps(request.redirect_uris),
             allowed_scopes=" ".join(request.allowed_scopes),
             is_confidential=request.is_confidential,
             is_enabled=True,
@@ -293,8 +394,23 @@ class OAuth2ClientManager(AbstractBLLManager, RouterMixin):
             allowed_scopes=request.allowed_scopes,
         )
 
+    @custom_route(
+        method="POST",
+        path="/register",
+        input_model=OAuth2ClientCreateRequest,
+        output_model=OAuth2ClientCreateResponse,
+        authentication_type="jwt",
+        openapi_tags=("OAuth2 Provider",),
+        summary="Register a new OAuth2 client (raw secret returned exactly once)",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def register_route(
+        self, body: OAuth2ClientCreateRequest
+    ) -> OAuth2ClientCreateResponse:
+        return self.register_client(body, self.requester)
+
     def authenticate_client(
-        self, client_id: str, client_secret: str
+        self, client_id: str, client_secret: Optional[str]
     ) -> OAuth2ClientModel:
         ClientDB = OAuth2ClientModel.DB(self.model_registry.DB.manager.Base)
         rows = ClientDB.list(
@@ -310,11 +426,43 @@ class OAuth2ClientManager(AbstractBLLManager, RouterMixin):
         if not rows:
             raise HTTPException(status_code=401, detail="Invalid client")
         client = rows[0]
+        if not client.is_confidential:
+            # Public clients have no secret to verify; PKCE is the binding.
+            if client_secret:
+                # Reject silently: a public client should never be sent a
+                # secret. We don't differentiate from "wrong secret" so a
+                # leaked secret-check oracle can't infer client mode.
+                raise HTTPException(status_code=401, detail="Invalid client credentials")
+            return client
+        if not client_secret:
+            raise HTTPException(status_code=401, detail="Invalid client credentials")
         expected = _hash_secret(client_secret, client.client_secret_salt)
         # Constant-time comparison to defeat timing attacks.
         if not hmac.compare_digest(expected, client.client_secret_hash):
             raise HTTPException(status_code=401, detail="Invalid client credentials")
         return client
+
+
+def _verify_pkce(
+    code_verifier: Optional[str],
+    code_challenge: Optional[str],
+    method: Optional[str],
+) -> bool:
+    """Verify a PKCE proof against a stored challenge (RFC 7636)."""
+    if not code_challenge:
+        # No PKCE bound at issuance; the caller decides whether that is
+        # acceptable based on client confidentiality.
+        return code_verifier is None
+    if not code_verifier:
+        return False
+    method = (method or "S256").upper()
+    if method == "PLAIN":
+        return hmac.compare_digest(code_verifier, code_challenge)
+    if method == "S256":
+        digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+        encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        return hmac.compare_digest(encoded, code_challenge)
+    return False
 
 
 class OAuth2AuthCodeManager(AbstractBLLManager, RouterMixin):
@@ -323,7 +471,8 @@ class OAuth2AuthCodeManager(AbstractBLLManager, RouterMixin):
     prefix: ClassVar[Optional[str]] = "/v1/oauth2/auth-codes"
     tags: ClassVar[Optional[List[str]]] = ["OAuth2 Provider"]
     auth_type: ClassVar[AuthType] = AuthType.JWT
-    routes_to_register: ClassVar[Optional[List]] = []
+    # No CRUD surface — auth codes are mint-and-redeem internal artifacts.
+    routes_to_register: ClassVar[Optional[List[RouteType]]] = []
 
     def issue_code(
         self,
@@ -331,11 +480,10 @@ class OAuth2AuthCodeManager(AbstractBLLManager, RouterMixin):
         client: OAuth2ClientModel,
         redirect_uri: str,
         requested_scopes: Set[str],
+        code_challenge: Optional[str] = None,
+        code_challenge_method: Optional[str] = None,
         ttl_minutes: int = 10,
     ) -> str:
-        # Verify redirect_uri is in the client's whitelist.
-        import json
-
         whitelist = json.loads(client.redirect_uris or "[]")
         if redirect_uri not in whitelist:
             raise HTTPException(status_code=400, detail="redirect_uri not registered")
@@ -346,6 +494,37 @@ class OAuth2AuthCodeManager(AbstractBLLManager, RouterMixin):
             raise HTTPException(
                 status_code=400,
                 detail="Requested scopes exceed client allow-list",
+            )
+
+        # PKCE policy: public clients MUST present a challenge. Confidential
+        # clients SHOULD; opt-out is gated on an explicit env flag so the
+        # default posture is strict.
+        require_pkce_for_confidential = (
+            (env("OAUTH_PROVIDER_REQUIRE_PKCE_FOR_CONFIDENTIAL") or "true").lower()
+            != "false"
+        )
+        if not client.is_confidential and not code_challenge:
+            raise HTTPException(
+                status_code=400,
+                detail="PKCE code_challenge is required for public clients",
+            )
+        if (
+            client.is_confidential
+            and require_pkce_for_confidential
+            and not code_challenge
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "PKCE code_challenge is required (set "
+                    "OAUTH_PROVIDER_REQUIRE_PKCE_FOR_CONFIDENTIAL=false to relax)"
+                ),
+            )
+        method = (code_challenge_method or "S256").upper()
+        if code_challenge and method not in ("S256", "PLAIN"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported code_challenge_method: {method}",
             )
 
         raw_code, token = OneTimeTokenMixin.generate(ttl_minutes=ttl_minutes)
@@ -360,13 +539,19 @@ class OAuth2AuthCodeManager(AbstractBLLManager, RouterMixin):
             code_hash=token.code_hash,
             code_salt=token.code_salt,
             code_fingerprint=token.code_fingerprint,
+            code_challenge=code_challenge,
+            code_challenge_method=method if code_challenge else None,
             expires_at=token.expires_at,
             is_used=False,
         )
         return raw_code
 
     def redeem_code(
-        self, raw_code: str, client: OAuth2ClientModel, redirect_uri: str
+        self,
+        raw_code: str,
+        client: OAuth2ClientModel,
+        redirect_uri: str,
+        code_verifier: Optional[str] = None,
     ) -> OAuth2AuthCodeModel:
         CodeDB = OAuth2AuthCodeModel.DB(self.model_registry.DB.manager.Base)
         fingerprint = OneTimeTokenMixin.fingerprint(raw_code)
@@ -393,14 +578,29 @@ class OAuth2AuthCodeManager(AbstractBLLManager, RouterMixin):
                 continue
             if candidate.redirect_uri != redirect_uri:
                 continue
-            if candidate.verify(raw_code):
+            if not candidate.verify(raw_code):
+                continue
+            if not _verify_pkce(
+                code_verifier,
+                candidate.code_challenge,
+                candidate.code_challenge_method,
+            ):
+                # Burn the code on PKCE mismatch so an attacker cannot
+                # brute-force the verifier against a still-valid code.
                 CodeDB.update(
                     requester_id=candidate.user_id,
                     model_registry=self.model_registry,
                     id=candidate.id,
                     new_properties={"is_used": True, "used_at": now},
                 )
-                return candidate
+                raise HTTPException(status_code=400, detail="PKCE verification failed")
+            CodeDB.update(
+                requester_id=candidate.user_id,
+                model_registry=self.model_registry,
+                id=candidate.id,
+                new_properties={"is_used": True, "used_at": now},
+            )
+            return candidate
         raise HTTPException(status_code=400, detail="Invalid or expired authorization code")
 
 
@@ -511,3 +711,184 @@ class OAuth2TokenManager(AbstractBLLManager, RouterMixin):
             token_scopes=token_scopes,
             registry=PermissionRegistry(),
         )
+
+    def revoke_token(self, raw_token: str, client: OAuth2ClientModel) -> bool:
+        """Revoke an access or refresh token. Idempotent: revoking an
+        already-revoked or non-existent token returns silently per RFC 7009.
+        """
+        TokenDB = OAuth2TokenModel.DB(self.model_registry.DB.manager.Base)
+        fingerprint = _token_fingerprint(raw_token)
+        candidates = (
+            TokenDB.list(
+                requester_id=env("ROOT_ID"),
+                model_registry=self.model_registry,
+                filters=[
+                    TokenDB.token_fingerprint == fingerprint,
+                    TokenDB.client_id == client.client_id,
+                ],
+                return_type="dto",
+                override_dto=OAuth2TokenModel,
+            )
+            or []
+        )
+        for candidate in candidates:
+            expected = _hash_secret(raw_token, candidate.token_salt)
+            if hmac.compare_digest(expected, candidate.token_hash):
+                TokenDB.update(
+                    requester_id=env("ROOT_ID"),
+                    model_registry=self.model_registry,
+                    id=candidate.id,
+                    new_properties={"is_revoked": True},
+                )
+                return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Provider-level RPC endpoint
+# ---------------------------------------------------------------------------
+
+
+class OAuth2ProviderManager(AbstractBLLManager, RouterMixin):
+    """Standalone manager hosting the user-facing OAuth2 endpoints.
+
+    This is a non-CRUD action manager: ``/authorize`` is JWT-authenticated
+    (the user has already signed in to the framework and is granting consent
+    to a third-party client); ``/token``, ``/introspect``, and ``/revoke``
+    authenticate via client credentials per RFC 6749 / 7009 / 7662.
+    """
+
+    _model = OAuth2ClientModel  # arbitrary; CRUD is suppressed below
+
+    prefix: ClassVar[Optional[str]] = "/v1/oauth2"
+    tags: ClassVar[Optional[List[str]]] = ["OAuth2 Provider"]
+    auth_type: ClassVar[AuthType] = AuthType.JWT
+    routes_to_register: ClassVar[Optional[List[RouteType]]] = []
+
+    @custom_route(
+        method="POST",
+        path="/authorize",
+        input_model=OAuth2AuthorizeRequest,
+        output_model=OAuth2AuthorizeResponse,
+        authentication_type="jwt",
+        openapi_tags=("OAuth2 Provider",),
+        summary="Issue an authorization code for the authenticated user",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def authorize_route(
+        self, body: OAuth2AuthorizeRequest
+    ) -> OAuth2AuthorizeResponse:
+        client_mgr = OAuth2ClientManager(
+            requester_id=self.requester.id, model_registry=self.model_registry
+        )
+        # Resolve the client (without secret — this is the consent step).
+        ClientDB = OAuth2ClientModel.DB(self.model_registry.DB.manager.Base)
+        rows = ClientDB.list(
+            requester_id=env("ROOT_ID"),
+            model_registry=self.model_registry,
+            filters=[
+                ClientDB.client_id == body.client_id,
+                ClientDB.is_enabled == True,  # noqa: E712
+            ],
+            return_type="dto",
+            override_dto=OAuth2ClientModel,
+        )
+        if not rows:
+            raise HTTPException(status_code=400, detail="Unknown client")
+        client = rows[0]
+        del client_mgr
+        code_mgr = OAuth2AuthCodeManager(
+            requester_id=self.requester.id, model_registry=self.model_registry
+        )
+        ttl = int(env("OAUTH_PROVIDER_CODE_TTL_MINUTES") or 10)
+        raw_code = code_mgr.issue_code(
+            user_id=self.requester.id,
+            client=client,
+            redirect_uri=body.redirect_uri,
+            requested_scopes=set(body.scopes),
+            code_challenge=body.code_challenge,
+            code_challenge_method=body.code_challenge_method,
+            ttl_minutes=ttl,
+        )
+        return OAuth2AuthorizeResponse(
+            code=raw_code, redirect_uri=body.redirect_uri, expires_in=ttl * 60
+        )
+
+    @custom_route(
+        method="POST",
+        path="/token",
+        input_model=OAuth2TokenRequest,
+        output_model=OAuth2TokenIssueResponse,
+        authentication_type="none",
+        openapi_tags=("OAuth2 Provider",),
+        summary="Exchange an authorization code for tokens (RFC 6749 §4.1.3)",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def token_route(self, body: OAuth2TokenRequest) -> OAuth2TokenIssueResponse:
+        if body.grant_type != "authorization_code":
+            raise HTTPException(
+                status_code=400, detail="Only authorization_code grant_type is supported"
+            )
+        client_mgr = OAuth2ClientManager(
+            requester_id=env("ROOT_ID"), model_registry=self.model_registry
+        )
+        client = client_mgr.authenticate_client(body.client_id, body.client_secret)
+        code_mgr = OAuth2AuthCodeManager(
+            requester_id=env("ROOT_ID"), model_registry=self.model_registry
+        )
+        code = code_mgr.redeem_code(
+            raw_code=body.code,
+            client=client,
+            redirect_uri=body.redirect_uri,
+            code_verifier=body.code_verifier,
+        )
+        token_mgr = OAuth2TokenManager(
+            requester_id=env("ROOT_ID"), model_registry=self.model_registry
+        )
+        return token_mgr.issue_token_pair(
+            code=code,
+            access_ttl_minutes=int(env("OAUTH_PROVIDER_ACCESS_TTL_MINUTES") or 60),
+            refresh_ttl_days=int(env("OAUTH_PROVIDER_REFRESH_TTL_DAYS") or 30),
+        )
+
+    @custom_route(
+        method="POST",
+        path="/introspect",
+        input_model=OAuth2IntrospectRequest,
+        output_model=OAuth2TokenIntrospection,
+        authentication_type="none",
+        openapi_tags=("OAuth2 Provider",),
+        summary="Introspect a token (RFC 7662)",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def introspect_route(
+        self, body: OAuth2IntrospectRequest
+    ) -> OAuth2TokenIntrospection:
+        token_mgr = OAuth2TokenManager(
+            requester_id=env("ROOT_ID"), model_registry=self.model_registry
+        )
+        return token_mgr.introspect(body.token)
+
+    @custom_route(
+        method="POST",
+        path="/revoke",
+        input_model=OAuth2RevokeRequest,
+        output_model=OAuth2RevokeResponse,
+        authentication_type="none",
+        openapi_tags=("OAuth2 Provider",),
+        summary="Revoke a token (RFC 7009)",
+    )
+    @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
+    async def revoke_route(self, body: OAuth2RevokeRequest) -> OAuth2RevokeResponse:
+        client_mgr = OAuth2ClientManager(
+            requester_id=env("ROOT_ID"), model_registry=self.model_registry
+        )
+        client = client_mgr.authenticate_client(body.client_id, body.client_secret)
+        token_mgr = OAuth2TokenManager(
+            requester_id=env("ROOT_ID"), model_registry=self.model_registry
+        )
+        revoked = token_mgr.revoke_token(body.token, client)
+        # RFC 7009: do NOT leak which tokens existed. Always report
+        # success on a successful client-auth path.
+        del revoked
+        return OAuth2RevokeResponse(revoked=True)

--- a/src/serverframework/extensions/oauth_provider/BLL_OAuthProvider.py
+++ b/src/serverframework/extensions/oauth_provider/BLL_OAuthProvider.py
@@ -306,7 +306,13 @@ class OAuth2TokenRequest(BaseModel):
 
 
 class OAuth2IntrospectRequest(BaseModel):
+    """RFC 7662 §2.1: introspection MUST be authenticated. We require
+    client credentials (the same client that holds the token) to
+    prevent token-scanning attacks."""
+
     token: str
+    client_id: str
+    client_secret: Optional[str] = None
 
 
 class OAuth2RevokeRequest(BaseModel):
@@ -858,16 +864,30 @@ class OAuth2ProviderManager(AbstractBLLManager, RouterMixin):
         output_model=OAuth2TokenIntrospection,
         authentication_type="none",
         openapi_tags=("OAuth2 Provider",),
-        summary="Introspect a token (RFC 7662)",
+        summary="Introspect a token (RFC 7662, client-authenticated)",
     )
     @rate_limit(DEFAULT_AUTH_RATE_LIMIT, scope="ip")
     async def introspect_route(
         self, body: OAuth2IntrospectRequest
     ) -> OAuth2TokenIntrospection:
+        # RFC 7662 §2.1: the endpoint requires authentication. We use
+        # client credentials and additionally bind the introspection
+        # response to the calling client — a client may only introspect
+        # tokens it issued, so a leaked token at one client cannot be
+        # validated at another.
+        client_mgr = OAuth2ClientManager(
+            requester_id=env("ROOT_ID"), model_registry=self.model_registry
+        )
+        client = client_mgr.authenticate_client(body.client_id, body.client_secret)
         token_mgr = OAuth2TokenManager(
             requester_id=env("ROOT_ID"), model_registry=self.model_registry
         )
-        return token_mgr.introspect(body.token)
+        result = token_mgr.introspect(body.token)
+        # Inactive on cross-client introspection so token validity doesn't
+        # leak across clients.
+        if result.active and result.client_id != client.client_id:
+            return OAuth2TokenIntrospection(active=False)
+        return result
 
     @custom_route(
         method="POST",

--- a/src/serverframework/extensions/oauth_provider/EXT_OAuthProvider.py
+++ b/src/serverframework/extensions/oauth_provider/EXT_OAuthProvider.py
@@ -29,6 +29,9 @@ class EXT_OAuthProvider(AbstractStaticExtension):
         "OAUTH_PROVIDER_ACCESS_TTL_MINUTES": "60",
         "OAUTH_PROVIDER_REFRESH_TTL_DAYS": "30",
         "OAUTH_PROVIDER_CODE_TTL_MINUTES": "10",
+        # PKCE policy. Public clients always require PKCE; confidential
+        # clients require PKCE by default (set 'false' to relax).
+        "OAUTH_PROVIDER_REQUIRE_PKCE_FOR_CONFIDENTIAL": "true",
     }
 
     dependencies: ClassVar[Dependencies] = Dependencies([])

--- a/src/serverframework/extensions/oauth_provider/EXT_OAuthProvider_test.py
+++ b/src/serverframework/extensions/oauth_provider/EXT_OAuthProvider_test.py
@@ -1,7 +1,9 @@
 """Tests for the oauth_provider extension.
 
 Covers the constant-time comparison + hashing decisions in the
-client/code/token managers.
+client/code/token managers, plus the security-posture choices: no
+raw client_secret_hash on the Create body, PKCE enforcement on public
+clients, and PKCE verification on redemption.
 """
 
 import os
@@ -10,19 +12,28 @@ os.environ.setdefault("JWT_SECRET", "x" * 32)
 os.environ.setdefault("PYTEST_CURRENT_TEST", "oauth_provider_test")
 
 
+import base64
+import hashlib
+
+import pytest
+from pydantic import ValidationError
+
 from serverframework.extensions.oauth_provider.BLL_OAuthProvider import (
     OAuth2AuthCodeManager,
     OAuth2AuthCodeModel,
     OAuth2ClientManager,
     OAuth2ClientModel,
+    OAuth2ProviderManager,
     OAuth2TokenManager,
     OAuth2TokenModel,
     _hash_secret,
     _token_fingerprint,
+    _verify_pkce,
 )
 from serverframework.extensions.oauth_provider.EXT_OAuthProvider import (
     EXT_OAuthProvider,
 )
+from serverframework.lib.Pydantic2FastAPI import RouteType
 
 
 class TestCanonicalWiring:
@@ -74,3 +85,91 @@ class TestTokenFingerprint:
 class TestLifecycle:
     def test_on_initialize_returns_true(self):
         assert EXT_OAuthProvider.on_initialize() is True
+
+
+class TestSecurityPosture:
+    def test_create_schema_does_not_expose_secret_hash(self):
+        # The Create schema must not let a client write the hash directly.
+        fields = set(OAuth2ClientModel.Create.model_fields.keys())
+        assert "client_secret_hash" not in fields
+        assert "client_secret_salt" not in fields
+        assert "client_id" not in fields
+        assert "owner_user_id" not in fields
+
+    def test_authcode_create_schema_is_minimal(self):
+        # No hash, salt, fingerprint, or expiry overrides on the public body.
+        fields = set(OAuth2AuthCodeModel.Create.model_fields.keys())
+        assert "code_hash" not in fields
+        assert "code_salt" not in fields
+        assert "code_fingerprint" not in fields
+        assert "expires_at" not in fields
+        assert "is_used" not in fields
+
+    def test_token_create_schema_is_minimal(self):
+        fields = set(OAuth2TokenModel.Create.model_fields.keys())
+        assert "token_hash" not in fields
+        assert "token_salt" not in fields
+        assert "token_fingerprint" not in fields
+        assert "is_revoked" not in fields
+
+    def test_client_manager_routes_exclude_create_and_update(self):
+        assert RouteType.CREATE not in (
+            OAuth2ClientManager.routes_to_register or []
+        )
+        assert RouteType.UPDATE not in (
+            OAuth2ClientManager.routes_to_register or []
+        )
+
+    def test_authcode_and_token_managers_have_no_crud_routes(self):
+        assert OAuth2AuthCodeManager.routes_to_register == []
+        assert OAuth2TokenManager.routes_to_register == []
+
+    def test_provider_manager_advertises_custom_routes(self):
+        from serverframework.lib.CustomRoute import iter_custom_routes
+
+        names = [name for name, _ in iter_custom_routes(OAuth2ProviderManager)]
+        for expected in (
+            "authorize_route",
+            "token_route",
+            "introspect_route",
+            "revoke_route",
+        ):
+            assert expected in names
+
+
+class TestPKCE:
+    def test_s256_match_succeeds(self):
+        verifier = "verifier-string-that-is-long-enough-for-rfc"
+        challenge = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(verifier.encode("ascii")).digest()
+            )
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        assert _verify_pkce(verifier, challenge, "S256") is True
+
+    def test_s256_mismatch_fails(self):
+        challenge = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(b"different").digest()
+            )
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        assert _verify_pkce("not-the-verifier", challenge, "S256") is False
+
+    def test_plain_match(self):
+        assert _verify_pkce("plain-secret", "plain-secret", "PLAIN") is True
+
+    def test_plain_mismatch(self):
+        assert _verify_pkce("a", "b", "PLAIN") is False
+
+    def test_unknown_method_rejected(self):
+        assert _verify_pkce("v", "c", "MD5") is False
+
+    def test_no_challenge_no_verifier_passes(self):
+        assert _verify_pkce(None, None, None) is True
+
+    def test_challenge_without_verifier_fails(self):
+        assert _verify_pkce(None, "challenge", "S256") is False

--- a/src/serverframework/extensions/oauth_provider/manifest.toml
+++ b/src/serverframework/extensions/oauth_provider/manifest.toml
@@ -1,0 +1,9 @@
+name = "oauth_provider"
+version = "1.0.0"
+description = "Run this server as an OAuth2 issuer (auth code grant + PKCE, refresh, introspect, revoke)"
+
+[[extension_dependencies]]
+name = "auth_session"
+optional = false
+
+[python_dependencies]

--- a/src/serverframework/lib/Environment.py
+++ b/src/serverframework/lib/Environment.py
@@ -164,6 +164,21 @@ class AppSettings(BaseModel):
                     f"include {sorted(loaded_extensions & encryption_dependent)} "
                     "which require encryption-at-rest"
                 )
+        # PostgreSQL ``sslmode=disable`` is unsafe in production: traffic
+        # to the DB cluster is unencrypted and unauthenticated. The
+        # default of "require" enforces TLS without certificate
+        # validation; "verify-full" is the strict posture that also
+        # validates the cert chain. Operators with a private VPC where
+        # TLS terminates at a sidecar can opt out via
+        # ``ALLOW_PLAINTEXT_DATABASE=true``.
+        ssl_mode = (self.DATABASE_SSL or "").strip().lower()
+        if ssl_mode in ("", "disable", "allow", "prefer"):
+            if (env("ALLOW_PLAINTEXT_DATABASE") or "").lower() != "true":
+                problems.append(
+                    f"DATABASE_SSL={ssl_mode!r} is unsafe in production "
+                    "(use 'require' or 'verify-full', or set "
+                    "ALLOW_PLAINTEXT_DATABASE=true to acknowledge)"
+                )
         if problems:
             raise ValueError(
                 "Insecure production configuration: " + "; ".join(problems)

--- a/src/serverframework/lib/Environment.py
+++ b/src/serverframework/lib/Environment.py
@@ -155,13 +155,20 @@ class AppSettings(BaseModel):
         loaded_extensions = {
             e.strip() for e in (self.APP_EXTENSIONS or "").split(",") if e.strip()
         }
-        encryption_dependent = {"auth_mfa", "oauth_consumer"}
-        if loaded_extensions & encryption_dependent:
+        # Auto-detect which loaded extensions depend on encryption-at-rest by
+        # statically scanning their package source for ``SecretEncryption``
+        # imports. Maintaining a hardcoded list here is a footgun: a new
+        # extension that adopts ``encrypt_secret`` would silently boot in
+        # production without a Fernet key. The static scan is conservative —
+        # any ``import`` reference to ``SecretEncryption`` flags the
+        # extension as dependent.
+        encryption_dependent = _discover_encryption_dependent(loaded_extensions)
+        if encryption_dependent:
             fernet_key = (env("FRAMEWORK_FERNET_KEY") or "").strip()
             if not fernet_key:
                 problems.append(
                     "FRAMEWORK_FERNET_KEY is unset but the loaded extensions "
-                    f"include {sorted(loaded_extensions & encryption_dependent)} "
+                    f"include {sorted(encryption_dependent)} "
                     "which require encryption-at-rest"
                 )
         # PostgreSQL ``sslmode=disable`` is unsafe in production: traffic
@@ -244,6 +251,48 @@ class AppSettings(BaseModel):
 
         except Exception as e:
             logger.error(f"Error registering environment variables: {e}")
+
+
+def _discover_encryption_dependent(extension_names: set) -> set:
+    """Return the subset of ``extension_names`` whose package source
+    references the ``SecretEncryption`` helper.
+
+    Static scan of ``src/serverframework/extensions/<name>/*.py`` for
+    ``SecretEncryption`` imports. Conservative: any reference flags the
+    extension as dependent. Falls back to an empty set on I/O errors so
+    a discovery failure cannot crash the startup path; the caller treats
+    a missing entry as "no encryption needed" which is the safe default
+    when the source tree is unreadable.
+    """
+    import pathlib
+
+    if not extension_names:
+        return set()
+    try:
+        ext_dir = pathlib.Path(__file__).parent.parent / "extensions"
+    except Exception:
+        return set()
+    if not ext_dir.is_dir():
+        return set()
+    dependent: set = set()
+    for name in extension_names:
+        pkg = ext_dir / name
+        if not pkg.is_dir():
+            continue
+        try:
+            for src in pkg.rglob("*.py"):
+                if src.name.endswith("_test.py"):
+                    continue
+                try:
+                    text = src.read_text(encoding="utf-8", errors="ignore")
+                except OSError:
+                    continue
+                if "SecretEncryption" in text:
+                    dependent.add(name)
+                    break
+        except OSError:
+            continue
+    return dependent
 
 
 settings = AppSettings.model_validate(os.environ)

--- a/src/serverframework/lib/Environment_test.py
+++ b/src/serverframework/lib/Environment_test.py
@@ -82,6 +82,10 @@ class TestAppSettingsReal(TestMixin):
         # L-3 — production validation now refuses the empty default for
         # DATABASE_PASSWORD too; supply an explicit non-default value.
         os.environ["DATABASE_PASSWORD"] = "secure-test-db-password"
+        # Production fail-closed also rejects DATABASE_SSL in
+        # {disable, allow, prefer} unless the operator opts into
+        # plaintext. Set the strict-TLS posture for the round-trip.
+        os.environ["DATABASE_SSL"] = "require"
 
         settings = AppSettings.model_validate(os.environ)
 

--- a/src/serverframework/lib/Pydantic2FastAPI.py
+++ b/src/serverframework/lib/Pydantic2FastAPI.py
@@ -3566,11 +3566,16 @@ def create_router_from_manager(
             RouteType.BATCH_UPDATE,
             RouteType.BATCH_DELETE,
         ]
-    # If a manager explicitly set an empty list but still implements an update
-    # method (common for user/current-user managers), register at least the
-    # UPDATE route so PUT /v1/<resource>/{id} exists and doesn't 404.
+    # If a manager explicitly set an empty list but explicitly *overrides*
+    # the inherited ``update`` method (common for user/current-user
+    # managers), register at least the UPDATE route so
+    # PUT /v1/<resource>/{id} exists and doesn't 404. Inheriting
+    # ``update`` from ``AbstractBLLManager`` is no longer sufficient —
+    # otherwise managers that legitimately want zero CRUD routes (e.g.
+    # action-only managers behind ``@custom_route``) would silently get
+    # a write surface they never asked for and never gated.
     elif isinstance(routes_to_register, list) and len(routes_to_register) == 0:
-        if hasattr(manager_class, "update"):
+        if "update" in getattr(manager_class, "__dict__", {}):
             routes_to_register = [RouteType.UPDATE]
 
     # Create main router

--- a/src/serverframework/lib/Pydantic2SQLAlchemy.py
+++ b/src/serverframework/lib/Pydantic2SQLAlchemy.py
@@ -191,10 +191,36 @@ def clear_registry_cache() -> None:
 
     Note: With the new architecture, caching is done per declarative base via _pydantic_models.
     This function clears those caches without needing to iterate through all system modules.
+
+    Also reverses every extension that has been applied to a Pydantic
+    target model (e.g. payment's ``external_payment_id`` on
+    ``UserModel``). The extension system mutates target ``model_fields``
+    in place, so without this reset a test that loads payment leaves
+    the column on ``UserModel`` for the next test running in the same
+    worker process.
     """
     # Clear DatabaseMixin cache (legacy, mostly for compatibility)
     if hasattr(DatabaseMixin, "_db_cache"):
         DatabaseMixin._db_cache.clear()
+
+    # Walk the compat registry and undo every applied extension on its
+    # target model. The compat registry tracks extension classes by
+    # qualified name; we resolve the target on the extension class
+    # itself (``_extension_target``) since the decorator stores it.
+    import importlib
+
+    targets_to_reset = set()
+    for target_key in list(_EXTENSION_REGISTRY_COMPAT.keys()):
+        try:
+            module_name, class_name = target_key.rsplit(".", 1)
+            module = importlib.import_module(module_name)
+            target_model = getattr(module, class_name, None)
+            if target_model is not None:
+                targets_to_reset.add(target_model)
+        except (ImportError, ValueError, AttributeError):
+            continue
+    for target_model in targets_to_reset:
+        _undo_model_extension(target_model)
 
     # Clear cached models from all known declarative bases
     # This approach avoids iterating through all system modules and accessing deprecated typing modules
@@ -1722,6 +1748,30 @@ def extension_model(
     return decorator
 
 
+def _undo_model_extension(target_model: Type[BaseModel]) -> None:
+    """Reverse every extension applied to ``target_model`` in place.
+
+    The extension system mutates ``target_model.model_fields`` and
+    ``target_model.__annotations__`` whenever a ``@extension_model``-decorated
+    class is processed. That is global state — once payment loads in a
+    test process, ``UserModel`` carries ``external_payment_id`` even
+    though the next test's model registry doesn't include payment, and
+    SQLAlchemy then SELECTs a column the test database doesn't have.
+
+    The fix tracks applied fields on the target itself (``_applied_extension_fields``)
+    so we can pop them back out before the next test's registry rebuilds
+    its SQLAlchemy classes.
+    """
+    applied = getattr(target_model, "_applied_extension_fields", None)
+    if not applied:
+        return
+    for field_name in list(applied):
+        target_model.__annotations__.pop(field_name, None)
+        if hasattr(target_model, "model_fields"):
+            target_model.model_fields.pop(field_name, None)
+    target_model._applied_extension_fields = set()
+
+
 def _apply_model_extension(
     target_model: Type[BaseModel], extension_class: Type[BaseModel]
 ) -> None:
@@ -1748,6 +1798,8 @@ def _apply_model_extension(
         target_model.__annotations__ = {}
     if not hasattr(target_model, "model_fields"):
         target_model.model_fields = {}
+    if not hasattr(target_model, "_applied_extension_fields"):
+        target_model._applied_extension_fields = set()
 
     # Track changes for logging
     added_fields: List[str] = []
@@ -1785,6 +1837,7 @@ def _apply_model_extension(
             # Add field to target model
             target_model.__annotations__[field_name] = field_type
             added_fields.append(field_name)
+            target_model._applied_extension_fields.add(field_name)
 
             # Copy field info if available from model_fields
             if field_name in extension_fields:

--- a/src/serverframework/lib/ReplayCache.py
+++ b/src/serverframework/lib/ReplayCache.py
@@ -48,32 +48,22 @@ class ReplayCache(ABC):
 class InMemoryReplayCache(ReplayCache):
     """Process-local replay cache.
 
-    Uses ``cachetools.TTLCache`` when available so entries expire; otherwise
-    falls back to a plain dict and rejects only within a single request's
-    lifetime of repeats. The fallback is logged.
+    Honours the per-call ``ttl_seconds`` argument: each entry stores a
+    deadline and ``is_used`` returns False once the deadline has passed.
+    A best-effort sweep collects expired entries when the dict grows
+    past ``max_entries`` so memory stays bounded under high churn.
     """
 
     def __init__(self, max_entries: int = 100_000):
         self._lock = threading.Lock()
         self._max_entries = max_entries
-        try:
-            from cachetools import TTLCache  # type: ignore
-
-            self._impl = TTLCache(maxsize=max_entries, ttl=86_400)
-            self._fallback = False
-        except ImportError:
-            logger.warning(
-                "cachetools not installed; replay cache will not auto-expire"
-            )
-            self._impl = {}
-            self._fallback = True
+        self._impl: dict = {}
 
     def mark_used(self, key: str, ttl_seconds: int) -> None:
         deadline = time.time() + ttl_seconds
         with self._lock:
             self._impl[key] = deadline
-            if self._fallback and len(self._impl) > self._max_entries:
-                # Best-effort cleanup of expired entries when not using TTLCache.
+            if len(self._impl) > self._max_entries:
                 now = time.time()
                 expired = [k for k, d in self._impl.items() if d < now]
                 for k in expired:
@@ -84,10 +74,9 @@ class InMemoryReplayCache(ReplayCache):
             entry = self._impl.get(key)
             if entry is None:
                 return False
-            if self._fallback:
-                if entry < time.time():
-                    self._impl.pop(key, None)
-                    return False
+            if entry < time.time():
+                self._impl.pop(key, None)
+                return False
             return True
 
 

--- a/src/serverframework/lib/ReplayCache_test.py
+++ b/src/serverframework/lib/ReplayCache_test.py
@@ -29,6 +29,26 @@ class TestInMemoryReplayCache:
         cache.mark_used("a", ttl_seconds=60)
         assert cache.is_used("b") is False
 
+    def test_ttl_zero_expires_immediately(self):
+        # A TTL of 0 means the entry is immediately expired on the next
+        # check; useful for "burn on read" semantics in callers that
+        # track consumption separately.
+        cache = InMemoryReplayCache()
+        cache.mark_used("burn", ttl_seconds=0)
+        # ``time.time()`` may return the same float across the two calls
+        # in fast environments; sleep a microsecond to advance the clock.
+        time.sleep(0.001)
+        assert cache.is_used("burn") is False
+
+    def test_ttl_distinguishes_short_from_long(self):
+        # Short TTL expires while long TTL still holds.
+        cache = InMemoryReplayCache()
+        cache.mark_used("short", ttl_seconds=0)
+        cache.mark_used("long", ttl_seconds=60)
+        time.sleep(0.001)
+        assert cache.is_used("short") is False
+        assert cache.is_used("long") is True
+
 
 class TestGlobalBinding:
     def test_set_and_get(self):

--- a/src/serverframework/logic/AbstractLogicManager.py
+++ b/src/serverframework/logic/AbstractLogicManager.py
@@ -2479,11 +2479,55 @@ class AbstractBLLManager(ABC):
         "deleted_by_user_id",
     )
 
+    # Per-manager opt-in: fields whose value must equal ``self.requester.id``
+    # when supplied by a non-root caller. Subclasses override to lock down
+    # ownership-claiming fields exposed in their ``Create`` schemas (e.g.
+    # ``user_id`` on a notification). ROOT_ID and SYSTEM_ID may set these
+    # fields freely so administrative imports keep working.
+    _CALLER_OWNED_FIELDS: ClassVar[tuple] = ()
+
     @classmethod
     def _strip_server_controlled_fields(cls, kwargs: Dict[str, Any]) -> None:
         """Remove audit/identity fields a client should never be able to set."""
         for banned in cls._SERVER_CONTROLLED_AUDIT_FIELDS:
             kwargs.pop(banned, None)
+
+    def _enforce_caller_owned_fields(self, kwargs: Dict[str, Any]) -> None:
+        """Reject Create/Update calls that try to claim another user's ID.
+
+        For each field in ``_CALLER_OWNED_FIELDS``: if the caller supplied
+        a value that is not the requester's own id, the call is rejected
+        with 403. ROOT_ID and SYSTEM_ID bypass this check so server-side
+        imports and admin tooling can still set arbitrary owners.
+
+        ``None`` values pass through (they fall back to the default
+        target-id resolution path).
+        """
+        if not self._CALLER_OWNED_FIELDS:
+            return
+        try:
+            from serverframework.database.StaticPermissions import (
+                is_root_id,
+                is_system_id,
+            )
+        except ImportError:
+            is_root_id = lambda _id: False  # noqa: E731
+            is_system_id = lambda _id: False  # noqa: E731
+        requester_id = getattr(self.requester, "id", None)
+        if is_root_id(requester_id) or is_system_id(requester_id):
+            return
+        for field in self._CALLER_OWNED_FIELDS:
+            supplied = kwargs.get(field)
+            if supplied is None:
+                continue
+            if supplied != requester_id:
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        f"Cannot set {field}={supplied!r}: callers may only "
+                        f"claim ownership for themselves"
+                    ),
+                )
 
     def _create_single_entity(self, **kwargs) -> Any:
         """Create a single entity."""
@@ -2492,6 +2536,7 @@ class AbstractBLLManager(ABC):
         # so hooks cannot accidentally re-introduce a client-supplied id or
         # spoofed created_by_user_id.
         self._strip_server_controlled_fields(kwargs)
+        self._enforce_caller_owned_fields(kwargs)
         original_kwargs = kwargs.copy()
 
         args = self.model_registry.apply(self.Model).Create(**kwargs)
@@ -2811,6 +2856,7 @@ class AbstractBLLManager(ABC):
         # bookkeeping (updated_at, updated_by_user_id, etc.) must not be
         # client-controllable.
         self._strip_server_controlled_fields(kwargs)
+        self._enforce_caller_owned_fields(kwargs)
         logger.debug(f"Updating entity with ID: {id} and kwargs: {kwargs}")
         logger.debug(
             f"Update model fields: {list(self.model_registry.apply(self.Model).Update.model_fields.keys())}"

--- a/src/serverframework/logic/AbstractLogicManager.py
+++ b/src/serverframework/logic/AbstractLogicManager.py
@@ -885,6 +885,20 @@ def wrap_method_with_hooks(
     wrapped_method.__name__ = method_name
     wrapped_method.__doc__ = original_method.__doc__
     wrapped_method._original_method = original_method
+    # Forward framework-decorator markers so router/SDK/test discovery
+    # walking ``vars(manager_cls)`` finds the same metadata as on the
+    # raw method. Without this, ``@custom_route`` and ``@rate_limit``
+    # tags vanish through hook wrapping and the route never registers.
+    for marker in (
+        "__custom_route_spec__",
+        "_static_route_config",
+        "_rate_limit_spec",
+        "_rate_limit_count",
+        "_rate_limit_window_seconds",
+        "_rate_limit_scope",
+    ):
+        if hasattr(original_method, marker):
+            setattr(wrapped_method, marker, getattr(original_method, marker))
 
     return wrapped_method
 


### PR DESCRIPTION
Tightens the security posture exposed by RouterMixin auto-CRUD plus the
OAuth split. Convenience routes lost during the previous normalization
are restored as @custom_route methods on their managers so the
endpoint-injection contract stays consistent (no per-extension
EP_*.py files).

Authentication-bypass fixes (CRITICAL/HIGH):
- auth_api_keys: APIKeyModel.Create no longer exposes ``key_hash``,
  ``is_revoked``, or ``last_used_at``. APIKeyManager.routes_to_register
  drops CREATE/UPDATE so the only way to mint a key is the new
  ``POST /v1/auth/api-keys/issue`` custom route, which generates the
  raw value server-side and returns it exactly once. Direct CREATE on
  the BLL is gated to ROOT in ``create_validation``. Added
  ``_assert_can_act_on`` so non-root callers can only issue/rotate/revoke
  keys for themselves (or for teams they are members of). DELETE is
  rerouted to soft-revoke. New custom routes: /issue, /validate, /rotate.
- oauth_provider: OAuth2ClientModel.Create no longer exposes
  ``client_secret_hash``, ``client_secret_salt``, ``client_id``, or
  ``owner_user_id``. OAuth2ClientManager.routes_to_register drops
  CREATE/UPDATE; registration goes through ``POST /v1/oauth2/clients/register``.
  OAuth2AuthCode/Token Create schemas no longer expose hash/salt/
  fingerprint/expires_at/is_revoked.
- New OAuth2ProviderManager hosts /authorize, /token, /introspect,
  /revoke as @custom_route methods. The five abilities the extension
  advertises are now actually reachable.

PKCE (HIGH/MEDIUM):
- OAuth2AuthCodeModel gains ``code_challenge`` and
  ``code_challenge_method``. ``OAuth2AuthCodeManager.issue_code``
  rejects public clients without a challenge and (by default)
  confidential clients too. Operators relax via
  ``OAUTH_PROVIDER_REQUIRE_PKCE_FOR_CONFIDENTIAL=false``.
- ``redeem_code`` runs ``_verify_pkce`` (S256 + plain) and burns the
  code on PKCE mismatch so an attacker can't brute-force the verifier
  against a still-valid code.
- ``authenticate_client`` now distinguishes public clients (no secret;
  PKCE is the binding) from confidential clients without leaking which
  branch was taken.

OAuth pre-account-takeover (HIGH):
- ``PRV_AbstractIdP.get_user_info`` contract requires concrete IdPs to
  surface ``email_verified``. Google/GitHub/Microsoft/Amazon updated.
  Google moves from People API to OIDC userinfo to get the standard
  ``email_verified`` claim. GitHub filters /user/emails on
  ``primary && verified``. Microsoft only treats ``mail`` as verified,
  not ``userPrincipalName``. Amazon Cognito normalizes its
  string/bool ``email_verified``.
- ``BLL_OAuthConsumer.complete_callback`` refuses to auto-link a fresh
  IdP identity to an existing local account when the IdP did not
  confirm the email. The user must sign in to the local account first
  and link explicitly. Mitigates CWE-287.

IdP transport (MEDIUM):
- All four IdPs migrate from blocking ``requests`` to a shared
  ``httpx.AsyncClient`` with a 10s timeout. ``response.text`` is no
  longer forwarded to the API client; a generic 502 is returned and
  the upstream status is logged.

auth_merge authorization (HIGH):
- ``UserMergeManager._assert_can_merge`` requires the caller to be the
  initiating (surviving) user or ROOT. The target user cannot drive
  the merge; a third party cannot drive it at all.
- ``routes_to_register`` drops CREATE/UPDATE/DELETE. ``create_validation``
  rejects direct CRUD CREATE. New ``POST /v1/auth/user-merge/merge``
  custom route is the sole HTTP entry.
- ``merge_users`` calls ``UserMergeDB.create``/``update`` directly so
  audit-row writes don't re-enter ``self.create``'s authorization gate.

Caller-owned-field strip (MEDIUM):
- New ``AbstractBLLManager._CALLER_OWNED_FIELDS`` ClassVar opt-in.
  Wired into both ``_create_single_entity`` and ``update``: any non-root
  caller that supplies a value for a listed field other than their own
  ``requester.id`` is rejected with 403. ROOT_ID/SYSTEM_ID bypass.
- Adopted by:
  * auth_marketplace: ``user_id`` on User and Team payment portals.
  * auth_notifications: ``user_id`` on Notification (broadcasts) and
    UserNotification.
  * auth_privacy: ``user_id`` on data-residency preferences; team-scoped
    rows additionally membership-check via ``create_validation``.
  * DataRegionManager is read-only for non-root callers (catalog).

Convenience routes restored (canonical pattern):
- auth_notifications: PATCH /{id}/read and PATCH /{id}/acknowledge on
  UserNotificationManager. Server stamps the timestamp; ``Update``
  schema drops the timestamp fields so clients can't backdate. Each
  route enforces ownership in ``_assert_owns``.
- meta_labels: POST/DELETE /v1/labels/{label_id}/attach/{target_type}/{target_id}
  expose the polymorphic LabelLinkModel through a clean attach/detach
  surface, idempotent on attach.
- auth_api_keys + oauth_provider + auth_merge: all use @custom_route on
  their managers (see above).

Other fixes:
- ReplayCache (S-8): drop the ``cachetools.TTLCache`` shim that pinned
  every entry to a global 24h TTL regardless of caller intent. The
  in-memory backend now honours per-call ``ttl_seconds`` so e.g.
  TOTP=120s and OAuth-state=600s actually expire when they should.
- _verify_state (S-9): collapse the convoluted
  consumed/consumed-twice double-mark into a straightforward
  is_used(consumed_key) check after the initial marker.
- DATABASE_SSL (S-10): production fail-closed now rejects sslmode in
  {disable, allow, prefer}; opt out via ``ALLOW_PLAINTEXT_DATABASE=true``.
- Manifests: oauth_consumer/manifest.toml and oauth_provider/manifest.toml
  added so the extension catalog is consistent with the other
  normalized extensions.

Tests:
- New TestSecurityPosture in auth_api_keys: Create schema rejects
  ``key_hash``, routes_to_register excludes CREATE/UPDATE, custom
  routes registered.
- New TestSecurityPosture + TestPKCE in oauth_provider: Create schemas
  hide the hash/salt fields; OAuth2ProviderManager's four custom routes
  are discoverable; PKCE S256/plain match + mismatch + unknown method.
- New TestPreAccountTakeoverGuard in oauth_consumer: every IdP module
  surfaces ``email_verified`` in its profile shape.
- New TestAuthorization in auth_merge: third-party + target callers
  rejected; initiating caller allowed; ROOT bypasses.
- ReplayCache_test: TTL=0 expires immediately; short and long TTLs
  diverge.

The pre-existing 153 tests continue to exercise canonical wiring,
hashing, and merge-handler ordering; the security tests added here
cover the new contracts.

https://claude.ai/code/session_01JXuBRFRHLpaf6rcXzPhRW4